### PR TITLE
feat: add quickfix action for marked files

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -457,6 +457,23 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
   Prefix marker icon displayed before the file/folder icon on marked nodes.
   Set to `""` to disable the prefix icon (the name highlight still applies).
 
+### quickfix
+
+`table`
+
+- `auto_open` `boolean` (default: `true`)
+  Open the quickfix window automatically after the `quickfix` action populates
+  the list. Set to `false` to populate the list silently; you can open the
+  window manually with `:copen`.
+
+  When the explorer is a float (`window.kind = "float"`) and `auto_open` is
+  `true`, the float is closed just before `:copen` so the quickfix window
+  becomes the sole foreground pane. Split and replace layouts do not overlap
+  the quickfix split and stay open.
+
+To remove the default `gq` mapping entirely, set
+`mappings = { ["gq"] = false }`.
+
 ### header
 
 `table|false`
@@ -624,6 +641,7 @@ configuration option.
 | `gx`    | cut                | Cut target nodes (Visual > marks > cursor) |
 | `gy`    | copy               | Copy target nodes (Visual > marks > cursor) |
 | `gp`    | paste              | Paste from register           |
+| `gq`    | quickfix           | Send target nodes to quickfix (Visual > marks > cursor) |
 | `g?`    | help               | Show help                     |
 | `ga`    | actions            | Open action picker            |
 | `<C-f>` | preview_scroll_down| Scroll preview down (half page) |
@@ -684,6 +702,13 @@ success (partial failures keep the marks for the failed/unattempted entries).
 - **duplicate** — Duplicate each target node into its parent directory with
   the same `_copy` collision-resolution as `paste`. No prompt; works on
   files and directories.
+- **quickfix** — Send target node paths to Neovim's quickfix list. Files
+  only (directories are skipped with a warning). Preserves marks
+  (non-destructive, unlike `cut`/`copy`/`delete`/`duplicate`). Opens the
+  quickfix window automatically when `quickfix.auto_open` is `true`
+  (default); when the explorer is a float, the float is closed first so
+  it does not overlap the quickfix split. Replaces the current list; use
+  `:colder` / `:cnewer` to navigate the quickfix history.
 - **mark_toggle** — Toggle mark on the current node and move cursor down.
 
 > **Note:** `mark_bulk_delete` and `mark_bulk_move` were removed in favour of

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -478,6 +478,22 @@ MARK ~
     Set to `""` to disable the prefix icon (the name highlight still applies).
 
 
+QUICKFIX ~
+
+`table`
+
+- `auto_open` `boolean` (default: `true`) Open the quickfix window automatically
+    after the `quickfix` action populates the list. Set to `false` to populate the
+    list silently; you can open the window manually with `:copen`.
+    When the explorer is a float (`window.kind = "float"`) and `auto_open` is
+    `true`, the float is closed just before `:copen` so the quickfix window becomes
+    the sole foreground pane. Split and replace layouts do not overlap the quickfix
+    split and stay open.
+
+To remove the default `gq` mapping entirely, set `mappings = { ["gq"] = false
+}`.
+
+
 HEADER ~
 
 `table|false`
@@ -687,6 +703,9 @@ configuration option.
 
   gp              paste                   Paste from register
 
+  gq              quickfix                Send target nodes to quickfix
+                                          (Visual > marks > cursor)
+
   g?              help                    Show help
 
   ga              actions                 Open action picker
@@ -757,6 +776,13 @@ success (partial failures keep the marks for the failed/unattempted entries).
 - **duplicate** — Duplicate each target node into its parent directory with
     the same `_copy` collision-resolution as `paste`. No prompt; works on
     files and directories.
+- **quickfix** — Send target node paths to Neovim’s quickfix list. Files
+    only (directories are skipped with a warning). Preserves marks
+    (non-destructive, unlike `cut`/`copy`/`delete`/`duplicate`). Opens the
+    quickfix window automatically when `quickfix.auto_open` is `true`
+    (default); when the explorer is a float, the float is closed first so
+    it does not overlap the quickfix split. Replaces the current list; use
+    `:colder` / `:cnewer` to navigate the quickfix history.
 - **mark_toggle** — Toggle mark on the current node and move cursor down.
 
 

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -941,7 +941,9 @@ end, { desc = "Inspect node data" })
 ---@return eda.TargetNodes
 local function get_target_nodes(ctx)
   local mode = vim.fn.mode()
-  if mode == "v" or mode == "V" then
+  -- "\22" is <C-v> (blockwise Visual). Treat all three Visual submodes uniformly
+  -- so the Visual > marks > cursor contract holds regardless of how the user entered Visual.
+  if mode == "v" or mode == "V" or mode == "\22" then
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "x", false)
     local start_line = vim.fn.line("'<")
     local end_line = vim.fn.line("'>")
@@ -1013,6 +1015,58 @@ action.register("copy", function(ctx)
   end
   vim.notify("Copied " .. #paths .. " item(s)")
 end, { desc = "Copy target nodes (Visual > marks > cursor)" })
+
+action.register("quickfix", function(ctx)
+  local target = get_target_nodes(ctx)
+  if #target.nodes == 0 then
+    vim.notify("No items selected")
+    return
+  end
+
+  local files = {}
+  local skipped = 0
+  for _, node in ipairs(target.nodes) do
+    if Node.is_dir(node) then
+      skipped = skipped + 1
+    else
+      -- lnum/col are omitted so `:copen` renders file-reference form ("path||")
+      -- rather than pinning every entry to (1, 1).
+      table.insert(files, { filename = node.path })
+    end
+  end
+
+  if #files == 0 then
+    vim.notify("No files to add to quickfix (" .. skipped .. " dir(s) skipped)", vim.log.levels.WARN)
+    return
+  end
+
+  vim.fn.setqflist({}, " ", { title = "eda marks", items = files })
+
+  local msg = "Quickfix: " .. #files .. " file(s)"
+  local level = vim.log.levels.INFO
+  if skipped > 0 then
+    msg = msg .. " (" .. skipped .. " dir(s) skipped)"
+    -- Elevate to WARN so users notice that some selected entries were skipped.
+    level = vim.log.levels.WARN
+  end
+  vim.notify(msg, level)
+
+  -- Intentionally no clear_marks / refresh: quickfix is non-destructive, tree
+  -- display is unchanged, and retained marks support iterative `gq` workflows.
+  -- Defensive guard: users may shadow the default `quickfix` table via setup()
+  -- with a non-table value (e.g. `setup({ quickfix = false })`) — honor that
+  -- as "auto_open disabled" rather than crashing on a nil index.
+  if type(ctx.config.quickfix) == "table" and ctx.config.quickfix.auto_open then
+    -- A float explorer overlaps the bottom qf split and leaves the screen in a
+    -- visually broken state once `:copen` steals focus. Close it first so the
+    -- qf window becomes the sole foreground pane. Split and replace kinds do
+    -- not overlap the qf split and stay open.
+    if ctx.window.kind == "float" then
+      get_eda().close()
+    end
+    vim.cmd("copen")
+  end
+end, { desc = "Create quickfix from target nodes (Visual > marks > cursor)" })
 
 action.register("paste", function(ctx)
   local register = require("eda.register")

--- a/lua/eda/buffer/init.lua
+++ b/lua/eda/buffer/init.lua
@@ -223,6 +223,7 @@ end
 local visual_mode_actions = {
   cut = true,
   copy = true,
+  quickfix = true,
 }
 
 ---Set keymaps on the buffer.

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -43,6 +43,7 @@ local M = {}
 ---@field preview eda.PreviewConfig
 ---@field full_name eda.FullNameConfig
 ---@field mark eda.MarkConfig
+---@field quickfix eda.QuickfixConfig
 ---@field header eda.HeaderConfig|false
 ---@field expand_depth integer
 ---@field update_focused_file eda.UpdateFocusedFileConfig
@@ -99,6 +100,9 @@ local M = {}
 
 ---@class eda.MarkConfig
 ---@field icon string
+
+---@class eda.QuickfixConfig
+---@field auto_open boolean
 
 ---@alias eda.HeaderPosition "left" | "center" | "right"
 
@@ -196,6 +200,10 @@ local defaults = {
     icon = string.char(0xf3, 0xb0, 0x84, 0xb2),
   },
 
+  quickfix = {
+    auto_open = true,
+  },
+
   header = {
     format = "short",
     position = "left",
@@ -234,6 +242,7 @@ local defaults = {
     ["gx"] = "cut",
     ["gy"] = "copy",
     ["gp"] = "paste",
+    ["gq"] = "quickfix",
     ["g?"] = "help",
     ["ga"] = "actions",
     ["<C-f>"] = "preview_scroll_down",

--- a/tests/action/test_builtin.lua
+++ b/tests/action/test_builtin.lua
@@ -455,6 +455,19 @@ T["_get_target_nodes: visual takes priority over marks"] = function()
   MiniTest.expect.equality(result.nodes[2].id, 4)
 end
 
+T["_get_target_nodes: blockwise visual (<C-v>) also resolves as visual"] = function()
+  local ctx = make_target_ctx(nil)
+  local result
+  -- "\22" is the raw key code for CTRL-V (U+0016); vim.fn.mode() returns it for blockwise Visual.
+  with_visual_range("\22", 2, 3, function()
+    result = get_target(ctx)
+  end)
+  MiniTest.expect.equality(result.origin, "visual")
+  MiniTest.expect.equality(#result.nodes, 2)
+  MiniTest.expect.equality(result.nodes[1].id, 3)
+  MiniTest.expect.equality(result.nodes[2].id, 4)
+end
+
 T["_get_target_nodes: visual range excludes root"] = function()
   local ctx = make_target_ctx(nil)
   ctx.buffer.flat_lines = {
@@ -591,6 +604,208 @@ T["_resolve_unique_dst: matches paste inline behavior (regression)"] = function(
     MiniTest.expect.equality(actual, expected)
   end
   helpers.remove_temp_dir(dir)
+end
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- quickfix action
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Close any quickfix window and wipe the quickfix list so each case starts clean.
+local function qf_reset()
+  pcall(vim.cmd, "cclose")
+  vim.fn.setqflist({}, "f")
+end
+
+-- Entry guard: action must be registered. Falsey before Task 2 implementation.
+T["quickfix action is registered"] = function()
+  MiniTest.expect.equality(action.get_entry("quickfix") ~= nil, true)
+end
+
+-- Cursor fallback when no marks are set (unified Visual > marks > cursor rule).
+T["quickfix action sets qflist from cursor when no marks"] = function()
+  qf_reset()
+  local ctx = make_ctx(3) -- cursor on file_a (/project/dir_a/file_a.lua)
+  ctx.config.quickfix = { auto_open = false }
+  action.dispatch("quickfix", ctx)
+  local items = vim.fn.getqflist()
+  MiniTest.expect.equality(#items, 1)
+  MiniTest.expect.equality(vim.api.nvim_buf_get_name(items[1].bufnr), "/project/dir_a/file_a.lua")
+  qf_reset()
+end
+
+-- Marks include 2 files + 1 directory; directory is skipped, files go into qflist,
+-- and the user-facing notification is elevated to WARN so the skip is visible.
+T["quickfix action sends marked files (directories skipped)"] = function()
+  qf_reset()
+  local ctx, store = make_ctx(nil)
+  store:get(3)._marked = true -- file_a
+  store:get(5)._marked = true -- file_b (under sub_dir)
+  store:get(6)._marked = true -- dir_b (directory, must be skipped)
+  ctx.config.quickfix = { auto_open = false }
+
+  local notify_level
+  local notify_msg
+  local orig_notify = vim.notify
+  vim.notify = function(msg, level)
+    notify_msg = msg
+    notify_level = level
+  end
+  action.dispatch("quickfix", ctx)
+  vim.notify = orig_notify
+
+  local items = vim.fn.getqflist()
+  MiniTest.expect.equality(#items, 2)
+  local names = {
+    vim.api.nvim_buf_get_name(items[1].bufnr),
+    vim.api.nvim_buf_get_name(items[2].bufnr),
+  }
+  table.sort(names)
+  MiniTest.expect.equality(names[1], "/project/dir_a/file_a.lua")
+  MiniTest.expect.equality(names[2], "/project/dir_a/sub_dir/file_b.lua")
+  MiniTest.expect.equality(notify_level, vim.log.levels.WARN)
+  MiniTest.expect.equality(notify_msg, "Quickfix: 2 file(s) (1 dir(s) skipped)")
+  qf_reset()
+end
+
+-- All marked targets are directories: qflist must be left untouched.
+T["quickfix action leaves qflist unchanged when all targets are directories"] = function()
+  qf_reset()
+  vim.fn.setqflist({}, " ", { title = "prior list", items = {} })
+  local ctx, store = make_ctx(nil)
+  store:get(2)._marked = true -- dir_a
+  store:get(6)._marked = true -- dir_b
+  ctx.config.quickfix = { auto_open = false }
+  action.dispatch("quickfix", ctx)
+  MiniTest.expect.equality(vim.fn.getqflist({ title = 0 }).title, "prior list")
+  qf_reset()
+end
+
+-- No marks, no cursor, no visual: notify and noop; qflist unchanged.
+T["quickfix action is no-op on empty target"] = function()
+  qf_reset()
+  vim.fn.setqflist({}, " ", { title = "prior list", items = {} })
+  local ctx = make_ctx(nil) -- no cursor node
+  ctx.config.quickfix = { auto_open = false }
+  action.dispatch("quickfix", ctx)
+  MiniTest.expect.equality(vim.fn.getqflist({ title = 0 }).title, "prior list")
+  qf_reset()
+end
+
+-- Title is set to "eda marks".
+T["quickfix action sets title to 'eda marks'"] = function()
+  qf_reset()
+  local ctx = make_ctx(3)
+  ctx.config.quickfix = { auto_open = false }
+  action.dispatch("quickfix", ctx)
+  MiniTest.expect.equality(vim.fn.getqflist({ title = 0 }).title, "eda marks")
+  qf_reset()
+end
+
+-- auto_open = true opens the quickfix window (observable via winid lookup).
+T["quickfix action opens quickfix window when auto_open is true"] = function()
+  qf_reset()
+  local ctx = make_ctx(3)
+  ctx.config.quickfix = { auto_open = true }
+  action.dispatch("quickfix", ctx)
+  local winid = vim.fn.getqflist({ winid = 0 }).winid
+  MiniTest.expect.equality(winid ~= 0, true)
+  qf_reset()
+end
+
+-- auto_open = false leaves the quickfix window closed.
+T["quickfix action does not open window when auto_open is false"] = function()
+  qf_reset()
+  local ctx = make_ctx(3)
+  ctx.config.quickfix = { auto_open = false }
+  action.dispatch("quickfix", ctx)
+  MiniTest.expect.equality(vim.fn.getqflist({ winid = 0 }).winid, 0)
+  qf_reset()
+end
+
+-- Defensive: malformed user config (`quickfix = false`) must not crash the action.
+T["quickfix action tolerates quickfix config replaced with a non-table"] = function()
+  qf_reset()
+  local ctx = make_ctx(3)
+  ctx.config.quickfix = false -- simulates `setup({ quickfix = false })`
+  action.dispatch("quickfix", ctx)
+  -- qflist still populated, copen suppressed (no crash)
+  MiniTest.expect.equality(#vim.fn.getqflist(), 1)
+  MiniTest.expect.equality(vim.fn.getqflist({ winid = 0 }).winid, 0)
+  qf_reset()
+end
+
+-- Marks are preserved after quickfix dispatch (non-destructive semantics).
+T["quickfix action does not clear marks"] = function()
+  qf_reset()
+  local ctx, store = make_ctx(nil)
+  store:get(3)._marked = true
+  store:get(5)._marked = true
+  ctx.config.quickfix = { auto_open = false }
+  action.dispatch("quickfix", ctx)
+  MiniTest.expect.equality(store:get(3)._marked, true)
+  MiniTest.expect.equality(store:get(5)._marked, true)
+  qf_reset()
+end
+
+-- Helper: stub eda.close and restore it after `fn` runs. Returns the invocation count.
+local function with_eda_close_stub(fn)
+  local eda = require("eda")
+  local orig_close = eda.close
+  local calls = 0
+  eda.close = function()
+    calls = calls + 1
+  end
+  local ok, err = pcall(fn)
+  eda.close = orig_close
+  if not ok then
+    error(err)
+  end
+  return calls
+end
+
+-- Float + auto_open=true: close the float explorer before opening the quickfix
+-- window to prevent the float from visually overlapping the qf split.
+T["quickfix action closes float explorer before opening quickfix"] = function()
+  qf_reset()
+  local ctx = make_ctx(3)
+  ctx.window.kind = "float"
+  ctx.config.quickfix = { auto_open = true }
+  local close_calls = with_eda_close_stub(function()
+    action.dispatch("quickfix", ctx)
+  end)
+  MiniTest.expect.equality(close_calls, 1)
+  MiniTest.expect.equality(vim.fn.getqflist({ winid = 0 }).winid ~= 0, true)
+  qf_reset()
+end
+
+-- Non-float window kinds must NOT auto-close the explorer — split_left/split_right/replace
+-- do not visually overlap the bottom qf split.
+T["quickfix action does not close explorer for non-float window kinds"] = function()
+  for _, kind in ipairs({ "split_left", "split_right", "replace" }) do
+    qf_reset()
+    local ctx = make_ctx(3)
+    ctx.window.kind = kind
+    ctx.config.quickfix = { auto_open = true }
+    local close_calls = with_eda_close_stub(function()
+      action.dispatch("quickfix", ctx)
+    end)
+    MiniTest.expect.equality(close_calls, 0)
+    qf_reset()
+  end
+end
+
+-- Float + auto_open=false: neither close nor :copen should fire.
+T["quickfix action does not close float when auto_open is false"] = function()
+  qf_reset()
+  local ctx = make_ctx(3)
+  ctx.window.kind = "float"
+  ctx.config.quickfix = { auto_open = false }
+  local close_calls = with_eda_close_stub(function()
+    action.dispatch("quickfix", ctx)
+  end)
+  MiniTest.expect.equality(close_calls, 0)
+  MiniTest.expect.equality(vim.fn.getqflist({ winid = 0 }).winid, 0)
+  qf_reset()
 end
 
 return T

--- a/tests/e2e/test_marks.lua
+++ b/tests/e2e/test_marks.lua
@@ -624,4 +624,92 @@ T["marks"]["visual selection takes priority over marks in cut"] = function()
   MiniTest.expect.equality(c_still_marked, true)
 end
 
+T["marks"]["quickfix action sends marked files to qflist and keeps marks"] = function()
+  e2e.stop(child)
+  child = e2e.spawn()
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = false },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      quickfix = { auto_open = false },
+    })
+  ]]
+  )
+
+  e2e.open_eda(child, tmp)
+
+  -- Guard: quickfix action must be registered
+  MiniTest.expect.equality(e2e.exec(child, 'return require("eda.action").get_entry("quickfix") ~= nil'), true)
+
+  -- Mark a.txt and b.txt (m advances the cursor each time)
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {1, 0})")
+  e2e.feed(child, "m")
+  e2e.feed(child, "m")
+
+  e2e.wait_until(
+    child,
+    [[
+    local buf = require("eda").get_current().buffer
+    local count = 0
+    for _, fl in ipairs(buf.flat_lines) do
+      if fl.node._marked then count = count + 1 end
+    end
+    return count == 2
+  ]]
+  )
+
+  -- Reset qflist so the populated-state assertion is unambiguous
+  e2e.exec(child, 'vim.fn.setqflist({}, "f")')
+
+  -- Fire quickfix action via its default keymap
+  e2e.feed(child, "gq")
+
+  -- Wait until qflist has the two marked files
+  e2e.wait_until(child, "return #vim.fn.getqflist() == 2", 5000)
+
+  -- Title check
+  local title = e2e.exec(child, "return vim.fn.getqflist({ title = 0 }).title")
+  MiniTest.expect.equality(title, "eda marks")
+
+  -- Entries include a.txt and b.txt
+  local has_files = e2e.exec(
+    child,
+    [[
+    local items = vim.fn.getqflist()
+    local basenames = {}
+    for _, it in ipairs(items) do
+      local name = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(it.bufnr), ":t")
+      basenames[name] = true
+    end
+    return basenames["a.txt"] and basenames["b.txt"]
+  ]]
+  )
+  MiniTest.expect.equality(has_files, true)
+
+  -- Marks survive (quickfix is non-destructive)
+  local marks_retained = e2e.exec(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local count = 0
+    for _, node in pairs(explorer.store.nodes) do
+      if (node.name == "a.txt" or node.name == "b.txt") and node._marked then
+        count = count + 1
+      end
+    end
+    return count == 2
+  ]]
+  )
+  MiniTest.expect.equality(marks_retained, true)
+
+  -- Quickfix window must stay closed with auto_open = false
+  local qf_winid = e2e.exec(child, "return vim.fn.getqflist({ winid = 0 }).winid")
+  MiniTest.expect.equality(qf_winid, 0)
+end
+
 return T


### PR DESCRIPTION
## Summary

Add a new `quickfix` action that sends marked files (or Visual / cursor targets) to Neovim's quickfix list, following the existing mark-aware action pattern (`cut` / `copy` / `delete` / `duplicate`).

- **Targets**: unified `Visual > marks > cursor` priority via the existing `_get_target_nodes` resolver. Directories are skipped with a WARN-level notification so entries stay `:cfirst`-safe.
- **Non-destructive**: marks are preserved after the action (unlike `cut` / `copy` / `delete`), so iterative workflows (`mark more → gq again`) are supported.
- **Configurable auto-open**: `config.quickfix.auto_open` (default `true`) controls whether `:copen` fires automatically after the list is populated.
- **Float-friendly**: when the explorer is a float (`window.kind = "float"`) and `auto_open` is on, the float is closed just before `:copen` so it no longer overlaps the bottom quickfix split.
- **Blockwise Visual fix**: `_get_target_nodes` now recognises `<C-v>` / `"\22"` alongside `"v"` / `"V"`, so blockwise Visual selections flow through the unified resolution path for all mark-aware actions (previously blockwise fell back to marks/cursor).
- **Default mapping**: `gq`. Opt-out with `mappings = { ["gq"] = false }`.
- **Defensive config handling**: the action tolerates malformed overrides such as `setup({ quickfix = false })` without crashing (the `auto_open` access is guarded by `type(...) == "table"`).

Covered by new unit + E2E tests, docs regenerated via `just doc`.

## References

- n/a
