### PR TITLE
feat: split EdaMarkedNode into Icon/Name and fix linked name_hl in arrays

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -949,10 +949,21 @@ Directories only receive suffix highlighting (not name highlighting).
 
 ### Operations
 
-| Group           | Default Link      | Description                    |
-|-----------------|-------------------|--------------------------------|
-| `EdaMarkedNode` | `Special`         | Marked node (prefix icon and name; bg stripped, attributes preserved) |
-| `EdaCut`        | `italic = true`   | Cut node (italic, preserves git colors) |
+Marked nodes use a three-group pattern: `EdaMarked` (base), `EdaMarkedIcon`
+(applied to the prefix icon), and `EdaMarkedName` (applied to the filename).
+Both `Icon` and `Name` link to `EdaMarked` by default, so setting `EdaMarked`
+alone styles icon and name together. To differentiate, override `EdaMarkedIcon`
+or `EdaMarkedName` directly. The plugin strips `bg` / `ctermbg` from the
+resolved `EdaMarked` on setup (and on `ColorScheme`) so marks do not clobber
+`CursorLine` / `Visual`; direct overrides on `EdaMarkedIcon` / `EdaMarkedName`
+keep their user-provided attributes untouched (same as git suffix icons).
+
+| Group             | Default Link      | Description                    |
+|-------------------|-------------------|--------------------------------|
+| `EdaMarked`       | `Special`         | Marked node base. `bg` / `ctermbg` are stripped on setup (and re-stripped on `ColorScheme`) so marks do not clobber `CursorLine` / `Visual`. |
+| `EdaMarkedIcon`   | `EdaMarked`       | Prefix icon on marked nodes. Override to style the icon only. |
+| `EdaMarkedName`   | `EdaMarked`       | Filename portion on marked nodes. Override to style the name only, or set to `{}` to make it transparent (lets `EdaFileName` or any other overlay like `EdaCut` style the name instead). |
+| `EdaCut`          | `italic = true`   | Cut node (italic, preserves git colors) |
 | `EdaOpDeleteSign` | `DiagnosticError`  | Delete sign in confirm              |
 | `EdaOpDeletePath` | `DiagnosticError`  | Delete path in confirm              |
 | `EdaOpDeleteText` | `EdaOpDeleteSign`  | Delete count text in confirm title  |

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -1096,36 +1096,57 @@ names (e.g., `vim.api.nvim_set_hl(0, "EdaGitAddedName", { link = "EdaGitAdded"
 
 OPERATIONS ~
 
-  -----------------------------------------------------------------------
-  Group             Default Link        Description
-  ----------------- ------------------- ---------------------------------
-  EdaMarkedNode     Special             Marked node (prefix icon and
-                                        name; bg stripped, attributes
-                                        preserved)
+Marked nodes use a three-group pattern: `EdaMarked` (base), `EdaMarkedIcon`
+(applied to the prefix icon), and `EdaMarkedName` (applied to the filename).
+Both `Icon` and `Name` link to `EdaMarked` by default, so setting `EdaMarked`
+alone styles icon and name together. To differentiate, override `EdaMarkedIcon`
+or `EdaMarkedName` directly. The plugin strips `bg` / `ctermbg` from the
+resolved `EdaMarked` on setup (and on `ColorScheme`) so marks do not clobber
+`CursorLine` / `Visual`; direct overrides on `EdaMarkedIcon` / `EdaMarkedName`
+keep their user-provided attributes untouched (same as git suffix icons).
 
-  EdaCut            italic = true       Cut node (italic, preserves git
-                                        colors)
+  ------------------------------------------------------------------------
+  Group               Default Link        Description
+  ------------------- ------------------- --------------------------------
+  EdaMarked           Special             Marked node base. bg / ctermbg
+                                          are stripped on setup (and
+                                          re-stripped on ColorScheme) so
+                                          marks do not clobber CursorLine
+                                          / Visual.
 
-  EdaOpDeleteSign   DiagnosticError     Delete sign in confirm
+  EdaMarkedIcon       EdaMarked           Prefix icon on marked nodes.
+                                          Override to style the icon only.
 
-  EdaOpDeletePath   DiagnosticError     Delete path in confirm
+  EdaMarkedName       EdaMarked           Filename portion on marked
+                                          nodes. Override to style the
+                                          name only, or set to {} to make
+                                          it transparent (lets EdaFileName
+                                          or any other overlay like EdaCut
+                                          style the name instead).
 
-  EdaOpDeleteText   EdaOpDeleteSign     Delete count text in confirm
-                                        title
+  EdaCut              italic = true       Cut node (italic, preserves git
+                                          colors)
 
-  EdaOpCreateSign   DiagnosticOk        Create sign in confirm
+  EdaOpDeleteSign     DiagnosticError     Delete sign in confirm
 
-  EdaOpCreatePath   DiagnosticOk        Create path in confirm
+  EdaOpDeletePath     DiagnosticError     Delete path in confirm
 
-  EdaOpCreateText   EdaOpCreateSign     Create count text in confirm
-                                        title
+  EdaOpDeleteText     EdaOpDeleteSign     Delete count text in confirm
+                                          title
 
-  EdaOpMoveSign     DiagnosticWarn      Move sign in confirm
+  EdaOpCreateSign     DiagnosticOk        Create sign in confirm
 
-  EdaOpMovePath     DiagnosticWarn      Move path in confirm
+  EdaOpCreatePath     DiagnosticOk        Create path in confirm
 
-  EdaOpMoveText     EdaOpMoveSign       Move count text in confirm title
-  -----------------------------------------------------------------------
+  EdaOpCreateText     EdaOpCreateSign     Create count text in confirm
+                                          title
+
+  EdaOpMoveSign       DiagnosticWarn      Move sign in confirm
+
+  EdaOpMovePath       DiagnosticWarn      Move path in confirm
+
+  EdaOpMoveText       EdaOpMoveSign       Move count text in confirm title
+  ------------------------------------------------------------------------
 
 CONFIRMATION DIALOG ~
 

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -95,7 +95,9 @@ local highlight_groups = {
   EdaGitConflictIcon = { link = "EdaGitConflict" },
   EdaGitIgnoredName = { link = "EdaGitIgnored" },
   EdaGitIgnoredIcon = { link = "EdaGitIgnored" },
-  EdaMarkedNode = { link = "Special" },
+  EdaMarked = { link = "Special" },
+  EdaMarkedIcon = { link = "EdaMarked" },
+  EdaMarkedName = { link = "EdaMarked" },
   EdaCut = { italic = true },
   EdaOpDeleteSign = { link = "DiagnosticError" },
   EdaOpDeletePath = { link = "DiagnosticError" },
@@ -160,22 +162,25 @@ local function setup_highlights()
       end
     end
   end
-  -- Resolve EdaMarkedNode to strip bg while preserving user attributes.
+  -- Resolve EdaMarked to strip bg while preserving user attributes.
   -- Marked nodes should highlight the filename fg (and any user-defined
   -- attributes like bold / underline / italic) without overriding CursorLine
   -- or adding bg. Unlike the git suffix groups above (which keep only fg
   -- because their sources like DiagnosticError are single-purpose),
-  -- EdaMarkedNode's default source `Special` is a general-purpose group that
+  -- EdaMarked's default source `Special` is a general-purpose group that
   -- users frequently customize with richer attributes via direct colorscheme
   -- definition or the on_highlight callback. We therefore resolve the full
-  -- attribute set and strip only bg-related fields.
+  -- attribute set and strip only bg-related fields. EdaMarkedIcon and
+  -- EdaMarkedName link to EdaMarked by default, so stripping the base is
+  -- sufficient for link-based users; users who override Icon/Name directly
+  -- keep their attributes untouched.
   do
-    local resolved = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    local resolved = vim.api.nvim_get_hl(0, { name = "EdaMarked", link = false })
     if resolved and resolved.fg then
       resolved.bg = nil
       resolved.ctermbg = nil
       ---@diagnostic disable-next-line: param-type-mismatch
-      vim.api.nvim_set_hl(0, "EdaMarkedNode", resolved)
+      vim.api.nvim_set_hl(0, "EdaMarked", resolved)
     end
   end
 end

--- a/lua/eda/render/decorator.lua
+++ b/lua/eda/render/decorator.lua
@@ -343,7 +343,7 @@ function M.mark_decorator(node, ctx)
     return nil
   end
   local icon = ctx.config.mark and ctx.config.mark.icon or MARK_ICON
-  return { icon = icon, icon_hl = "EdaMarkedNode", name_hl = "EdaMarkedNode" }
+  return { icon = icon, icon_hl = "EdaMarkedIcon", name_hl = "EdaMarkedName" }
 end
 
 M.Chain = Chain

--- a/lua/eda/render/painter.lua
+++ b/lua/eda/render/painter.lua
@@ -106,13 +106,30 @@ function Painter.new(bufnr, indent_width)
       -- Note: Icon extmarks are set in paint() as non-ephemeral because
       -- Neovim does not render ephemeral inline virtual text (neovim/neovim#24797).
 
-      -- Name highlight
+      -- Name highlight.
+      -- Neovim does not resolve link chains inside hl_group arrays, so link-only
+      -- groups (e.g. EdaMarkedName, EdaGitIgnoredName) lose their attributes if
+      -- passed as an array. Emit one single-string extmark per element with
+      -- stair-stepped priority so each element resolves its own link chain; the
+      -- later element wins overlapping attrs.
       if indent_len < line_len then
-        vim.api.nvim_buf_set_extmark(buf, self.ns_hl, row, indent_len, {
-          end_col = line_len,
-          hl_group = entry.name_hl,
-          ephemeral = true,
-        })
+        local name_hl = entry.name_hl
+        if type(name_hl) == "string" then
+          vim.api.nvim_buf_set_extmark(buf, self.ns_hl, row, indent_len, {
+            end_col = line_len,
+            hl_group = name_hl,
+            ephemeral = true,
+          })
+        else
+          for i, hl in ipairs(name_hl) do
+            vim.api.nvim_buf_set_extmark(buf, self.ns_hl, row, indent_len, {
+              end_col = line_len,
+              hl_group = hl,
+              priority = 200 + i,
+              ephemeral = true,
+            })
+          end
+        end
       end
 
       -- Link suffix (symlink target path, rendered first at EOL)
@@ -295,7 +312,7 @@ local function build_cache_entry(dec, node, name_hl, separator)
   end
   return {
     prefix_text = dec.prefix and dec.prefix ~= "" and (dec.prefix .. " ") or nil,
-    prefix_hl = dec.prefix_hl or "EdaMarkedNode",
+    prefix_hl = dec.prefix_hl,
     icon_text = dec.icon and dec.icon ~= "" and (dec.icon .. separator) or nil,
     icon_hl = dec.icon_hl or (Node.is_dir(node) and "EdaDirectoryIcon") or "EdaFileIcon",
     name_hl = name_hl,

--- a/tests/e2e/test_highlights.lua
+++ b/tests/e2e/test_highlights.lua
@@ -19,9 +19,9 @@ T["highlights"]["direct definition preserves user attributes"] = function()
   local result = e2e.exec(
     child,
     [[
-    vim.api.nvim_set_hl(0, "EdaMarkedNode", { fg = 0xa8a384, bold = true, underline = true })
+    vim.api.nvim_set_hl(0, "EdaMarked", { fg = 0xa8a384, bold = true, underline = true })
     require("eda").setup({})
-    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarked", link = false })
     return {
       fg = h.fg,
       bold = h.bold,
@@ -43,14 +43,14 @@ T["highlights"]["strips bg and ctermbg while keeping attributes"] = function()
   local result = e2e.exec(
     child,
     [[
-    vim.api.nvim_set_hl(0, "EdaMarkedNode", {
+    vim.api.nvim_set_hl(0, "EdaMarked", {
       fg = 0xa8a384,
       bg = 0x222222,
       ctermbg = 8,
       bold = true,
     })
     require("eda").setup({})
-    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarked", link = false })
     return {
       fg = h.fg,
       bold = h.bold,
@@ -68,14 +68,14 @@ T["highlights"]["strips bg and ctermbg while keeping attributes"] = function()
   MiniTest.expect.equality(result.cterm_has_bg, false)
 end
 
-T["highlights"]["falls back to Special when EdaMarkedNode is undefined"] = function()
+T["highlights"]["falls back to Special when EdaMarked is undefined"] = function()
   local result = e2e.exec(
     child,
     [[
     vim.api.nvim_set_hl(0, "Special", { fg = 0xff00ff })
-    vim.api.nvim_set_hl(0, "EdaMarkedNode", {})
+    vim.api.nvim_set_hl(0, "EdaMarked", {})
     require("eda").setup({})
-    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarked", link = false })
     return { fg = h.fg, has_bg = h.bg ~= nil }
   ]]
   )
@@ -89,9 +89,9 @@ T["highlights"]["flattens link chain and strips bg"] = function()
     child,
     [[
     vim.api.nvim_set_hl(0, "DiffAdd", { fg = 0x00ff00, bg = 0x003300 })
-    vim.api.nvim_set_hl(0, "EdaMarkedNode", { link = "DiffAdd" })
+    vim.api.nvim_set_hl(0, "EdaMarked", { link = "DiffAdd" })
     require("eda").setup({})
-    local h = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    local h = vim.api.nvim_get_hl(0, { name = "EdaMarked", link = false })
     return { fg = h.fg, has_bg = h.bg ~= nil }
   ]]
   )
@@ -106,13 +106,13 @@ T["highlights"]["ColorScheme autocmd strips bg after :hi clear when new Special 
     [[
     require("eda").setup({})
     -- Simulate a colorscheme that defines Special with bg.
-    -- :hi clear wipes the override (so EdaMarkedNode falls back to link=Special),
+    -- :hi clear wipes the override (so EdaMarked falls back to link=Special),
     -- then Special is redefined with bg, then ColorScheme fires the autocmd to
-    -- re-strip bg on EdaMarkedNode.
+    -- re-strip bg on EdaMarked.
     vim.cmd("hi clear")
     vim.api.nvim_set_hl(0, "Special", { fg = 0x123456, bg = 0x654321 })
     vim.api.nvim_exec_autocmds("ColorScheme", {})
-    local marked = vim.api.nvim_get_hl(0, { name = "EdaMarkedNode", link = false })
+    local marked = vim.api.nvim_get_hl(0, { name = "EdaMarked", link = false })
     return {
       marked_fg = marked.fg,
       marked_has_bg = marked.bg ~= nil,
@@ -122,6 +122,141 @@ T["highlights"]["ColorScheme autocmd strips bg after :hi clear when new Special 
 
   MiniTest.expect.equality(result.marked_fg, 0x123456)
   MiniTest.expect.equality(result.marked_has_bg, false)
+end
+
+T["highlights"]["icon and name inherit fg from EdaMarked base via link chain"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    vim.api.nvim_set_hl(0, "Special", { fg = 0xff00ff })
+    require("eda").setup({})
+    local icon = vim.api.nvim_get_hl(0, { name = "EdaMarkedIcon", link = false })
+    local name = vim.api.nvim_get_hl(0, { name = "EdaMarkedName", link = false })
+    return {
+      icon_fg = icon.fg,
+      name_fg = name.fg,
+      icon_has_bg = icon.bg ~= nil,
+      name_has_bg = name.bg ~= nil,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.icon_fg, 0xff00ff)
+  MiniTest.expect.equality(result.name_fg, 0xff00ff)
+  MiniTest.expect.equality(result.icon_has_bg, false)
+  MiniTest.expect.equality(result.name_has_bg, false)
+end
+
+T["highlights"]["icon and name can be overridden independently"] = function()
+  local result = e2e.exec(
+    child,
+    [[
+    vim.api.nvim_set_hl(0, "EdaMarkedIcon", { fg = 0xff0000 })
+    vim.api.nvim_set_hl(0, "EdaMarkedName", { fg = 0x0000ff, underline = true })
+    require("eda").setup({})
+    local icon = vim.api.nvim_get_hl(0, { name = "EdaMarkedIcon", link = false })
+    local name = vim.api.nvim_get_hl(0, { name = "EdaMarkedName", link = false })
+    return {
+      icon_fg = icon.fg,
+      name_fg = name.fg,
+      name_underline = name.underline,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.icon_fg, 0xff0000)
+  MiniTest.expect.equality(result.name_fg, 0x0000ff)
+  MiniTest.expect.equality(result.name_underline, true)
+end
+
+T["highlights"]["ignored + marked: decoration cache stacks git and mark name hls"] = function()
+  -- Regression guard for the real-world bug: when a gitignored node is marked,
+  -- the Chain used to emit `{ "EdaGitIgnoredName", "EdaMarkedName" }` as a single
+  -- extmark array. Neovim does not resolve link chains inside hl_group arrays,
+  -- so the link-only EdaMarkedName silently lost its fg and the filename stayed
+  -- the ignored color. The decoration cache must contain both hl groups in order
+  -- (git first, mark last), and the on_line per-element emission (covered by the
+  -- unit test in test_painter.lua) makes the later element win.
+  --
+  -- Note: headless --listen mode does not fire the decoration provider's on_line
+  -- callback, so this E2E verifies the cache that feeds on_line, not the final
+  -- extmark calls.
+  local tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+  e2e.create_file(tmp .. "/.gitignore", "ignored.txt\n")
+  e2e.create_file(tmp .. "/ignored.txt", "content")
+  e2e.create_git_repo(tmp)
+
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = true },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      show_gitignored = true,
+    })
+  ]]
+  )
+
+  e2e.open_eda(child, tmp)
+  e2e.wait_until(child, string.format([[require("eda.git").get_cached(%q) ~= nil]], tmp), 10000)
+
+  e2e.exec(
+    child,
+    [[
+    local buffer = require("eda").get_current().buffer
+    for idx, fl in ipairs(buffer.flat_lines) do
+      if fl.node.name == "ignored.txt" then
+        vim.api.nvim_win_set_cursor(0, { idx, 0 })
+        break
+      end
+    end
+  ]]
+  )
+  e2e.feed(child, "m")
+  e2e.wait_until(
+    child,
+    [[
+    local buffer = require("eda").get_current().buffer
+    for _, fl in ipairs(buffer.flat_lines) do
+      if fl.node.name == "ignored.txt" and fl.node._marked then
+        return true
+      end
+    end
+    return false
+  ]]
+  )
+
+  local result = e2e.exec(
+    child,
+    [[
+    local buffer = require("eda").get_current().buffer
+    local ignored_id
+    for _, fl in ipairs(buffer.flat_lines) do
+      if fl.node.name == "ignored.txt" then
+        ignored_id = fl.node_id
+        break
+      end
+    end
+    local entry = buffer.painter._decoration_cache[ignored_id]
+    return {
+      name_hl = entry and entry.name_hl or nil,
+      type_tag = entry and type(entry.name_hl) or nil,
+    }
+  ]]
+  )
+
+  -- The cache entry for ignored.txt must contain an array with both hl groups,
+  -- with EdaMarkedName placed last (so on_line's per-element emission assigns it
+  -- the highest priority and its link chain wins the final rendered fg).
+  MiniTest.expect.equality(result.type_tag, "table")
+  MiniTest.expect.equality(type(result.name_hl), "table")
+  MiniTest.expect.equality(result.name_hl[1], "EdaGitIgnoredName")
+  MiniTest.expect.equality(result.name_hl[#result.name_hl], "EdaMarkedName")
+
+  e2e.remove_temp_dir(tmp)
 end
 
 return T

--- a/tests/render/test_decorator.lua
+++ b/tests/render/test_decorator.lua
@@ -817,8 +817,8 @@ T["mark_decorator returns icon/icon_hl/name_hl for marked node"] = function()
   local ctx = { store = {}, git_status = nil, config = config.get() }
   local dec = decorator.mark_decorator(node, ctx)
   MiniTest.expect.equality(dec.icon, ctx.config.mark.icon)
-  MiniTest.expect.equality(dec.icon_hl, "EdaMarkedNode")
-  MiniTest.expect.equality(dec.name_hl, "EdaMarkedNode")
+  MiniTest.expect.equality(dec.icon_hl, "EdaMarkedIcon")
+  MiniTest.expect.equality(dec.name_hl, "EdaMarkedName")
 end
 
 T["mark_decorator returns nil for unmarked node"] = function()
@@ -845,7 +845,7 @@ T["mark_decorator returns empty icon when mark.icon is empty string"] = function
   local ctx = { store = {}, git_status = nil, config = config.get() }
   local dec = decorator.mark_decorator(node, ctx)
   MiniTest.expect.equality(dec.icon, "")
-  MiniTest.expect.equality(dec.name_hl, "EdaMarkedNode")
+  MiniTest.expect.equality(dec.name_hl, "EdaMarkedName")
 end
 
 T["Chain decorate passes through prefix field (last-write-wins)"] = function()
@@ -882,10 +882,10 @@ T["cut + marked node accumulates name_hl and overrides icon"] = function()
   local result = chain:decorate(flat_lines, ctx)
 
   MiniTest.expect.equality(result[1].icon, config.get().mark.icon)
-  MiniTest.expect.equality(result[1].icon_hl, "EdaMarkedNode")
+  MiniTest.expect.equality(result[1].icon_hl, "EdaMarkedIcon")
   MiniTest.expect.equality(type(result[1].name_hl), "table")
   MiniTest.expect.equality(result[1].name_hl[1], "EdaCut")
-  MiniTest.expect.equality(result[1].name_hl[2], "EdaMarkedNode")
+  MiniTest.expect.equality(result[1].name_hl[2], "EdaMarkedName")
 
   register.clear()
 end

--- a/tests/render/test_painter.lua
+++ b/tests/render/test_painter.lua
@@ -987,6 +987,68 @@ T["decoration cache name_hl resolves to array when multiple groups have visual a
   vim.api.nvim_set_hl(0, "TestArrayGroupB", {})
 end
 
+T["on_line emits per-element extmarks when name_hl is an array"] = function()
+  -- Regression: Neovim's extmark does not resolve link chains inside hl_group arrays,
+  -- so link-only groups like EdaMarkedName/EdaGitIgnoredName silently lose their fg
+  -- when stacked. The fix emits one single-string extmark per array element with
+  -- stair-stepped priority so each hl_group resolves its own link chain.
+  local store, root = build_store()
+  local flat_lines = Flatten.flatten(store, root)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  local painter = Painter.new(buf)
+
+  -- Two groups with direct visual attrs so has_visual_attrs keeps both in the array.
+  vim.api.nvim_set_hl(0, "TestLayerA", { fg = 0x111111 })
+  vim.api.nvim_set_hl(0, "TestLayerB", { fg = 0x222222 })
+
+  local decorations = {}
+  decorations[2] = { name_hl = { "TestLayerA", "TestLayerB" } }
+
+  painter:paint(flat_lines, decorations)
+
+  local captured = {}
+  local orig_set_extmark = vim.api.nvim_buf_set_extmark
+  vim.api.nvim_buf_set_extmark = function(b, n, row, col, opts)
+    if b == buf and n == painter.ns_hl and opts and opts.hl_group and opts.end_col then
+      table.insert(captured, {
+        row = row,
+        col = col,
+        end_col = opts.end_col,
+        hl_group = opts.hl_group,
+        priority = opts.priority,
+      })
+    end
+    return orig_set_extmark(b, n, row, col, opts)
+  end
+
+  -- Force the decoration provider to fire so on_line runs for every visible row.
+  vim.api.nvim__redraw({ buf = buf, flush = true })
+
+  vim.api.nvim_buf_set_extmark = orig_set_extmark
+
+  -- Filter to the row that received the array decoration (flat_lines index 2 → row 1)
+  local row_captured = {}
+  for _, c in ipairs(captured) do
+    if c.row == 1 then
+      table.insert(row_captured, c)
+    end
+  end
+
+  -- Expect two single-string extmarks, not one extmark with a table hl_group.
+  MiniTest.expect.equality(#row_captured, 2)
+  MiniTest.expect.equality(type(row_captured[1].hl_group), "string")
+  MiniTest.expect.equality(type(row_captured[2].hl_group), "string")
+  MiniTest.expect.equality(row_captured[1].hl_group, "TestLayerA")
+  MiniTest.expect.equality(row_captured[2].hl_group, "TestLayerB")
+  -- Later element wins overlapping attrs → higher priority.
+  MiniTest.expect.equality(row_captured[1].priority < row_captured[2].priority, true)
+
+  vim.api.nvim_buf_delete(buf, { force = true })
+  vim.api.nvim_set_hl(0, "TestLayerA", {})
+  vim.api.nvim_set_hl(0, "TestLayerB", {})
+end
+
 T["decoration cache name_hl filters non-visual groups from array"] = function()
   local store, root = build_store()
   local flat_lines = Flatten.flatten(store, root)


### PR DESCRIPTION
## Summary

Split `EdaMarkedNode` into a three-layer highlight pattern mirroring the existing Git status groups, and fix a latent rendering bug where link-only hl groups lost their attributes when stacked into an extmark `hl_group` array.

### Highlight groups

- `EdaMarked` — base (links `Special`). `bg` / `ctermbg` are stripped on setup and on `ColorScheme` so marks do not clobber `CursorLine` / `Visual`.
- `EdaMarkedIcon` — defaults to `EdaMarked`; override to style the mark icon only.
- `EdaMarkedName` — defaults to `EdaMarked`; override (or set to `{}`) to make the filename transparent so other overlays (e.g. `EdaCut`) can style it.

The old `EdaMarkedNode` group is removed (pre-release, no deprecation alias).

### Bug fix: link chain loss inside `hl_group` arrays

When multiple decorators contribute `name_hl` (e.g. gitignored + marked), `Chain.decorate` produces `{ "EdaGitIgnoredName", "EdaMarkedName" }`. Neovim does not resolve link chains inside `hl_group` arrays, so link-only groups silently lost their attributes and the mark color never reached the filename (visible as gitignored nodes staying Comment-colored after being marked).

`Painter:on_line` now emits one single-string `hl_group` extmark per array element with stair-stepped priority (`200 + i`). Each extmark resolves its own link chain, and the later decorator (e.g. `EdaMarkedName`) wins overlapping attrs.

### New tests

- `tests/render/test_painter.lua`: `on_line emits per-element extmarks when name_hl is an array` — monkey-patches `nvim_buf_set_extmark` and forces the decoration provider via `nvim__redraw`, asserting two single-hl extmarks with ascending priority.
- `tests/e2e/test_highlights.lua`: `ignored + marked: decoration cache stacks git and mark name hls` — reproduces the real-world scenario and asserts the cache array ends with `EdaMarkedName` (unit + e2e together cover the chain end-to-end since headless `--listen` mode cannot fire `on_line`).

### Side fix

Dropped the dead `prefix_hl = "EdaMarkedNode"` fallback in `build_cache_entry` (no production decorator returns `prefix`).

### Docs

`doc/eda.md` updated and `doc/eda.nvim.txt` regenerated via `just doc`.

## References

- n/a
