### PR TITLE
docs: add Nerd Font name comments to icon defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ require("eda").setup({
     path_format = "short",
     -- Signs shown in confirm dialogs
     signs = {
-      create = "",
-      delete = "",
-      move = "",
+      create = "", -- nf-oct-plus
+      delete = "", -- nf-oct-circle_slash
+      move = "",   -- nf-oct-arrow_right
     },
   },
 
@@ -229,13 +229,13 @@ require("eda").setup({
     enabled = true,
     -- Git status icons
     icons = {
-      untracked = "",
-      added = "",
-      modified = "●",
-      deleted = "",
-      renamed = "",
-      staged = "",
-      conflict = "",
+      untracked = "", -- nf-oct-question
+      added = "",     -- nf-oct-plus
+      modified = "",  -- nf-oct-diff
+      deleted = "",   -- nf-oct-circle_slash
+      renamed = "",   -- nf-oct-arrow_right
+      staged = "",    -- nf-oct-check
+      conflict = "",  -- nf-oct-alert
       ignored = "◌",
     },
   },


### PR DESCRIPTION
## Summary

Add inline Nerd Font name comments (`-- nf-oct-*`) to `git.icons` and `confirm.signs` defaults in README. PUA characters are invisible in rendered Markdown, so readers previously saw empty strings with no indication of the actual icon. Also corrects `modified` default from `"●"` to match the `nf-oct-diff` value introduced in #6.

## References

- Related: #6
