### PR TITLE
docs: fix documentation drift and add Actions section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### E2E Tests
 
 - E2E tests use `MiniTest.new_child_neovim()` for process isolation (`--listen pipe` + `vim.uv.sleep()` polling)
-- Each test case spawns a fresh child Neovim via `tests/e2e/helpers.lua` — `e2e.spawn()`, `e2e.stop()`, `e2e.exec()`, `e2e.feed()`, `e2e.wait_until()`
+- Each test case spawns a fresh child Neovim via `tests/e2e/helpers.lua` — `e2e.spawn()`, `e2e.stop()`, `e2e.exec()`, `e2e.feed()`, `e2e.feed_insert()`, `e2e.wait_until()`, `e2e.setup_eda()`, `e2e.open_eda()`, `e2e.create_git_repo()`, plus `e2e.get_buf_lines()` / `e2e.get_win_count()` / `e2e.get_tab_count()`
 - Inner Neovim config: `--clean --headless`, `split_left`, `header=false`, `git.enabled=false`, `icon.provider="none"`
 - Headless `--listen` mode limitations: `BufWinEnter`/`BufEnter` do not fire for RPC-initiated commands; `nvim_set_decoration_provider` `on_line` does not fire (no UI redraw). Use `doautocmd` workarounds or verify internal state (`_decoration_cache`) instead
 - `wait_until()` wraps multiline predicates in `(function() ... end)()` — single expressions use `return (expr)`, block statements use the function wrapper
@@ -92,11 +92,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `on_win` callback (once per window per redraw) can safely call `nvim_buf_get_extmarks`, `nvim_buf_clear_namespace`, and `nvim_buf_set_extmark`. Use position comparison to skip unnecessary rebuilds (fast path)
 - Float window titles render on top of the float border: padding with spaces replaces the border horizontal character and breaks the visual frame. To right-align content in a float title (e.g., a status indicator), fill the gap with the border's horizontal char (`─` for rounded/single, `═` for double) rather than spaces. `title_pos` (center/right) additionally shifts the entire chunk array, so right-edge padding layouts only work with `title_pos = "left"` — fall back to adjacent placement for other positions
 - `nvim_win_set_config({title = {{text, hl_group}, ...}})` accepts chunk arrays for multi-highlight float titles (Neovim 0.9+). `nvim_win_get_config(winid).title` round-trips the same chunk form; plain string titles are normalized to a single-element chunk `{{text}}`
+- Mark invariant: nodes carry `_marked = true|nil` (2-state). Action target resolution across mark-aware operations (delete/cut/copy/duplicate/paste) follows `Visual > marks > cursor` priority (single source of truth in `action/builtin.lua`)
+- Mark highlight pattern: `EdaMarked` (base, `Special` link) → `EdaMarkedIcon` / `EdaMarkedName` (both linked to `EdaMarked`). On setup and `ColorScheme` events, `bg` / `ctermbg` are stripped from resolved `EdaMarked` to avoid clobbering `CursorLine` / `Visual`
+- `paint_incremental()` (`render/painter.lua`): directory expand/collapse uses a differential paint strategy driven by `_incremental_hint` (node ID of the toggled dir) set in `init.lua`. Only the affected line range is re-decorated, avoiding a full-buffer repaint
 
 ## Benchmarking
 
 - Script: `benchmarks/render.lua` — run via `nvim --headless -l benchmarks/render.lua [target_dir]`
-- 6 scenarios: root-only / all-expanded / post-toggle / re-render / window+render / window+re-render
+- 9 scenarios (1-6: baseline render pipeline — root-only / all-expanded / post-toggle / re-render / window+render / window+re-render; 7: single-toggle profiled breakdown; 8: edit-preserve capture profiled; 9: `paint_incremental` vs full paint)
 - Run before and after performance-related changes (render pipeline, store, decorator, painter) and compare results
 - Headless mode does not measure `nvim_set_decoration_provider` visible-line optimization; Scenarios 5-6 (with window) partially compensate
+- Scenario 9 is the regression gate for `paint_incremental` (used on directory toggle to avoid full-buffer repaint). Always run Scenario 9 after touching `painter.lua` or `init.lua` toggle paths
 - For large-scale benchmarking: `git clone --depth=1 https://github.com/neovim/neovim /tmp/neovim-bench` → run benchmark → `rm -rf /tmp/neovim-bench`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Explore as a tree, edit as a buffer — a file explorer for Neovim that combines
 - **Extensible action system** — Named registry with custom actions as first-class citizens
 - **netrw replacement** — `hijack_netrw` option for seamless default browsing
 - **60+ highlight groups** — Full appearance customization across 6 categories
-- **Event hooks** — `EdaTreeOpen`, `EdaMutationPost`, etc. for plugin integration
+- **Event hooks** — `EdaTreeOpen`, `EdaTreeClose`, `EdaMutationPre`, `EdaMutationPost`, `EdaRootChanged` for plugin integration. See [`doc/eda.nvim.txt`](doc/eda.nvim.txt) for event payload details.
 
 ## Requirements
 
@@ -260,6 +260,16 @@ require("eda").setup({
     enabled = true,
   },
 
+  -- Marker icon displayed before the file/folder icon on marked nodes
+  -- Use `m` (default `mark_toggle`) to mark/unmark nodes. Marked nodes are
+  -- highlighted via EdaMarked / EdaMarkedIcon / EdaMarkedName and become the
+  -- default target for mark-aware actions (delete, cut, copy, duplicate, paste)
+  -- when no Visual selection is active.
+  mark = {
+    -- Set to "" to disable the prefix icon (name highlight still applies)
+    icon = "󰄲", -- nf-md-checkbox_marked (U+F0132)
+  },
+
   -- Header displayed above the tree (set to false to disable entirely)
   header = {
     -- Format: "short", or fun(root_path): string|false
@@ -321,6 +331,146 @@ require("eda").setup({
 
 > [!TIP]
 > See `:help eda.nvim` for detailed descriptions of each option, available actions, events, and highlight groups.
+
+## Actions
+
+All operations in eda.nvim are registered as named actions in an action registry. Built-ins and user-defined actions share the same namespace — anything registered can be bound to a key via `mappings`, dispatched programmatically, or discovered at runtime through the `actions` picker (`ga` by default).
+
+### Built-in Actions
+
+The table below groups built-ins by role. See [`:help eda-actions`](doc/eda.nvim.txt) for per-action parameters, edge cases, and target-resolution rules.
+
+#### Navigation
+
+| Action | Description |
+| --- | --- |
+| `select` | Open file in the target window or toggle directory open/closed |
+| `select_split` | Open file in a horizontal split |
+| `select_vsplit` | Open file in a vertical split |
+| `select_tab` | Open file in a new tab |
+| `parent` | Navigate to the parent directory (changes root when invoked on root) |
+| `cwd` | Change root to the current working directory |
+| `cd` | Change root to the directory under the cursor |
+
+#### Tree Manipulation
+
+| Action | Description |
+| --- | --- |
+| `collapse_all` | Collapse all directories except root |
+| `collapse_node` | Collapse current directory, or move cursor to parent if already collapsed |
+| `collapse_recursive` | Recursively collapse a directory and all its children |
+| `expand_all` | Expand every directory up to `expand_depth` |
+| `expand_recursive` | Recursively expand the directory under the cursor up to `expand_depth` |
+
+#### Yank
+
+| Action | Description |
+| --- | --- |
+| `yank_path` | Yank the relative path to the system clipboard |
+| `yank_path_absolute` | Yank the absolute path to the system clipboard |
+| `yank_name` | Yank the filename to the system clipboard |
+
+#### File Operations
+
+Target resolution is unified across `delete` / `cut` / `copy` / `duplicate`: **Visual selection > marked nodes > cursor node**. The root node is always excluded.
+
+| Action | Description |
+| --- | --- |
+| `mark_toggle` | Toggle mark on the current node and move cursor down |
+| `delete` | Delete target nodes (routes through `confirm.delete` dialog) |
+| `cut` | Move target paths into the register; `paste` later moves them |
+| `copy` | Copy target paths into the register; `paste` later duplicates them |
+| `paste` | Paste from the register into the directory under the cursor |
+| `duplicate` | Duplicate target nodes in place, appending `_copy` on name collision |
+
+#### Display
+
+| Action | Description |
+| --- | --- |
+| `toggle_hidden` | Toggle visibility of hidden files (dotfiles) |
+| `toggle_gitignored` | Toggle visibility of git-ignored files |
+| `toggle_git_changes` | Toggle filter showing only files with git changes |
+| `next_git_change` | Jump to the next git-changed file (wraps at end) |
+| `prev_git_change` | Jump to the previous git-changed file |
+| `toggle_preview` | Toggle the file preview pane |
+| `preview_scroll_down` | Scroll the preview down by half a page |
+| `preview_scroll_up` | Scroll the preview up by half a page |
+| `preview_scroll_page_down` | Scroll the preview down by a full page |
+| `preview_scroll_page_up` | Scroll the preview up by a full page |
+
+#### Misc
+
+| Action | Description |
+| --- | --- |
+| `refresh` | Rescan the filesystem and re-render the tree |
+| `close` | Close the explorer window |
+| `system_open` | Open the file with the system default application |
+| `inspect` | Print node data to the console (debug) |
+| `help` | Show keybinding help in a floating window |
+| `split` | Open the explorer in a new vertical split with the same root |
+| `vsplit` | Open the explorer in a new horizontal split with the same root |
+| `actions` | Open an action picker listing every registered action |
+
+### Defining Custom Actions
+
+Register a function under a name, then map it like any built-in. Custom actions also appear in the `actions` picker, so they remain discoverable without a dedicated keymap.
+
+```lua
+local action = require("eda.action")
+
+action.register("my_action", function(ctx)
+  local node = ctx.buffer:get_cursor_node(ctx.window.winid)
+  if node then
+    vim.notify("Selected: " .. node.path)
+  end
+end, { desc = "Show selected file path" })
+
+require("eda").setup({
+  mappings = {
+    ["<C-x>"] = "my_action",
+  },
+})
+```
+
+#### `action.register(name, fn, opts?)`
+
+- `name` `string` — Action identifier used by `mappings` and dispatched calls.
+- `fn` `fun(ctx: eda.ActionContext)` — Action body. Receives the context described below.
+- `opts.desc` `string?` — Human-readable description shown in the `actions` picker.
+
+#### `ActionContext`
+
+Every action receives a context table with handles to the running explorer state:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `ctx.store` | `eda.Store` | Tree node store (lookup, mutations) |
+| `ctx.buffer` | `eda.Buffer` | Explorer buffer API (cursor node, line helpers) |
+| `ctx.window` | `eda.Window` | Explorer window (`winid`, focus helpers) |
+| `ctx.scanner` | `eda.Scanner` | Filesystem scanner |
+| `ctx.config` | `eda.Config` | Resolved configuration |
+| `ctx.explorer` | `eda.Explorer` | Current explorer instance (`root_path`, `instance_id`) |
+
+See [`:help eda-api`](doc/eda.nvim.txt) for the full public API, including the `action.dispatch` / `action.list` / `action.get_entry` helpers.
+
+#### Example: open a terminal in the directory under the cursor
+
+```lua
+action.register("open_terminal", function(ctx)
+  local node = ctx.buffer:get_cursor_node(ctx.window.winid)
+  local dir = node and node.is_dir and node.path
+    or node and vim.fn.fnamemodify(node.path, ":h")
+    or ctx.explorer.root_path
+  vim.cmd("split | terminal")
+  vim.fn.chansend(vim.b.terminal_job_id, "cd " .. vim.fn.shellescape(dir) .. "\n")
+end, { desc = "Open terminal in directory" })
+
+require("eda").setup({
+  mappings = {
+    ["<C-\\>"] = "open_terminal",
+  },
+})
+```
 
 ## Recipes
 
@@ -462,33 +612,6 @@ require("eda").setup({
       end
       return "·", "EdaFileIcon"
     end,
-  },
-})
-```
-
-</details>
-
-<details>
-<summary>Register custom actions</summary>
-
-Add project-specific actions to the registry. They appear in the action picker (`ga`) and can be mapped to keys.
-
-```lua
-local action = require("eda.action")
-
-action.register("open_terminal", function(ctx)
-  local node = ctx.buffer:get_cursor_node(ctx.window.winid)
-  local dir = node and node.is_dir and node.path
-    or node and vim.fn.fnamemodify(node.path, ":h")
-    or ctx.explorer.root_path
-  vim.cmd("split | terminal")
-  vim.fn.chansend(vim.b.terminal_job_id, "cd " .. vim.fn.shellescape(dir) .. "\n")
-end, { desc = "Open terminal in directory" })
-
--- Map it
-require("eda").setup({
-  mappings = {
-    ["<C-\\>"] = "open_terminal",
   },
 })
 ```

--- a/doc/eda.md
+++ b/doc/eda.md
@@ -65,15 +65,16 @@ require("eda").setup({
   git = {
     enabled = true,
     icons = {
-      untracked = "nf-oct-question",     -- U+F420
-      added = "nf-oct-plus",             -- U+F44D
-      modified = "nf-oct-diff",          -- U+F444
-      deleted = "nf-oct-circle_slash",   -- U+F474
-      renamed = "nf-oct-arrow_right",    -- U+F432
-      staged = "nf-oct-check",           -- U+F42E
-      conflict = "nf-oct-alert",         -- U+F421
+      untracked = "",     -- U+F420
+      added = "",             -- U+F44D
+      modified = "",          -- U+F444
+      deleted = "",   -- U+F474
+      renamed = "",    -- U+F432
+      staged = "",           -- U+F42E
+      conflict = "",         -- U+F421
       ignored = "◌",                     -- U+25CC
     },
+  },
 
   indent = {
     width = 2,
@@ -87,6 +88,10 @@ require("eda").setup({
 
   full_name = {
     enabled = true,
+  },
+
+  mark = {
+    icon = "󰄲",        -- nf-md-checkbox_marked (U+F0132)
   },
 
   header = {
@@ -448,7 +453,7 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
 
 `table`
 
-- `icon` `string` (default: `mark.icon` — nf-md-checkbox_marked)
+- `icon` `string` (default: nf-md-checkbox_marked, U+F0132)
   Prefix marker icon displayed before the file/folder icon on marked nodes.
   Set to `""` to disable the prefix icon (the name highlight still applies).
 
@@ -871,7 +876,12 @@ automatically update LSP workspace paths on file rename/move.
 Fired when the explorer's root directory changes (via `parent`, `cwd`, or `cd`
 actions).
 
-`data`: `{ root_path = string, explorer = eda.Explorer }`
+`data`: `{ root_path = string, instance_id = integer }`
+
+`instance_id` is the integer ID that identifies the Explorer instance (the same
+value returned by `require("eda").get_all()` entries). eda.nvim allows multiple
+explorer instances to coexist, so event listeners can use this field to filter
+events to a specific instance when needed.
 
 ## Highlight Groups
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -84,15 +84,16 @@ DEFAULT CONFIGURATION ~
       git = {
         enabled = true,
         icons = {
-          untracked = "nf-oct-question",     -- U+F420
-          added = "nf-oct-plus",             -- U+F44D
-          modified = "nf-oct-diff",          -- U+F444
-          deleted = "nf-oct-circle_slash",   -- U+F474
-          renamed = "nf-oct-arrow_right",    -- U+F432
-          staged = "nf-oct-check",           -- U+F42E
-          conflict = "nf-oct-alert",         -- U+F421
+          untracked = "",     -- U+F420
+          added = "",             -- U+F44D
+          modified = "",          -- U+F444
+          deleted = "",   -- U+F474
+          renamed = "",    -- U+F432
+          staged = "",           -- U+F42E
+          conflict = "",         -- U+F421
           ignored = "◌",                     -- U+25CC
         },
+      },
     
       indent = {
         width = 2,
@@ -106,6 +107,10 @@ DEFAULT CONFIGURATION ~
     
       full_name = {
         enabled = true,
+      },
+    
+      mark = {
+        icon = "󰄲",        -- nf-md-checkbox_marked (U+F0132)
       },
     
       header = {
@@ -468,7 +473,7 @@ MARK ~
 
 `table`
 
-- `icon` `string` (default: `mark.icon` — nf-md-checkbox_marked)
+- `icon` `string` (default: nf-md-checkbox_marked, U+F0132)
     Prefix marker icon displayed before the file/folder icon on marked nodes.
     Set to `""` to disable the prefix icon (the name highlight still applies).
 
@@ -967,7 +972,12 @@ EDAROOTCHANGED ~
 Fired when the explorer’s root directory changes (via `parent`, `cwd`, or
 `cd` actions).
 
-`data`: `{ root_path = string, explorer = eda.Explorer }`
+`data`: `{ root_path = string, instance_id = integer }`
+
+`instance_id` is the integer ID that identifies the Explorer instance (the same
+value returned by `require("eda").get_all()` entries). eda.nvim allows multiple
+explorer instances to coexist, so event listeners can use this field to filter
+events to a specific instance when needed.
 
 
 HIGHLIGHT GROUPS                          *eda.nvim-eda.nvim-highlight-groups*


### PR DESCRIPTION
## Summary

- Fixes documentation drift between `README.md`, `doc/eda.md`, `CLAUDE.md` and the implementation (audit covered all user-facing docs)
- Introduces an `## Actions` section in README with a full 39-action catalog (six groups) and a dedicated custom-action guide (`action.register`, ActionContext fields, runnable example)

### Drift fixes

- **doc/eda.md**
  - Close the missing `}` in the `git = {}` block of the Default Configuration sample (was a Lua syntax error when copied verbatim)
  - Replace placeholder icon names (`"nf-oct-question"` …) with the real Nerd Font glyphs, byte-matched against `lua/eda/config.lua:168-175`
  - Correct the `EdaRootChanged` payload from `explorer = eda.Explorer` to `instance_id = integer` to match `lua/eda/init.lua:1230`
  - Add `mark = { icon = ... }` to the Default Configuration sample
  - Replace the self-referential `default: mark.icon` with `default: nf-md-checkbox_marked, U+F0132`
- **CLAUDE.md**
  - Benchmark scenario count: 6 → 9 (adds the profiled toggle, edit-preserve, and `paint_incremental` scenarios)
  - Expand the E2E helper listing (`setup_eda`, `open_eda`, `feed_insert`, `create_git_repo`, `get_buf_lines`, `get_win_count`, `get_tab_count`)
  - Document the mark invariants (`_marked = true|nil`, `Visual > marks > cursor` priority) and the `EdaMarked` / `EdaMarkedIcon` / `EdaMarkedName` highlight chain
  - Note Scenario 9 as the regression gate for `paint_incremental`
- **README.md**
  - Enumerate all five User autocmds in the Features section (`EdaTreeOpen`, `EdaTreeClose`, `EdaMutationPre`, `EdaMutationPost`, `EdaRootChanged`)
  - Add the `mark = { icon = ... }` block to the Default Configuration sample with usage comments
- **doc/eda.nvim.txt** regenerated via `just doc`

### New Actions section

Placed between `## Configuration` and `## Recipes` so readers can drill into the action surface without leaving README:

- Grouped catalog of all 39 built-in actions (Navigation / Tree Manipulation / Yank / File Operations / Display / Misc), with target-resolution rules called out for `delete` / `cut` / `copy` / `duplicate`
- `action.register(name, fn, opts?)` signature
- `ActionContext` table (store / buffer / window / scanner / config / explorer)
- Minimal custom-action example plus a more complete "open terminal in directory" example
- The previous "Register custom actions" recipe was folded into this section to avoid duplication

## Verification

- `just test-all` — all unit tests pass, 127 E2E cases across 22 groups pass (Fails 0 / Notes 0)
- The Default Configuration Lua block in `doc/eda.md` parses cleanly via `loadstring`
- Action catalog completeness: every action registered in `lua/eda/action/builtin.lua` (39) appears in the README catalog (39), cross-checked with `diff`
- Git icon glyphs in `doc/eda.md` are byte-identical to `lua/eda/config.lua:168-175`

## References

- No linked issue; drift items were surfaced by a doc-vs-code audit against PRs #11–#16 (mark feature work) and the `paint_incremental` / benchmark additions

## Test plan

- [x] `just test-all` green locally
- [x] `just doc` regenerates `doc/eda.nvim.txt` without drift
- [ ] CI green on PR
