### PR TITLE
chore: clarify language rules and merge strategy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Language
 
-- All comments, documentation, commit messages, and user-facing strings must be written in English
+- All comments, documentation, commit messages, PR titles/descriptions, and user-facing strings must be written in English
+- When invoking skills with language arguments (e.g., `/create-pr ja`), respect this rule — do not use `ja` flag unless the user explicitly requests it
 
 ## Testing
 
@@ -57,6 +58,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Git Conventions
 
 - Conventional Commits: `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`
+- Merge strategy: squash merge only (merge commits are not allowed)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Add PR titles/descriptions to the English-only language rule (previously only covered comments, docs, commit messages)
- Document that the repository only allows squash merges

Both were discovered during the demo image regeneration session where a Japanese PR was accidentally created and `gh pr merge --merge` failed.

## References

- n/a
