### PR TITLE
fix: mark highlight wins priority over symlink

### DIFF
--- a/lua/eda/render/decorator.lua
+++ b/lua/eda/render/decorator.lua
@@ -300,23 +300,31 @@ function M.dotgit_decorator(node, ctx)
   return { suffix = icon, suffix_hl = "EdaGitIgnoredIcon", name_hl = "EdaGitIgnoredName" }
 end
 
----Symlink decorator: shows link target as suffix.
+---Symlink decorator: contributes EdaSymlink / EdaBrokenSymlink name_hl and link target suffix.
 ---@param node eda.TreeNode
 ---@param ctx eda.DecoratorContext
 ---@return eda.Decoration?
 function M.symlink_decorator(node, ctx)
-  if not node.link_target then
+  if not node.link_target and not node.link_broken then
     return nil
+  end
+  local name_hl = node.link_broken and "EdaBrokenSymlink" or "EdaSymlink"
+  if not node.link_target then
+    return { name_hl = name_hl }
   end
   local root_node = ctx.store:get(ctx.store.root_id)
   if not root_node then
-    return nil
+    return { name_hl = name_hl }
   end
   local rel = relative_path(root_node.path, node.link_target)
   if Node.is_dir(node) then
     rel = rel .. "/"
   end
-  return { link_suffix = "→ " .. rel, link_suffix_hl = "EdaSymlinkTarget" }
+  return {
+    name_hl = name_hl,
+    link_suffix = "→ " .. rel,
+    link_suffix_hl = "EdaSymlinkTarget",
+  }
 end
 
 ---Cut decorator: dims nodes that are in the cut register.

--- a/lua/eda/render/painter.lua
+++ b/lua/eda/render/painter.lua
@@ -224,9 +224,9 @@ end
 ---(no visual attributes), the default name highlight is used instead. This allows
 ---EdaGit*Name groups to be transparent by default while still supporting user
 ---customization via colorschemes or nvim_set_hl.
----When multiple decorators contribute name_hl (e.g., git + cut), the result is a
----string[] for Neovim 0.11's hl_group array support. Only groups with visual
----attributes are included; base_hl is used as a fallback when none qualify.
+---When multiple decorators contribute name_hl (e.g., symlink + mark, git + cut),
+---the result is a string[] for Neovim 0.11's hl_group array support. Only groups
+---with visual attributes are included; base_hl is used as a fallback when none qualify.
 ---@param node eda.TreeNode
 ---@param dec eda.Decoration?
 ---@return string|string[]
@@ -241,49 +241,17 @@ local function resolve_name_hl(node, dec)
   elseif Node.is_link(node) then
     base_hl = "EdaSymlink"
   end
-  -- Determine symlink highlight to compose (nil for non-symlink nodes).
-  -- Uses node.link_target (not Node.is_link) because follow_symlinks=true
-  -- converts directory symlinks to type="directory" while retaining link_target.
-  local symlink_hl = nil
-  if node.link_broken then
-    symlink_hl = "EdaBrokenSymlink"
-  elseif node.link_target then
-    symlink_hl = "EdaSymlink"
-  end
-
-  -- Helper: append symlink_hl to a result (bypasses has_visual_attrs gating)
-  local function with_symlink(result)
-    if not symlink_hl then
-      return result
-    end
-    if type(result) == "string" then
-      if result == symlink_hl then
-        return result
-      end
-      return { result, symlink_hl }
-    end
-    -- Array: append if not already present
-    for _, hl in ipairs(result) do
-      if hl == symlink_hl then
-        return result
-      end
-    end
-    result[#result + 1] = symlink_hl
-    return result
-  end
 
   if not dec or not dec.name_hl then
-    return with_symlink(base_hl)
+    return base_hl
   end
-  -- Single string path (most common)
   if type(dec.name_hl) == "string" then
     local name_hl_str = dec.name_hl --[[@as string]]
     if has_visual_attrs(name_hl_str) then
-      return with_symlink(name_hl_str)
+      return name_hl_str
     end
-    return with_symlink(base_hl)
+    return base_hl
   end
-  -- Array path: filter to groups with visual attributes
   local visual = {}
   local name_hl_arr = dec.name_hl --[[@as string[] ]]
   for _, hl in ipairs(name_hl_arr) do
@@ -292,12 +260,12 @@ local function resolve_name_hl(node, dec)
     end
   end
   if #visual == 0 then
-    return with_symlink(base_hl)
+    return base_hl
   end
   if #visual == 1 then
-    return with_symlink(visual[1])
+    return visual[1]
   end
-  return with_symlink(visual)
+  return visual
 end
 
 ---Build a cache entry for a decoration.

--- a/tests/e2e/test_highlights.lua
+++ b/tests/e2e/test_highlights.lua
@@ -259,4 +259,82 @@ T["highlights"]["ignored + marked: decoration cache stacks git and mark name hls
   e2e.remove_temp_dir(tmp)
 end
 
+T["highlights"]["symlink + marked: decoration cache stacks symlink and mark name hls"] = function()
+  -- Regression guard: marked symlink must place EdaMarkedName after EdaSymlink in the
+  -- decoration cache array so on_line's per-element emission gives mark the highest
+  -- priority and its fg wins over Underlined's fg.
+  -- Note: headless --listen mode does not fire on_line, so this E2E verifies the
+  -- cache feeding on_line, not the final extmark calls.
+  local tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+  e2e.create_file(tmp .. "/real.txt", "content")
+  vim.uv.fs_symlink(tmp .. "/real.txt", tmp .. "/link.txt")
+
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      git = { enabled = false },
+    })
+  ]]
+  )
+
+  e2e.open_eda(child, tmp)
+
+  e2e.exec(
+    child,
+    [[
+    local buffer = require("eda").get_current().buffer
+    for idx, fl in ipairs(buffer.flat_lines) do
+      if fl.node.name == "link.txt" then
+        vim.api.nvim_win_set_cursor(0, { idx, 0 })
+        break
+      end
+    end
+  ]]
+  )
+  e2e.feed(child, "m")
+  e2e.wait_until(
+    child,
+    [[
+    local buffer = require("eda").get_current().buffer
+    for _, fl in ipairs(buffer.flat_lines) do
+      if fl.node.name == "link.txt" and fl.node._marked then
+        return true
+      end
+    end
+    return false
+  ]]
+  )
+
+  local result = e2e.exec(
+    child,
+    [[
+    local buffer = require("eda").get_current().buffer
+    local link_id
+    for _, fl in ipairs(buffer.flat_lines) do
+      if fl.node.name == "link.txt" then
+        link_id = fl.node_id
+        break
+      end
+    end
+    local entry = buffer.painter._decoration_cache[link_id]
+    return {
+      name_hl = entry and entry.name_hl or nil,
+      type_tag = entry and type(entry.name_hl) or nil,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.type_tag, "table")
+  MiniTest.expect.equality(type(result.name_hl), "table")
+  MiniTest.expect.equality(result.name_hl[1], "EdaSymlink")
+  MiniTest.expect.equality(result.name_hl[#result.name_hl], "EdaMarkedName")
+
+  e2e.remove_temp_dir(tmp)
+end
+
 return T

--- a/tests/render/test_decorator.lua
+++ b/tests/render/test_decorator.lua
@@ -699,15 +699,18 @@ T["symlink_decorator returns link_suffix for file symlink"] = function()
   MiniTest.expect.equality(dec ~= nil, true)
   MiniTest.expect.equality(dec.link_suffix, "→ ../other/target.txt")
   MiniTest.expect.equality(dec.link_suffix_hl, "EdaSymlinkTarget")
+  MiniTest.expect.equality(dec.name_hl, "EdaSymlink")
 end
 
-T["symlink_decorator returns nil for broken symlink"] = function()
+T["symlink_decorator contributes name_hl EdaBrokenSymlink for broken symlink without target"] = function()
   config.setup()
   local store = make_store_with_root("/project")
   local node = Node.create({ id = 2, name = "broken", path = "/project/broken", type = "link", link_broken = true })
   local ctx = { store = store, git_status = nil, config = config.get() }
   local dec = decorator.symlink_decorator(node, ctx)
-  MiniTest.expect.equality(dec, nil)
+  MiniTest.expect.equality(dec ~= nil, true)
+  MiniTest.expect.equality(dec.name_hl, "EdaBrokenSymlink")
+  MiniTest.expect.equality(dec.link_suffix, nil)
 end
 
 T["symlink_decorator returns nil for non-symlink node"] = function()
@@ -763,6 +766,7 @@ T["symlink_decorator appends / for directory symlinks"] = function()
   local ctx = { store = store, git_status = nil, config = config.get() }
   local dec = decorator.symlink_decorator(node, ctx)
   MiniTest.expect.equality(dec.link_suffix, "→ ../other/lib/")
+  MiniTest.expect.equality(dec.name_hl, "EdaSymlink")
 end
 
 -- =============================================
@@ -888,6 +892,66 @@ T["cut + marked node accumulates name_hl and overrides icon"] = function()
   MiniTest.expect.equality(result[1].name_hl[2], "EdaMarkedName")
 
   register.clear()
+end
+
+T["Chain: marked symlink → {EdaSymlink, EdaMarkedName} array (mark wins priority)"] = function()
+  vim.api.nvim_set_hl(0, "EdaSymlink", { fg = 0x8080ff, underline = true })
+  vim.api.nvim_set_hl(0, "EdaMarkedName", { fg = 0xff00ff })
+
+  config.setup()
+  local store = make_store_with_root("/project")
+  local node = Node.create({
+    id = 2,
+    name = "link.txt",
+    path = "/project/link.txt",
+    type = "link",
+    link_target = "/project/target.txt",
+  })
+  node._marked = true
+  local ctx = { store = store, git_status = nil, config = config.get() }
+
+  local chain = decorator.Chain.new()
+  chain:add(decorator.symlink_decorator)
+  chain:add(decorator.mark_decorator)
+
+  local result = chain:decorate({ { node_id = 2, depth = 0, node = node } }, ctx)
+
+  MiniTest.expect.equality(type(result[1].name_hl), "table")
+  MiniTest.expect.equality(result[1].name_hl[1], "EdaSymlink")
+  MiniTest.expect.equality(result[1].name_hl[2], "EdaMarkedName")
+
+  vim.api.nvim_set_hl(0, "EdaSymlink", { link = "Underlined" })
+  vim.api.nvim_set_hl(0, "EdaMarkedName", { link = "EdaMarked" })
+end
+
+T["Chain: marked broken symlink → {EdaBrokenSymlink, EdaMarkedName}"] = function()
+  vim.api.nvim_set_hl(0, "EdaBrokenSymlink", { fg = 0xff0000 })
+  vim.api.nvim_set_hl(0, "EdaMarkedName", { fg = 0xff00ff })
+
+  config.setup()
+  local store = make_store_with_root("/project")
+  local node = Node.create({
+    id = 2,
+    name = "broken",
+    path = "/project/broken",
+    type = "link",
+    link_broken = true,
+  })
+  node._marked = true
+  local ctx = { store = store, git_status = nil, config = config.get() }
+
+  local chain = decorator.Chain.new()
+  chain:add(decorator.symlink_decorator)
+  chain:add(decorator.mark_decorator)
+
+  local result = chain:decorate({ { node_id = 2, depth = 0, node = node } }, ctx)
+
+  MiniTest.expect.equality(type(result[1].name_hl), "table")
+  MiniTest.expect.equality(result[1].name_hl[1], "EdaBrokenSymlink")
+  MiniTest.expect.equality(result[1].name_hl[2], "EdaMarkedName")
+
+  vim.api.nvim_set_hl(0, "EdaBrokenSymlink", { link = "DiagnosticError" })
+  vim.api.nvim_set_hl(0, "EdaMarkedName", { link = "EdaMarked" })
 end
 
 return T

--- a/tests/render/test_painter.lua
+++ b/tests/render/test_painter.lua
@@ -1076,46 +1076,15 @@ T["decoration cache name_hl filters non-visual groups from array"] = function()
 end
 
 -- =============================================
--- resolve_name_hl symlink composition tests
+-- resolve_name_hl fallback for link-type nodes
 -- =============================================
 
-T["resolve_name_hl composes EdaSymlink for directory symlink"] = function()
-  local Node = require("eda.tree.node")
-  local store, root = build_store()
-  local flat_lines = Flatten.flatten(store, root)
-  local buf = vim.api.nvim_create_buf(false, true)
-  local painter = Painter.new(buf)
-
-  -- Simulate a directory symlink (follow_symlinks=true: type=directory, link_target set)
-  local dir_node = flat_lines[1].node
-  dir_node.link_target = "/other/dir"
-
-  -- Provide minimal decoration so build_cache_entry creates a cache entry
-  local decorations = {}
-  for i = 1, #flat_lines do
-    decorations[i] = {}
-  end
-
-  painter:paint(flat_lines, decorations)
-
-  local entry = painter._decoration_cache[flat_lines[1].node_id]
-  MiniTest.expect.equality(entry ~= nil, true)
-  -- Should be array: { "EdaOpenedDirectoryName", "EdaSymlink" }
-  MiniTest.expect.equality(type(entry.name_hl), "table")
-  MiniTest.expect.equality(entry.name_hl[1], "EdaOpenedDirectoryName")
-  MiniTest.expect.equality(entry.name_hl[2], "EdaSymlink")
-
-  -- Cleanup
-  dir_node.link_target = nil
-  vim.api.nvim_buf_delete(buf, { force = true })
-end
-
-T["resolve_name_hl returns EdaSymlink for type=link without decorator"] = function()
+T["resolve_name_hl falls back to EdaSymlink for link-type node when decorator returns nil"] = function()
   local Node = require("eda.tree.node")
   local buf = vim.api.nvim_create_buf(false, true)
   local painter = Painter.new(buf)
 
-  local link_node = Node.create({ id = 99, name = "lnk", path = "/lnk", type = "link", link_target = "/target" })
+  local link_node = Node.create({ id = 99, name = "lnk", path = "/lnk", type = "link" })
   local flat_lines = { { node_id = 99, depth = 0, node = link_node } }
   local decorations = { [1] = {} }
 
@@ -1123,54 +1092,9 @@ T["resolve_name_hl returns EdaSymlink for type=link without decorator"] = functi
 
   local entry = painter._decoration_cache[99]
   MiniTest.expect.equality(entry ~= nil, true)
-  -- type=link with link_target: base_hl=EdaSymlink, symlink_hl=EdaSymlink → deduplicated to string
   MiniTest.expect.equality(entry.name_hl, "EdaSymlink")
 
   vim.api.nvim_buf_delete(buf, { force = true })
-end
-
-T["resolve_name_hl composes EdaSymlink with decorator name_hl"] = function()
-  local Node = require("eda.tree.node")
-  local buf = vim.api.nvim_create_buf(false, true)
-  local painter = Painter.new(buf)
-
-  vim.api.nvim_set_hl(0, "TestSymlinkDecHl", { fg = 0xaabbcc })
-
-  local link_node = Node.create({ id = 99, name = "lnk", path = "/lnk", type = "link", link_target = "/target" })
-  local flat_lines = { { node_id = 99, depth = 0, node = link_node } }
-  local decorations = { [1] = { name_hl = "TestSymlinkDecHl" } }
-
-  painter:paint(flat_lines, decorations)
-
-  local entry = painter._decoration_cache[99]
-  MiniTest.expect.equality(type(entry.name_hl), "table")
-  MiniTest.expect.equality(entry.name_hl[1], "TestSymlinkDecHl")
-  MiniTest.expect.equality(entry.name_hl[2], "EdaSymlink")
-
-  vim.api.nvim_buf_delete(buf, { force = true })
-  vim.api.nvim_set_hl(0, "TestSymlinkDecHl", {})
-end
-
-T["resolve_name_hl composes EdaBrokenSymlink for broken symlink with decorator"] = function()
-  local Node = require("eda.tree.node")
-  local buf = vim.api.nvim_create_buf(false, true)
-  local painter = Painter.new(buf)
-
-  vim.api.nvim_set_hl(0, "TestBrokenDecHl", { fg = 0xaabbcc })
-
-  local broken_node = Node.create({ id = 99, name = "broken", path = "/broken", type = "link", link_broken = true })
-  local flat_lines = { { node_id = 99, depth = 0, node = broken_node } }
-  local decorations = { [1] = { name_hl = "TestBrokenDecHl" } }
-
-  painter:paint(flat_lines, decorations)
-
-  local entry = painter._decoration_cache[99]
-  MiniTest.expect.equality(type(entry.name_hl), "table")
-  MiniTest.expect.equality(entry.name_hl[1], "TestBrokenDecHl")
-  MiniTest.expect.equality(entry.name_hl[2], "EdaBrokenSymlink")
-
-  vim.api.nvim_buf_delete(buf, { force = true })
-  vim.api.nvim_set_hl(0, "TestBrokenDecHl", {})
 end
 
 T["cache entry includes both link_suffix and suffix"] = function()


### PR DESCRIPTION
## Summary

When a symlink node was marked, `EdaSymlink` overrode `EdaMarkedName` so the mark color was invisible — while the same pairing worked correctly for marked gitignored files.

Root cause: `painter.lua`'s `with_symlink` helper always appended `EdaSymlink` / `EdaBrokenSymlink` to the tail of the `name_hl` array after the decorator chain had already composed. Per-element extmarks are emitted with `priority = 200 + i`, so the tail always won — regardless of chain registration order.

Fix: move symlink `name_hl` into `symlink_decorator` so it participates in the normal chain (`symlink → git → cut → mark`) and lets natural registration order decide priority. Mark now wins fg, and symlink's underline still composes via Neovim's attribute-level extmark priority merging.

### Changes
- `decorator.lua`: `symlink_decorator` contributes `name_hl = EdaSymlink` (or `EdaBrokenSymlink` when `link_broken`) alongside the existing `link_suffix`
- `painter.lua`: remove `with_symlink` helper and `symlink_hl` injection from `resolve_name_hl`; keep `base_hl = EdaSymlink` fallback for link-type nodes when the decorator returns `nil`
- Tests: add 2 Chain composition unit tests (marked symlink, marked broken symlink), extend existing symlink_decorator tests with `name_hl` assertions, add symlink + marked E2E regression guard as a sibling of the existing ignored + marked guard

## References

- n/a
