### PR TITLE
feat: refresh git status after file operations for real-time indicators

### DIFF
--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -53,6 +53,20 @@ local function refresh(ctx)
   ctx.buffer:render(ctx.store)
 end
 
+---Refresh git status after file mutation and re-render.
+---@param ctx eda.ActionContext
+local function refresh_git(ctx)
+  if ctx.config.git.enabled then
+    git.status(ctx.explorer.root_path, function(_status)
+      local util = require("eda.util")
+      if not util.is_valid_buf(ctx.buffer.bufnr) then
+        return
+      end
+      refresh(ctx)
+    end)
+  end
+end
+
 ---Helper: refresh preserving user edits when buffer is dirty.
 ---@param ctx eda.ActionContext
 ---@param capture eda.EditCapture? Pre-computed capture to reuse (avoids redundant capture() call)
@@ -322,6 +336,7 @@ action.register("refresh", function(ctx)
         return
       end
       refresh(ctx)
+      refresh_git(ctx)
     end)
   end)
 end, { desc = "Refresh file tree" })
@@ -643,6 +658,7 @@ action.register("mark_bulk_delete", function(ctx)
         ctx.scanner:rescan_preserving_state(ctx.store.root_id, function()
           vim.schedule(function()
             refresh(ctx)
+            refresh_git(ctx)
           end)
         end)
       end)
@@ -685,6 +701,7 @@ action.register("mark_bulk_move", function(ctx)
             ctx.scanner:rescan_preserving_state(ctx.store.root_id, function()
               vim.schedule(function()
                 refresh(ctx)
+                refresh_git(ctx)
               end)
             end)
           end
@@ -730,6 +747,7 @@ action.register("duplicate", function(ctx)
       ctx.scanner:rescan_preserving_state(ctx.store.root_id, function()
         vim.schedule(function()
           refresh(ctx)
+          refresh_git(ctx)
         end)
       end)
     end)

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -910,6 +910,16 @@ function M.open(opts)
             end
             mark_render_dirty()
             schedule_render()
+            -- Refresh git status after external filesystem changes
+            if cfg.git.enabled then
+              git.status(root_path, function(_status)
+                if not util.is_valid_buf(buffer.bufnr) then
+                  return
+                end
+                mark_render_dirty()
+                schedule_render()
+              end)
+            end
           end)
         end)
       end)
@@ -1022,6 +1032,15 @@ function M._handle_write(explorer)
               vim.bo[buffer.bufnr].modified = false
               buffer:render(store)
               vim.notify("Applied " .. #result.completed .. " operation(s)")
+              -- Refresh git status after successful file operations
+              if cfg.git.enabled then
+                git.status(explorer.root_path, function(_status)
+                  if not util.is_valid_buf(buffer.bufnr) then
+                    return
+                  end
+                  buffer:render(store)
+                end)
+              end
             end
           end)
         end)
@@ -1158,6 +1177,18 @@ function M._change_root(explorer, new_path, opts)
               return
             end
             explorer.buffer:render(explorer.store)
+            -- Refresh git status after external filesystem changes
+            if cfg.git.enabled then
+              git.status(new_path, function(_status)
+                if explorer.generation ~= gen then
+                  return
+                end
+                if not util.is_valid_buf(explorer.buffer.bufnr) then
+                  return
+                end
+                explorer.buffer:render(explorer.store)
+              end)
+            end
           end)
         end)
       end)
@@ -1264,12 +1295,25 @@ end
 
 ---Refresh all active explorer instances.
 function M.refresh_all()
+  local cfg = config.get()
   for _, explorer in ipairs(M._instances) do
     if util.is_valid_buf(explorer.buffer.bufnr) then
+      local gen = explorer.generation
       explorer.scanner:rescan_preserving_state(explorer.store.root_id, function()
         vim.schedule(function()
           if util.is_valid_buf(explorer.buffer.bufnr) then
             explorer.buffer:render(explorer.store)
+            -- Refresh git status after rescan
+            if cfg.git.enabled then
+              git.status(explorer.root_path, function(_status)
+                if explorer.generation ~= gen then
+                  return
+                end
+                if util.is_valid_buf(explorer.buffer.bufnr) then
+                  explorer.buffer:render(explorer.store)
+                end
+              end)
+            end
           end
         end)
       end)

--- a/tests/e2e/test_git.lua
+++ b/tests/e2e/test_git.lua
@@ -1026,4 +1026,115 @@ T["git"]["next_git_change jumps through edit_preserve path on dirty buffer"] = f
   )
 end
 
+-- ===========================================================================
+-- Real-time git status refresh after buffer editing
+-- ===========================================================================
+
+T["git"]["git status refreshes after creating a file via buffer edit"] = function()
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = true },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+    })
+  ]]
+  )
+
+  e2e.open_eda(child, tmp)
+
+  -- Wait for initial git status to be ready
+  e2e.wait_until(child, string.format([[require("eda.git").get_status_ready(%q) == "ready"]], tmp), 10000)
+
+  -- Create a new file via buffer editing
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {1, 0})")
+  e2e.feed(child, "o")
+  e2e.feed_insert(child, "new_untracked.txt")
+  e2e.feed(child, ":w<CR>")
+
+  -- Wait for the file to exist on disk
+  local new_path = tmp .. "/new_untracked.txt"
+  e2e.wait_until(child, string.format("vim.uv.fs_stat(%q) ~= nil", new_path))
+
+  -- Wait for git status cache to reflect the new untracked file
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+    local git = require("eda.git")
+    local status = git.get_cached(%q)
+    if not status then return false end
+    return status[%q] == "?"
+  ]],
+      tmp,
+      new_path
+    ),
+    10000
+  )
+end
+
+T["git"]["git status refreshes after renaming a file via buffer edit"] = function()
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = true },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+    })
+  ]]
+  )
+
+  e2e.open_eda(child, tmp)
+
+  -- Wait for initial git status to be ready
+  e2e.wait_until(child, string.format([[require("eda.git").get_status_ready(%q) == "ready"]], tmp), 10000)
+
+  -- Rename tracked.txt to renamed.txt via buffer editing
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for i, l in ipairs(lines) do
+      if l:find("tracked.txt") then
+        vim.api.nvim_win_set_cursor(0, {i, 0})
+        return true
+      end
+    end
+    return false
+  ]]
+  )
+  e2e.feed(child, "cc")
+  e2e.feed_insert(child, "renamed.txt")
+  e2e.feed(child, ":w<CR>")
+
+  -- Wait for rename to complete on disk
+  local old_path = tmp .. "/tracked.txt"
+  local new_path = tmp .. "/renamed.txt"
+  e2e.wait_until(child, string.format("vim.uv.fs_stat(%q) == nil and vim.uv.fs_stat(%q) ~= nil", old_path, new_path))
+
+  -- Wait for git status cache to reflect the rename
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+    local git = require("eda.git")
+    local status = git.get_cached(%q)
+    if not status then return false end
+    -- After rename, the new file shows as untracked (?) or deleted+added
+    local s = status[%q]
+    return s ~= nil
+  ]],
+      tmp,
+      new_path
+    ),
+    10000
+  )
+end
+
 return T


### PR DESCRIPTION
## Summary

After buffer editing (create/rename/delete files via `:w`), git status indicators (untracked `?`, renamed `R`, etc.) were not updated in real-time because `git.status()` was never called after `rescan_preserving_state()` completed.

This PR adds `git.status()` refresh calls after all file mutation paths:
- `_handle_write()` — buffer editing success path
- Watcher callbacks in `M.open()` and `_change_root()` — external filesystem changes
- Builtin actions (`refresh`, `mark_bulk_delete`, `mark_bulk_move`, `duplicate`) — via a new `refresh_git()` helper
- `refresh_all()` — paste action path

Uses the same two-pass rendering pattern established at initial load: render first with stale git status, then re-render after async `git.status()` resolves.

## Test Plan

- Added 2 E2E tests verifying git status cache updates after buffer editing:
  - Create file via buffer edit -> git status shows `?` (untracked)
  - Rename file via buffer edit -> git status reflects renamed file

## References

- n/a
