### PR TITLE
fix: preserve user attributes on EdaMarkedNode and re-apply on :colorscheme

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -935,7 +935,7 @@ Directories only receive suffix highlighting (not name highlighting).
 
 | Group           | Default Link      | Description                    |
 |-----------------|-------------------|--------------------------------|
-| `EdaMarkedNode` | `Special`         | Marked node (prefix icon and name, fg-only) |
+| `EdaMarkedNode` | `Special`         | Marked node (prefix icon and name; bg stripped, attributes preserved) |
 | `EdaCut`        | `italic = true`   | Cut node (italic, preserves git colors) |
 | `EdaOpDeleteSign` | `DiagnosticError`  | Delete sign in confirm              |
 | `EdaOpDeletePath` | `DiagnosticError`  | Delete path in confirm              |

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -1042,7 +1042,8 @@ OPERATIONS ~
   Group             Default Link        Description
   ----------------- ------------------- ---------------------------------
   EdaMarkedNode     Special             Marked node (prefix icon and
-                                        name, fg-only)
+                                        name; bg stripped, attributes
+                                        preserved)
 
   EdaCut            italic = true       Cut node (italic, preserves git
                                         colors)

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -160,21 +160,22 @@ local function setup_highlights()
       end
     end
   end
-  -- Resolve EdaMarkedNode to fg-only (strip bg from link target).
-  -- Same pattern as git suffix groups above: marked nodes should highlight
-  -- the filename foreground without overriding CursorLine or adding bg.
-  -- NOTE: The main loop uses default=true, which silently skips groups that
-  -- were already set (e.g., a stale link to "Visual" from a prior session).
-  -- Force re-set the intended link first so the resolved fg comes from the
-  -- correct target, then strip the bg unconditionally.
+  -- Resolve EdaMarkedNode to strip bg while preserving user attributes.
+  -- Marked nodes should highlight the filename fg (and any user-defined
+  -- attributes like bold / underline / italic) without overriding CursorLine
+  -- or adding bg. Unlike the git suffix groups above (which keep only fg
+  -- because their sources like DiagnosticError are single-purpose),
+  -- EdaMarkedNode's default source `Special` is a general-purpose group that
+  -- users frequently customize with richer attributes via direct colorscheme
+  -- definition or the on_highlight callback. We therefore resolve the full
+  -- attribute set and strip only bg-related fields.
   do
-    local spec = highlight_groups.EdaMarkedNode
-    if spec and spec.link then
-      vim.api.nvim_set_hl(0, "EdaMarkedNode", { link = spec.link })
-      local resolved = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
-      if resolved and resolved.fg then
-        vim.api.nvim_set_hl(0, "EdaMarkedNode", { fg = resolved.fg })
-      end
+    local resolved = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    if resolved and resolved.fg then
+      resolved.bg = nil
+      resolved.ctermbg = nil
+      ---@diagnostic disable-next-line: param-type-mismatch
+      vim.api.nvim_set_hl(0, "EdaMarkedNode", resolved)
     end
   end
 end
@@ -357,6 +358,12 @@ end
 function M.setup(opts)
   config.setup(opts)
   setup_highlights()
+
+  -- Re-apply highlights on :colorscheme to survive :hi clear.
+  vim.api.nvim_create_autocmd("ColorScheme", {
+    group = vim.api.nvim_create_augroup("eda_highlights", { clear = true }),
+    callback = setup_highlights,
+  })
 
   local cfg = config.get()
 

--- a/tests/e2e/test_highlights.lua
+++ b/tests/e2e/test_highlights.lua
@@ -1,0 +1,127 @@
+local e2e = require("e2e.helpers")
+
+local T = MiniTest.new_set()
+
+local child
+
+T["highlights"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+    end,
+    post_case = function()
+      e2e.stop(child)
+    end,
+  },
+})
+
+T["highlights"]["direct definition preserves user attributes"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    vim.api.nvim_set_hl(0, "EdaMarkedNode", { fg = 0xa8a384, bold = true, underline = true })
+    require("eda").setup({})
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    return {
+      fg = h.fg,
+      bold = h.bold,
+      underline = h.underline,
+      has_bg = h.bg ~= nil,
+      has_ctermbg = h.ctermbg ~= nil,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.fg, 0xa8a384)
+  MiniTest.expect.equality(result.bold, true)
+  MiniTest.expect.equality(result.underline, true)
+  MiniTest.expect.equality(result.has_bg, false)
+  MiniTest.expect.equality(result.has_ctermbg, false)
+end
+
+T["highlights"]["strips bg and ctermbg while keeping attributes"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    vim.api.nvim_set_hl(0, "EdaMarkedNode", {
+      fg = 0xa8a384,
+      bg = 0x222222,
+      ctermbg = 8,
+      bold = true,
+    })
+    require("eda").setup({})
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    return {
+      fg = h.fg,
+      bold = h.bold,
+      has_bg = h.bg ~= nil,
+      has_ctermbg = h.ctermbg ~= nil,
+      cterm_has_bg = type(h.cterm) == "table" and h.cterm.bg ~= nil or false,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.fg, 0xa8a384)
+  MiniTest.expect.equality(result.bold, true)
+  MiniTest.expect.equality(result.has_bg, false)
+  MiniTest.expect.equality(result.has_ctermbg, false)
+  MiniTest.expect.equality(result.cterm_has_bg, false)
+end
+
+T["highlights"]["falls back to Special when EdaMarkedNode is undefined"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    vim.api.nvim_set_hl(0, "Special", { fg = 0xff00ff })
+    vim.api.nvim_set_hl(0, "EdaMarkedNode", {})
+    require("eda").setup({})
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    return { fg = h.fg, has_bg = h.bg ~= nil }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.fg, 0xff00ff)
+  MiniTest.expect.equality(result.has_bg, false)
+end
+
+T["highlights"]["flattens link chain and strips bg"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    vim.api.nvim_set_hl(0, "DiffAdd", { fg = 0x00ff00, bg = 0x003300 })
+    vim.api.nvim_set_hl(0, "EdaMarkedNode", { link = "DiffAdd" })
+    require("eda").setup({})
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    return { fg = h.fg, has_bg = h.bg ~= nil }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.fg, 0x00ff00)
+  MiniTest.expect.equality(result.has_bg, false)
+end
+
+T["highlights"]["ColorScheme autocmd strips bg after :hi clear when new Special has bg"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    require("eda").setup({})
+    -- Simulate a colorscheme that defines Special with bg.
+    -- :hi clear wipes the override (so EdaMarkedNode falls back to link=Special),
+    -- then Special is redefined with bg, then ColorScheme fires the autocmd to
+    -- re-strip bg on EdaMarkedNode.
+    vim.cmd("hi clear")
+    vim.api.nvim_set_hl(0, "Special", { fg = 0x123456, bg = 0x654321 })
+    vim.api.nvim_exec_autocmds("ColorScheme", {})
+    local marked = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    return {
+      marked_fg = marked.fg,
+      marked_has_bg = marked.bg ~= nil,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.marked_fg, 0x123456)
+  MiniTest.expect.equality(result.marked_has_bg, false)
+end
+
+return T


### PR DESCRIPTION
## Summary

The override block in `setup_highlights()` (`lua/eda/init.lua:170-179`) forcibly re-linked `EdaMarkedNode` to `Special` and copied only the resolved `fg`, discarding user-defined attributes such as `bold` / `underline` / `italic`. This broke integration with colorschemes (e.g. [vim-dogrun](https://github.com/wadackel/vim-dogrun) defining `EdaMarkedNode = yellow + Bold + Underline`) where the user's attributes were silently dropped.

Main changes:
- **Override block replaced**: resolve via `nvim_get_hl(link=false)`, strip only `bg` / `ctermbg`, and write the result back. Preserves the full attribute set (bold / underline / italic / sp / undercurl, etc.). Aligns with the git suffix group pattern but extended from fg-only to full-attribute preservation.
- **`ColorScheme` autocmd added**: registers an `eda_highlights` augroup in `M.setup` so `setup_highlights` re-runs when `:colorscheme foo` triggers `:hi clear`. Without this, switching to a colorscheme whose `Special` carries `bg` would leave `EdaMarkedNode` with that bg, defeating the CursorLine compatibility goal.
- **E2E tests** (`tests/e2e/test_highlights.lua`): 5 cases — direct-definition attribute preservation, bg stripping, link=Special fallback, link chain flattening, and ColorScheme autocmd re-application.
- **Docs**: updated `EdaMarkedNode` description from `fg-only` to `bg stripped, attributes preserved` and regenerated `doc/eda.nvim.txt`.

## References

- vim-dogrun: `EdaMarkedNode` set to yellow + Bold + Underline (already on main).
- This fix is required for the vim-dogrun change to take effect — eda.nvim was previously overriding the user-set attributes regardless.
