### PR TITLE
feat: change default mark icon to nf-md-checkbox_marked

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -447,7 +447,7 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
 
 `table`
 
-- `icon` `string` (default: `mark.icon` — nf-md-bookmark)
+- `icon` `string` (default: `mark.icon` — nf-md-checkbox_marked)
   Prefix marker icon displayed before the file/folder icon on marked nodes.
   Set to `""` to disable the prefix icon (the name highlight still applies).
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -467,7 +467,7 @@ MARK ~
 
 `table`
 
-- `icon` `string` (default: `mark.icon` — nf-md-bookmark)
+- `icon` `string` (default: `mark.icon` — nf-md-checkbox_marked)
     Prefix marker icon displayed before the file/folder icon on marked nodes.
     Set to `""` to disable the prefix icon (the name highlight still applies).
 

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -191,9 +191,9 @@ local defaults = {
   },
 
   mark = {
-    -- U+F01A4 (nf-md-bookmark). Built via string.char to avoid PUA-character
+    -- U+F0132 (nf-md-checkbox_marked). Built via string.char to avoid PUA-character
     -- dropping by tooling that cannot safely pass private-use code points.
-    icon = string.char(0xf3, 0xb0, 0x86, 0xa4),
+    icon = string.char(0xf3, 0xb0, 0x84, 0xb2),
   },
 
   header = {

--- a/lua/eda/render/decorator.lua
+++ b/lua/eda/render/decorator.lua
@@ -331,8 +331,8 @@ function M.cut_decorator(node, _ctx)
   return nil
 end
 
--- U+F01A4 (nf-md-bookmark). Built via string.char to avoid PUA-character dropping.
-local MARK_ICON = string.char(0xf3, 0xb0, 0x86, 0xa4)
+-- U+F0132 (nf-md-checkbox_marked). Built via string.char to avoid PUA-character dropping.
+local MARK_ICON = string.char(0xf3, 0xb0, 0x84, 0xb2)
 
 ---Mark decorator: shows a prefix marker icon on marked nodes.
 ---@param node eda.TreeNode


### PR DESCRIPTION
## Summary

Change the default mark icon from `nf-md-bookmark` (U+F01A4) to `nf-md-checkbox_marked` (U+F0132).

The checkbox-marked glyph conveys "selected for action" more directly for a multi-select mark feature, while keeping the same visual weight so the existing highlight group (`EdaMarkedNode`) and inline-replacement rendering behavior remain unchanged.

- `lua/eda/config.lua` — update `mark.icon` default bytes and comment
- `lua/eda/render/decorator.lua` — update the `MARK_ICON` fallback constant and comment
- `doc/eda.md` / `doc/eda.nvim.txt` — update the text reference

Users who have overridden `mark.icon` in their own config are unaffected; only the default changes.

## References

- Follow-up to #11 (`feat: add visual indicator for marked nodes`)
