### PR TITLE
feat: disable buffer editing in empty state when git filter is active

### DIFF
--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -528,10 +528,12 @@ function M.open(opts)
     if cfg_now.show_only_git_changes then
       local ready = git.get_status_ready(rp)
       if ready == "loading" or ready == nil then
+        vim.bo[buf.bufnr].modifiable = true
         vim.api.nvim_buf_set_lines(buf.bufnr, 0, -1, false, { "Git status loading..." })
         -- nvim_buf_set_lines marks the buffer modified; clear it so the next render
         -- (after git status becomes ready) is not skipped by the modified-guard.
         vim.bo[buf.bufnr].modified = false
+        vim.bo[buf.bufnr].modifiable = false
         buf.flat_lines = {}
         explorer._last_painted_gen = explorer._render_gen
         explorer._incremental_hint = nil
@@ -626,6 +628,9 @@ function M.open(opts)
     end
     if not used_incremental then
       buf.painter:paint(flat_lines, decorations, paint_opts)
+    end
+    if paint_opts.empty_message then
+      vim.bo[buf.bufnr].modifiable = false
     end
     buf:restore_cursor()
     buf.target_node_id = nil

--- a/tests/e2e/test_git.lua
+++ b/tests/e2e/test_git.lua
@@ -585,6 +585,11 @@ T["git"]["render shows loading empty-state when show_only_git_changes and git st
   local empty_seen = e2e.exec(child, [[return require("eda").get_current()._empty_state_rendered == true]])
   MiniTest.expect.equality(empty_seen, true)
 
+  -- Verify buffer is modifiable after git status becomes ready and tree renders
+  -- (non-empty render restores modifiable=true via paint())
+  local modifiable = e2e.exec(child, [[return vim.bo.modifiable]])
+  MiniTest.expect.equality(modifiable, true)
+
   -- Reset filter for test isolation
   e2e.feed(child, "gs")
 end
@@ -621,6 +626,16 @@ T["git"]["shows 'No git changes' when filter on and repo is clean"] = function()
   ]],
     5000
   )
+
+  -- Buffer should be non-modifiable in empty state
+  local modifiable = e2e.exec(child, [[return vim.bo.modifiable]])
+  MiniTest.expect.equality(modifiable, false)
+
+  -- Toggle filter off; buffer should become modifiable again
+  e2e.feed(child, "gs")
+  e2e.wait_until(child, [[return vim.bo.modifiable == true]], 5000)
+  local modifiable_after = e2e.exec(child, [[return vim.bo.modifiable]])
+  MiniTest.expect.equality(modifiable_after, true)
 end
 
 T["git"]["filter indicator extmark appears on header row in split mode"] = function()


### PR DESCRIPTION
## Summary

When the git changes filter (`show_only_git_changes`) is active and there are no changed files, the buffer displays a "No git changes" empty state message. Previously, the buffer remained modifiable in this state, allowing users to meaninglessly edit the empty message text.

This PR sets `modifiable = false` on the buffer when the empty state is rendered (both the "Git status loading..." transient state and the "No git changes" ready state). Editability is automatically restored when the filter is toggled off or when a non-empty render occurs, since `paint()` unconditionally sets `modifiable = true` at the start.

### Changes

- **Loading path** (`init.lua`): Bracket `nvim_buf_set_lines` with `modifiable = true/false` to handle re-entry while already non-modifiable
- **Ready-empty path** (`init.lua`): Set `modifiable = false` after painting when `empty_message` is present
- **E2E tests** (`test_git.lua`): Assert `modifiable` state transitions in both the clean-repo empty state and the loading empty state

## References

- n/a
