### PR TITLE
chore: add Renovate configuration for automated dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,18 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:best-practices",
+  ],
+  nix: {
+    enabled: true,
+  },
+  minimumReleaseAge: "7 days",
+  labels: ["dependencies"],
+  packageRules: [
+    {
+      groupName: "GitHub Actions",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Add Renovate configuration to automate dependency updates for GitHub Actions version pins and Nix `flake.lock`.

- Uses `config:best-practices` preset with Nix manager explicitly enabled
- Sets `minimumReleaseAge: "7 days"` for supply chain security
- Groups GitHub Actions minor/patch/pin/digest updates into a single PR
- No automerge — all updates require manual review (security review finding: third-party actions are executable CI code)

## References

- n/a
