### PR TITLE
feat: add mark_clear_all action and visual mode mark_toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ require("eda").setup({
     ["gs"] = "toggle_git_changes",   -- Toggle git-changes filter
     ["[c"] = "prev_git_change",      -- Jump to previous git change
     ["]c"] = "next_git_change",      -- Jump to next git change
-    ["m"] = "mark_toggle",           -- Toggle mark on node
+    ["m"] = "mark_toggle",           -- Mark/unmark node (Visual selection or cursor)
+    ["M"] = "mark_clear_all",        -- Clear all marks
     ["D"] = "delete",                -- Delete target nodes (Visual > marks > cursor)
     ["go"] = "system_open",          -- Open with system application
     ["K"] = "inspect",               -- Inspect node data
@@ -376,7 +377,8 @@ Target resolution is unified across `delete` / `cut` / `copy` / `duplicate`: **V
 
 | Action | Description |
 | --- | --- |
-| `mark_toggle` | Toggle mark on the current node and move cursor down |
+| `mark_toggle` | Mark/unmark target node(s). Normal mode toggles the cursor node and advances; Visual mode toggles each selected node |
+| `mark_clear_all` | Clear all marks across the tree |
 | `delete` | Delete target nodes (routes through `confirm.delete` dialog) |
 | `cut` | Move target paths into the register; `paste` later moves them |
 | `copy` | Copy target paths into the register; `paste` later duplicates them |

--- a/doc/eda.md
+++ b/doc/eda.md
@@ -633,7 +633,8 @@ configuration option.
 | `gs`    | toggle_git_changes | Toggle git-changes filter     |
 | `[c`    | prev_git_change    | Jump to previous git change   |
 | `]c`    | next_git_change    | Jump to next git change       |
-| `m`     | mark_toggle        | Mark/unmark node              |
+| `m`     | mark_toggle        | Mark/unmark node (Visual selection or cursor) |
+| `M`     | mark_clear_all     | Clear all marks               |
 | `D`     | delete             | Delete target nodes (Visual > marks > cursor) |
 | `go`    | system_open        | Open with system default app  |
 | `K`     | inspect            | Print node details            |
@@ -709,7 +710,11 @@ success (partial failures keep the marks for the failed/unattempted entries).
   (default); when the explorer is a float, the float is closed first so
   it does not overlap the quickfix split. Replaces the current list; use
   `:colder` / `:cnewer` to navigate the quickfix history.
-- **mark_toggle** — Toggle mark on the current node and move cursor down.
+- **mark_toggle** — Mark/unmark target node(s). In Normal mode toggles the
+  node under the cursor and moves the cursor down. In Visual mode toggles
+  each node in the selection independently (no cursor advance).
+- **mark_clear_all** — Clear all marks across the tree. No-op when no nodes
+  are marked.
 
 > **Note:** `mark_bulk_delete` and `mark_bulk_move` were removed in favour of
 > the unified `delete` and the cut-paste flow. To move marked files to a new

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -683,7 +683,10 @@ configuration option.
 
   ]c              next_git_change         Jump to next git change
 
-  m               mark_toggle             Mark/unmark node
+  m               mark_toggle             Mark/unmark node (Visual selection
+                                          or cursor)
+
+  M               mark_clear_all          Clear all marks
 
   D               delete                  Delete target nodes (Visual >
                                           marks > cursor)
@@ -783,7 +786,11 @@ success (partial failures keep the marks for the failed/unattempted entries).
     (default); when the explorer is a float, the float is closed first so
     it does not overlap the quickfix split. Replaces the current list; use
     `:colder` / `:cnewer` to navigate the quickfix history.
-- **mark_toggle** — Toggle mark on the current node and move cursor down.
+- **mark_toggle** — Mark/unmark target node(s). In Normal mode toggles the
+    node under the cursor and moves the cursor down. In Visual mode toggles
+    each node in the selection independently (no cursor advance).
+- **mark_clear_all** — Clear all marks across the tree. No-op when no nodes
+    are marked.
 
 
   **Note:** `mark_bulk_delete` and `mark_bulk_move` were removed in favour of the

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -621,6 +621,26 @@ action.register("collapse_recursive", function(ctx)
 end, { desc = "Collapse directory recursively" })
 
 action.register("mark_toggle", function(ctx)
+  -- M._get_visual_targets is used (not local get_visual_targets) because it is defined
+  -- later in the file; module-field lookup is deferred until call time. Same pattern as
+  -- M._get_target_nodes in delete/duplicate actions.
+  local visual = M._get_visual_targets(ctx)
+  if visual then
+    if #visual == 0 then
+      return
+    end
+    for _, node in ipairs(visual) do
+      -- Toggle between nil and true (avoids `false` intermediate state from `not`).
+      if node._marked then
+        node._marked = nil
+      else
+        node._marked = true
+      end
+    end
+    refresh(ctx)
+    return
+  end
+  -- Normal mode: single-node toggle + cursor advance for repeat-press UX.
   local node = ctx.buffer:get_cursor_node(ctx.window.winid)
   if not node then
     return
@@ -639,7 +659,7 @@ action.register("mark_toggle", function(ctx)
   if cursor[1] < line_count then
     vim.api.nvim_win_set_cursor(ctx.window.winid, { cursor[1] + 1, cursor[2] })
   end
-end, { desc = "Toggle mark on node" })
+end, { desc = "Mark/unmark node (Visual selection or cursor)" })
 
 --- Delete action: unified mark-aware deletion.
 --- Targets are resolved with priority Visual > marks > cursor via _get_target_nodes.
@@ -784,6 +804,22 @@ local function clear_marks(store)
 end
 
 M._clear_marks = clear_marks
+
+action.register("mark_clear_all", function(ctx)
+  -- Single-pass scan: count and clear in the same loop to avoid the two-pass
+  -- "probe then clear" pattern. Refresh is skipped when no marks existed so
+  -- the painter does not redraw for a no-op press.
+  local count = 0
+  for _, node in pairs(ctx.store.nodes) do
+    if node._marked then
+      node._marked = nil
+      count = count + 1
+    end
+  end
+  if count > 0 then
+    refresh(ctx)
+  end
+end, { desc = "Clear all marks" })
 
 --- Duplicate action: unified mark-aware duplication.
 --- Targets are resolved with priority Visual > marks > cursor via _get_target_nodes.
@@ -934,31 +970,46 @@ end, { desc = "Inspect node data" })
 ---@field nodes eda.TreeNode[]
 ---@field origin "visual"|"marks"|"cursor"|"empty"
 
+--- Return nodes under the current Visual selection, or nil when not in Visual mode.
+--- Exits Visual via <Esc> feedkeys so `'<` / `'>` are populated, matching the existing
+--- target-resolution contract used by delete/cut/copy/duplicate/quickfix.
+--- "\22" is <C-v> (blockwise Visual); all three Visual submodes are treated uniformly
+--- because eda is a read-only tree where column-level selection carries no meaning.
+---@param ctx eda.ActionContext
+---@return eda.TreeNode[]|nil
+local function get_visual_targets(ctx)
+  local mode = vim.fn.mode()
+  if mode ~= "v" and mode ~= "V" and mode ~= "\22" then
+    return nil
+  end
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "x", false)
+  local start_line = vim.fn.line("'<")
+  local end_line = vim.fn.line("'>")
+  local header_lines = ctx.buffer.painter.header_lines or 0
+  local nodes = {}
+  for line = start_line, end_line do
+    local fl = ctx.buffer.flat_lines[line - header_lines]
+    if fl then
+      local node = ctx.store:get(fl.node_id)
+      if node and node.id ~= ctx.store.root_id then
+        table.insert(nodes, node)
+      end
+    end
+  end
+  return nodes
+end
+
+M._get_visual_targets = get_visual_targets
+
 --- Resolve the target node set for mark-aware actions (cut/copy/delete/duplicate).
 --- Priority: Visual selection > marked nodes > cursor node. Root is always excluded.
 --- Returns origin info so callers can decide whether to clear marks post-operation.
 ---@param ctx eda.ActionContext
 ---@return eda.TargetNodes
 local function get_target_nodes(ctx)
-  local mode = vim.fn.mode()
-  -- "\22" is <C-v> (blockwise Visual). Treat all three Visual submodes uniformly
-  -- so the Visual > marks > cursor contract holds regardless of how the user entered Visual.
-  if mode == "v" or mode == "V" or mode == "\22" then
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "x", false)
-    local start_line = vim.fn.line("'<")
-    local end_line = vim.fn.line("'>")
-    local header_lines = ctx.buffer.painter.header_lines or 0
-    local nodes = {}
-    for line = start_line, end_line do
-      local fl = ctx.buffer.flat_lines[line - header_lines]
-      if fl then
-        local node = ctx.store:get(fl.node_id)
-        if node and node.id ~= ctx.store.root_id then
-          table.insert(nodes, node)
-        end
-      end
-    end
-    return { nodes = nodes, origin = "visual" }
+  local visual = get_visual_targets(ctx)
+  if visual then
+    return { nodes = visual, origin = "visual" }
   end
 
   local marked = {}

--- a/lua/eda/buffer/init.lua
+++ b/lua/eda/buffer/init.lua
@@ -224,6 +224,7 @@ local visual_mode_actions = {
   cut = true,
   copy = true,
   quickfix = true,
+  mark_toggle = true,
 }
 
 ---Set keymaps on the buffer.

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -235,6 +235,7 @@ local defaults = {
     ["[c"] = "prev_git_change",
     ["]c"] = "next_git_change",
     ["m"] = "mark_toggle",
+    ["M"] = "mark_clear_all",
     ["D"] = "delete",
     ["go"] = "system_open",
     ["K"] = "inspect",

--- a/tests/action/test_builtin.lua
+++ b/tests/action/test_builtin.lua
@@ -808,4 +808,58 @@ T["quickfix action does not close float when auto_open is false"] = function()
   qf_reset()
 end
 
+-- ===============================================================
+-- _get_visual_targets (extracted from _get_target_nodes) + mark_clear_all
+-- ===============================================================
+
+local get_visual = builtin._get_visual_targets
+
+T["_get_visual_targets: returns nil outside Visual mode"] = function()
+  local ctx = make_target_ctx(nil)
+  -- Default vim.fn.mode() returns "n" in headless tests
+  local result = get_visual(ctx)
+  MiniTest.expect.equality(result, nil)
+end
+
+T["_get_visual_targets: returns visual range nodes (root excluded)"] = function()
+  local ctx = make_target_ctx(nil)
+  ctx.buffer.flat_lines = {
+    { node_id = 1 }, -- root
+    { node_id = 2 },
+    { node_id = 3 },
+  }
+  local result
+  with_visual_range("V", 1, 3, function()
+    result = get_visual(ctx)
+  end)
+  MiniTest.expect.equality(#result, 2)
+  MiniTest.expect.equality(result[1].id, 2)
+  MiniTest.expect.equality(result[2].id, 3)
+end
+
+T["mark_clear_all: clears all _marked to nil"] = function()
+  local ctx, store = make_target_ctx(nil)
+  store:get(3)._marked = true
+  store:get(5)._marked = true
+  store:get(6)._marked = true
+
+  action.dispatch("mark_clear_all", ctx)
+
+  MiniTest.expect.equality(store:get(3)._marked, nil)
+  MiniTest.expect.equality(store:get(5)._marked, nil)
+  MiniTest.expect.equality(store:get(6)._marked, nil)
+  -- refresh must run when at least one mark was cleared
+  MiniTest.expect.equality(ctx._render_called(), true)
+end
+
+T["mark_clear_all: no-op (no refresh) when no marks exist"] = function()
+  local ctx, store = make_target_ctx(nil)
+  -- No _marked set on any node
+  action.dispatch("mark_clear_all", ctx)
+  -- Store state unchanged
+  MiniTest.expect.equality(store:get(3)._marked, nil)
+  -- refresh must be skipped to avoid a pointless repaint
+  MiniTest.expect.equality(ctx._render_called(), false)
+end
+
 return T

--- a/tests/e2e/test_marks.lua
+++ b/tests/e2e/test_marks.lua
@@ -624,6 +624,162 @@ T["marks"]["visual selection takes priority over marks in cut"] = function()
   MiniTest.expect.equality(c_still_marked, true)
 end
 
+-- ===============================================================
+-- Visual mode mark_toggle + mark_clear_all
+-- ===============================================================
+
+T["marks"]["visual mark_toggle marks all nodes in selection when none marked"] = function()
+  e2e.open_eda(child, tmp)
+
+  -- Select a.txt (line 1), b.txt (line 2), c.txt (line 3) with Visual-line
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {1, 0})")
+  e2e.feed(child, "Vjj")
+  e2e.wait_until(child, 'return vim.fn.mode() == "V"')
+
+  -- Toggle mark on the whole selection
+  e2e.feed(child, "m")
+
+  -- All 3 files should be marked after one `m` press
+  e2e.wait_until(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local count = 0
+    for _, node in pairs(explorer.store.nodes) do
+      if node._marked then count = count + 1 end
+    end
+    return count == 3
+  ]]
+  )
+
+  local final_count = e2e.exec(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local count = 0
+    for _, node in pairs(explorer.store.nodes) do
+      if node._marked then count = count + 1 end
+    end
+    return count
+  ]]
+  )
+  MiniTest.expect.equality(final_count, 3)
+end
+
+T["marks"]["visual mark_toggle inverts mixed state per-node"] = function()
+  e2e.open_eda(child, tmp)
+
+  -- Pre-mark b.txt (line 2) so the Visual selection contains a mixed state
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {2, 0})")
+  e2e.feed(child, "m")
+  e2e.wait_until(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    for _, node in pairs(explorer.store.nodes) do
+      if node.name == "b.txt" and node._marked then return true end
+    end
+    return false
+  ]]
+  )
+
+  -- Visual-line select all 3 files (a.txt, b.txt, c.txt)
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {1, 0})")
+  e2e.feed(child, "Vjj")
+  e2e.wait_until(child, 'return vim.fn.mode() == "V"')
+  e2e.feed(child, "m")
+
+  -- Expect: a.txt = true, b.txt = nil (was true, flipped), c.txt = true
+  e2e.wait_until(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local by_name = {}
+    for _, node in pairs(explorer.store.nodes) do
+      by_name[node.name] = node._marked
+    end
+    return by_name["a.txt"] == true and by_name["b.txt"] == nil and by_name["c.txt"] == true
+  ]]
+  )
+
+  local state = e2e.exec(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local by_name = {}
+    for _, node in pairs(explorer.store.nodes) do
+      by_name[node.name] = node._marked
+    end
+    return {
+      a = by_name["a.txt"],
+      b = by_name["b.txt"],
+      c = by_name["c.txt"],
+    }
+  ]]
+  )
+  MiniTest.expect.equality(state.a, true)
+  MiniTest.expect.equality(state.b, nil)
+  MiniTest.expect.equality(state.c, true)
+end
+
+T["marks"]["mark_clear_all clears all marks"] = function()
+  e2e.open_eda(child, tmp)
+  mark_first_three(child)
+
+  -- Trigger mark_clear_all via the default `M` keymap
+  e2e.feed(child, "M")
+
+  e2e.wait_until(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local count = 0
+    for _, node in pairs(explorer.store.nodes) do
+      if node._marked then count = count + 1 end
+    end
+    return count == 0
+  ]]
+  )
+
+  local final_count = e2e.exec(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local count = 0
+    for _, node in pairs(explorer.store.nodes) do
+      if node._marked then count = count + 1 end
+    end
+    return count
+  ]]
+  )
+  MiniTest.expect.equality(final_count, 0)
+end
+
+T["marks"]["mark_clear_all is no-op when no marks exist"] = function()
+  e2e.open_eda(child, tmp)
+
+  -- No marks initially; `M` should neither error nor mutate state
+  e2e.feed(child, "M")
+
+  -- Confirm state remains unmarked (nothing to clear)
+  local count = e2e.exec(
+    child,
+    [[
+    local explorer = require("eda").get_current()
+    local n = 0
+    for _, node in pairs(explorer.store.nodes) do
+      if node._marked then n = n + 1 end
+    end
+    return n
+  ]]
+  )
+  MiniTest.expect.equality(count, 0)
+
+  -- Buffer must still be the eda explorer (no crash / no filetype switch)
+  local ft = e2e.exec(child, "return vim.bo.filetype")
+  MiniTest.expect.equality(ft, "eda")
+end
+
 T["marks"]["quickfix action sends marked files to qflist and keeps marks"] = function()
   e2e.stop(child)
   child = e2e.spawn()


### PR DESCRIPTION
## Summary

Fills two gaps in the mark feature:

1. **Bulk clear**: new `mark_clear_all` action (default keymap `M`) clears every `_marked` flag across the tree. No-op (and no repaint) when nothing is marked.
2. **Visual-mode `mark_toggle`**: pressing `m` in Visual mode now toggles each node in the selection independently (per-node `nil ↔ true`), instead of operating only on the cursor node.

Internally, the Visual branch of `_get_target_nodes` was extracted into a shared helper `get_visual_targets` (exported as `M._get_visual_targets` so `mark_toggle` can deferred-lookup the same way existing `delete`/`duplicate` use `M._get_target_nodes`). Behavior of `delete` / `cut` / `copy` / `duplicate` / `quickfix` is preserved — the existing `visual > marks priority` E2E continues to pass as the regression guard.

### Changes

- `lua/eda/action/builtin.lua` — extract `get_visual_targets`, wire `mark_toggle` visual branch, register `mark_clear_all`
- `lua/eda/buffer/init.lua` — add `mark_toggle` to `visual_mode_actions` whitelist so Visual keypress dispatches the action
- `lua/eda/config.lua` — default mapping `["M"] = "mark_clear_all"`
- `README.md` / `doc/eda.md` / `doc/eda.nvim.txt` — documentation updates (panvimdoc regenerated)
- `tests/action/test_builtin.lua` — 4 new unit tests (`_get_visual_targets` nil/visual-range, `mark_clear_all` clear/no-op with refresh-tracking)
- `tests/e2e/test_marks.lua` — 4 new E2E tests (visual mark_toggle all-unmarked / mixed-state, `mark_clear_all` clear / no-op)

### Verification

- `just format-check` / `just lint` / `just typecheck` — all exit 0
- `just test` — 519 cases, 0 fails (includes 4 new unit tests)
- `just test-e2e` — 133 cases, 0 fails (includes 4 new E2E tests)
- `just doc` — vimdoc regenerated and committed

## References

- n/a
