### PR TITLE
feat: add visual indicator for marked nodes

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -443,6 +443,14 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
   in a narrow window. The popup displays the full line content (indent, icon,
   filename, and suffixes) with identical highlights.
 
+### mark
+
+`table`
+
+- `icon` `string` (default: `mark.icon` — nf-md-bookmark)
+  Prefix marker icon displayed before the file/folder icon on marked nodes.
+  Set to `""` to disable the prefix icon (the name highlight still applies).
+
 ### header
 
 `table|false`
@@ -927,7 +935,7 @@ Directories only receive suffix highlighting (not name highlighting).
 
 | Group           | Default Link      | Description                    |
 |-----------------|-------------------|--------------------------------|
-| `EdaMarkedNode` | `Visual`          | Marked node                    |
+| `EdaMarkedNode` | `Special`         | Marked node (prefix icon and name, fg-only) |
 | `EdaCut`        | `italic = true`   | Cut node (italic, preserves git colors) |
 | `EdaOpDeleteSign` | `DiagnosticError`  | Delete sign in confirm              |
 | `EdaOpDeletePath` | `DiagnosticError`  | Delete path in confirm              |

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -463,6 +463,15 @@ FULL_NAME ~
     filename, and suffixes) with identical highlights.
 
 
+MARK ~
+
+`table`
+
+- `icon` `string` (default: `mark.icon` — nf-md-bookmark)
+    Prefix marker icon displayed before the file/folder icon on marked nodes.
+    Set to `""` to disable the prefix icon (the name highlight still applies).
+
+
 HEADER ~
 
 `table|false`
@@ -1032,7 +1041,8 @@ OPERATIONS ~
   -----------------------------------------------------------------------
   Group             Default Link        Description
   ----------------- ------------------- ---------------------------------
-  EdaMarkedNode     Visual              Marked node
+  EdaMarkedNode     Special             Marked node (prefix icon and
+                                        name, fg-only)
 
   EdaCut            italic = true       Cut node (italic, preserves git
                                         colors)

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -42,6 +42,7 @@ local M = {}
 ---@field indent eda.IndentConfig
 ---@field preview eda.PreviewConfig
 ---@field full_name eda.FullNameConfig
+---@field mark eda.MarkConfig
 ---@field header eda.HeaderConfig|false
 ---@field expand_depth integer
 ---@field update_focused_file eda.UpdateFocusedFileConfig
@@ -95,6 +96,9 @@ local M = {}
 
 ---@class eda.FullNameConfig
 ---@field enabled boolean
+
+---@class eda.MarkConfig
+---@field icon string
 
 ---@alias eda.HeaderPosition "left" | "center" | "right"
 
@@ -184,6 +188,12 @@ local defaults = {
 
   full_name = {
     enabled = true,
+  },
+
+  mark = {
+    -- U+F01A4 (nf-md-bookmark). Built via string.char to avoid PUA-character
+    -- dropping by tooling that cannot safely pass private-use code points.
+    icon = string.char(0xf3, 0xb0, 0x86, 0xa4),
   },
 
   header = {

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -95,7 +95,7 @@ local highlight_groups = {
   EdaGitConflictIcon = { link = "EdaGitConflict" },
   EdaGitIgnoredName = { link = "EdaGitIgnored" },
   EdaGitIgnoredIcon = { link = "EdaGitIgnored" },
-  EdaMarkedNode = { link = "Visual" },
+  EdaMarkedNode = { link = "Special" },
   EdaCut = { italic = true },
   EdaOpDeleteSign = { link = "DiagnosticError" },
   EdaOpDeletePath = { link = "DiagnosticError" },
@@ -157,6 +157,23 @@ local function setup_highlights()
       local resolved = vim.api.nvim_get_hl(0, { name = name, link = false })
       if resolved and resolved.fg then
         vim.api.nvim_set_hl(0, name, { fg = resolved.fg })
+      end
+    end
+  end
+  -- Resolve EdaMarkedNode to fg-only (strip bg from link target).
+  -- Same pattern as git suffix groups above: marked nodes should highlight
+  -- the filename foreground without overriding CursorLine or adding bg.
+  -- NOTE: The main loop uses default=true, which silently skips groups that
+  -- were already set (e.g., a stale link to "Visual" from a prior session).
+  -- Force re-set the intended link first so the resolved fg comes from the
+  -- correct target, then strip the bg unconditionally.
+  do
+    local spec = highlight_groups.EdaMarkedNode
+    if spec and spec.link then
+      vim.api.nvim_set_hl(0, "EdaMarkedNode", { link = spec.link })
+      local resolved = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+      if resolved and resolved.fg then
+        vim.api.nvim_set_hl(0, "EdaMarkedNode", { fg = resolved.fg })
       end
     end
   end
@@ -457,6 +474,7 @@ function M.open(opts)
     chain:add(decorator_mod.git_decorator)
   end
   chain:add(decorator_mod.cut_decorator)
+  chain:add(decorator_mod.mark_decorator)
 
   ---@type eda.Explorer
   local explorer = {

--- a/lua/eda/render/decorator.lua
+++ b/lua/eda/render/decorator.lua
@@ -3,6 +3,8 @@ local Node = require("eda.tree.node")
 local M = {}
 
 ---@class eda.Decoration
+---@field prefix string?
+---@field prefix_hl string?
 ---@field icon string?
 ---@field icon_hl string?
 ---@field name_hl (string|string[])?
@@ -53,6 +55,12 @@ function Chain:decorate(flat_lines, ctx)
     for _, dec_fn in ipairs(self.decorators) do
       local dec = dec_fn(fl.node, ctx)
       if dec then
+        if dec.prefix ~= nil then
+          merged.prefix = dec.prefix
+        end
+        if dec.prefix_hl ~= nil then
+          merged.prefix_hl = dec.prefix_hl
+        end
         if dec.icon ~= nil then
           merged.icon = dec.icon
         end
@@ -321,6 +329,21 @@ function M.cut_decorator(node, _ctx)
     return { name_hl = "EdaCut", icon_hl = "EdaCut" }
   end
   return nil
+end
+
+-- U+F01A4 (nf-md-bookmark). Built via string.char to avoid PUA-character dropping.
+local MARK_ICON = string.char(0xf3, 0xb0, 0x86, 0xa4)
+
+---Mark decorator: shows a prefix marker icon on marked nodes.
+---@param node eda.TreeNode
+---@param ctx eda.DecoratorContext
+---@return eda.Decoration?
+function M.mark_decorator(node, ctx)
+  if not node._marked then
+    return nil
+  end
+  local icon = ctx.config.mark and ctx.config.mark.icon or MARK_ICON
+  return { icon = icon, icon_hl = "EdaMarkedNode", name_hl = "EdaMarkedNode" }
 end
 
 M.Chain = Chain

--- a/lua/eda/render/painter.lua
+++ b/lua/eda/render/painter.lua
@@ -12,6 +12,20 @@ local Exports = {
   FILTER_LABEL = FILTER_LABEL,
 }
 
+---Build the virt_text array for icon extmarks, optionally prepending a prefix.
+---@param entry table Decoration cache entry
+---@return table[] virt_text array
+local function build_icon_virt_text(entry)
+  local vt = {}
+  if entry.prefix_text then
+    vt[#vt + 1] = { entry.prefix_text, entry.prefix_hl }
+  end
+  if entry.icon_text then
+    vt[#vt + 1] = { entry.icon_text, entry.icon_hl }
+  end
+  return vt
+end
+
 ---@class eda.RenderSnapshot
 ---@field entries table<integer, { line: integer, path: string }>
 
@@ -24,7 +38,7 @@ local Exports = {
 ---@field indent_width integer
 ---@field header_lines integer Number of header lines (0, 1, or 2)
 ---@field snapshot eda.RenderSnapshot
----@field _decoration_cache table<integer, { icon_text: string?, icon_hl: string, name_hl: string|string[], suffix: string?, suffix_hl: string, link_suffix: string?, link_suffix_hl: string? }>
+---@field _decoration_cache table<integer, { prefix_text: string?, prefix_hl: string?, icon_text: string?, icon_hl: string, name_hl: string|string[], suffix: string?, suffix_hl: string, link_suffix: string?, link_suffix_hl: string? }>
 ---@field _flat_lines eda.FlatLine[] Current flat lines for decoration provider
 ---@field _line_lengths integer[] Pre-computed line text lengths for decoration provider
 ---@field _row_to_fl table<integer, integer> Buffer row -> flat_lines index mapping
@@ -274,12 +288,14 @@ end
 ---@param node eda.TreeNode
 ---@param name_hl string|string[]
 ---@param separator string
----@return { icon_text: string?, icon_hl: string, name_hl: string|string[], suffix: string?, suffix_hl: string, link_suffix: string?, link_suffix_hl: string? }?
+---@return { prefix_text: string?, prefix_hl: string?, icon_text: string?, icon_hl: string, name_hl: string|string[], suffix: string?, suffix_hl: string, link_suffix: string?, link_suffix_hl: string? }?
 local function build_cache_entry(dec, node, name_hl, separator)
   if not dec then
     return nil
   end
   return {
+    prefix_text = dec.prefix and dec.prefix ~= "" and (dec.prefix .. " ") or nil,
+    prefix_hl = dec.prefix_hl or "EdaMarkedNode",
     icon_text = dec.icon and dec.icon ~= "" and (dec.icon .. separator) or nil,
     icon_hl = dec.icon_hl or (Node.is_dir(node) and "EdaDirectoryIcon") or "EdaFileIcon",
     name_hl = name_hl,
@@ -407,10 +423,10 @@ function Painter:paint(flat_lines, decorations, opts)
   vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_icon, 0, -1)
   for i, fl in ipairs(flat_lines) do
     local entry = self._decoration_cache[fl.node_id]
-    if entry and entry.icon_text then
+    if entry and (entry.icon_text or entry.prefix_text) then
       local indent_len = fl.depth * self.indent_width
       vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, offset + i - 1, indent_len, {
-        virt_text = { { entry.icon_text, entry.icon_hl } },
+        virt_text = build_icon_virt_text(entry),
         virt_text_pos = "inline",
         right_gravity = false,
       })
@@ -598,10 +614,10 @@ function Painter:paint_incremental(flat_lines, decorations, opts, hint)
   vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_icon, 0, -1)
   for i, fl in ipairs(flat_lines) do
     local entry = self._decoration_cache[fl.node_id]
-    if entry and entry.icon_text then
+    if entry and (entry.icon_text or entry.prefix_text) then
       local indent_len = fl.depth * self.indent_width
       vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, offset + i - 1, indent_len, {
-        virt_text = { { entry.icon_text, entry.icon_hl } },
+        virt_text = build_icon_virt_text(entry),
         virt_text_pos = "inline",
         right_gravity = false,
       })
@@ -664,7 +680,7 @@ function Painter:_resync_on_redraw()
         local fl_idx = idx_by_node_id[m[1]]
         if fl_idx then
           local entry = self._decoration_cache[self._flat_lines[fl_idx].node_id]
-          if entry and entry.icon_text then
+          if entry and (entry.icon_text or entry.prefix_text) then
             if icon_idx > #icon_marks or icon_marks[icon_idx][2] ~= m[2] then
               icons_need_resync = true
               break
@@ -684,10 +700,10 @@ function Painter:_resync_on_redraw()
         if fl_idx then
           local fl = self._flat_lines[fl_idx]
           local entry = self._decoration_cache[fl.node_id]
-          if entry and entry.icon_text then
+          if entry and (entry.icon_text or entry.prefix_text) then
             local indent_len = fl.depth * self.indent_width
             vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, m[2], indent_len, {
-              virt_text = { { entry.icon_text, entry.icon_hl } },
+              virt_text = build_icon_virt_text(entry),
               virt_text_pos = "inline",
               right_gravity = false,
             })
@@ -739,10 +755,10 @@ function Painter:resync_highlights()
     if fl then
       row_to_fl[v.row] = i
       local entry = self._decoration_cache[fl.node_id]
-      if entry and entry.icon_text then
+      if entry and (entry.icon_text or entry.prefix_text) then
         local indent_len = fl.depth * self.indent_width
         vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, v.row, indent_len, {
-          virt_text = { { entry.icon_text, entry.icon_hl } },
+          virt_text = build_icon_virt_text(entry),
           virt_text_pos = "inline",
           right_gravity = false,
         })

--- a/tests/render/test_decorator.lua
+++ b/tests/render/test_decorator.lua
@@ -806,4 +806,88 @@ T["Chain decorate preserves link_suffix alongside suffix"] = function()
   MiniTest.expect.equality(result[1].suffix, "")
 end
 
+-- =============================================
+-- Mark decorator tests
+-- =============================================
+
+T["mark_decorator returns icon/icon_hl/name_hl for marked node"] = function()
+  config.setup()
+  local node = Node.create({ id = 1, name = "f", path = "/f", type = "file" })
+  node._marked = true
+  local ctx = { store = {}, git_status = nil, config = config.get() }
+  local dec = decorator.mark_decorator(node, ctx)
+  MiniTest.expect.equality(dec.icon, ctx.config.mark.icon)
+  MiniTest.expect.equality(dec.icon_hl, "EdaMarkedNode")
+  MiniTest.expect.equality(dec.name_hl, "EdaMarkedNode")
+end
+
+T["mark_decorator returns nil for unmarked node"] = function()
+  config.setup()
+  local node = Node.create({ id = 1, name = "f", path = "/f", type = "file" })
+  local ctx = { store = {}, git_status = nil, config = config.get() }
+  local dec = decorator.mark_decorator(node, ctx)
+  MiniTest.expect.equality(dec, nil)
+end
+
+T["mark_decorator uses custom icon from config"] = function()
+  config.setup({ mark = { icon = "X" } })
+  local node = Node.create({ id = 1, name = "f", path = "/f", type = "file" })
+  node._marked = true
+  local ctx = { store = {}, git_status = nil, config = config.get() }
+  local dec = decorator.mark_decorator(node, ctx)
+  MiniTest.expect.equality(dec.icon, "X")
+end
+
+T["mark_decorator returns empty icon when mark.icon is empty string"] = function()
+  config.setup({ mark = { icon = "" } })
+  local node = Node.create({ id = 1, name = "f", path = "/f", type = "file" })
+  node._marked = true
+  local ctx = { store = {}, git_status = nil, config = config.get() }
+  local dec = decorator.mark_decorator(node, ctx)
+  MiniTest.expect.equality(dec.icon, "")
+  MiniTest.expect.equality(dec.name_hl, "EdaMarkedNode")
+end
+
+T["Chain decorate passes through prefix field (last-write-wins)"] = function()
+  local chain = decorator.Chain.new()
+  chain:add(function()
+    return { prefix = "A" }
+  end)
+  chain:add(function()
+    return { prefix = "B" }
+  end)
+
+  config.setup()
+  local flat_lines = {
+    { node_id = 1, depth = 0, node = Node.create({ id = 1, name = "f", path = "/f", type = "file" }) },
+  }
+  local ctx = { store = {}, git_status = nil, config = config.get() }
+  local result = chain:decorate(flat_lines, ctx)
+  MiniTest.expect.equality(result[1].prefix, "B") -- last wins
+end
+
+T["cut + marked node accumulates name_hl and overrides icon"] = function()
+  local register = require("eda.register")
+  register.set({ "/f" }, "cut")
+
+  local chain = decorator.Chain.new()
+  chain:add(decorator.cut_decorator)
+  chain:add(decorator.mark_decorator)
+
+  config.setup()
+  local node = Node.create({ id = 1, name = "f", path = "/f", type = "file" })
+  node._marked = true
+  local flat_lines = { { node_id = 1, depth = 0, node = node } }
+  local ctx = { store = {}, git_status = nil, config = config.get() }
+  local result = chain:decorate(flat_lines, ctx)
+
+  MiniTest.expect.equality(result[1].icon, config.get().mark.icon)
+  MiniTest.expect.equality(result[1].icon_hl, "EdaMarkedNode")
+  MiniTest.expect.equality(type(result[1].name_hl), "table")
+  MiniTest.expect.equality(result[1].name_hl[1], "EdaCut")
+  MiniTest.expect.equality(result[1].name_hl[2], "EdaMarkedNode")
+
+  register.clear()
+end
+
 return T


### PR DESCRIPTION
## Summary

Add visual feedback for marked nodes in the file explorer. Previously, `mark_toggle` toggled `node._marked` internally but produced no visual change, making it impossible to identify which nodes were marked.

Marked nodes now display:
- A bookmark icon (nf-md-bookmark) replacing the file/folder icon
- Highlighted filename text via `EdaMarkedNode` (fg-only, linked to `Special`)

The mark icon is configurable via `mark.icon` in the setup options.

### Implementation details

- Extended `eda.Decoration` type with `prefix`/`prefix_hl` fields for generic prefix support in the decorator chain
- Added `mark_decorator` as the last decorator in the chain, overriding the file icon with the mark indicator
- `EdaMarkedNode` highlight is resolved to fg-only in `setup_highlights()` to prevent colorscheme bg leakage
- Added 6 unit tests covering mark_decorator behavior (marked/unmarked, custom icon, chain composition, cut+marked interaction)

## References

- n/a
