### PR TITLE
feat: async directory size calculation in inspect float

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -90,6 +90,13 @@ require("eda").setup({
     enabled = true,
   },
 
+  inspect = {
+    dir_size = {
+      enabled = true,
+      cache_ttl_ms = 30000,
+    },
+  },
+
   mark = {
     icon = "󰄲",        -- nf-md-checkbox_marked (U+F0132)
   },
@@ -450,6 +457,33 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
   in a narrow window. The popup displays the full line content (indent, icon,
   filename, and suffixes) with identical highlights.
 
+### inspect
+
+`table`
+
+- `dir_size` `table` — Async directory size calculation shown by the `inspect`
+  action. When a directory node is inspected, a background recursive walk
+  computes the total byte count without blocking the UI, and an animated
+  spinner is shown in the `Size` field until the walk completes. Results are
+  cached per path for `cache_ttl_ms` and reused when sticky-mode cursor moves
+  re-visit the same directory within TTL. Cursor moves do NOT cancel in-flight
+  walks; they run to completion and populate the cache. Closing the float
+  stops the spinner UI but lets the walk complete in the background.
+  There is no entry-count cap and no per-walk timeout: very large trees may
+  take a long time to resolve.
+  - `enabled` `boolean` (default: `true`) — Disable to restore the legacy
+    placeholder (`Size -`) with no async walk.
+  - `cache_ttl_ms` `integer` (default: `30000`) — Cache lifetime in
+    milliseconds. Raising this extends reuse across sticky-mode browsing at
+    the cost of freshness after filesystem changes.
+
+  Example display while a walk is in progress (the spinner cycles through
+  10 Braille frames at 100 ms per step):
+
+  ```
+  Size          ⠋ calculating...
+  ```
+
 ### mark
 
 `table`
@@ -769,7 +803,10 @@ success (partial failures keep the marks for the failed/unattempted entries).
   re-pressing the key. Pressing `<leader>i` again toggles the float
   closed. Leaving the explorer buffer closes the float as well, except
   when you deliberately focus the float via `<C-w>w` (in which case
-  `q` / `<Esc>` close it).
+  `q` / `<Esc>` close it). Directory size is resolved asynchronously
+  (see `inspect.dir_size`); an animated spinner appears in the `Size`
+  field until the walk completes, and the result is cached briefly
+  for sticky re-visits.
   Default mapping: `<leader>i`
 - **help** — Show keybinding help in a floating window.
 - **split** — Open a new explorer split pane with the same root.
@@ -1053,6 +1090,7 @@ keep their user-provided attributes untouched (same as git suffix icons).
 | `EdaInspectValue`      | `Normal`          | Row value (main portion)                          |
 | `EdaInspectValueMuted` | `Comment`         | Muted secondary value (e.g. `(1,024 bytes)`, `(~3 hours)`, symlink target path) |
 | `EdaInspectError`      | `DiagnosticError` | Error value (e.g. `(stat failed)`, broken symlink) |
+| `EdaInspectSpinner`    | `Comment`         | Animated spinner frame in the `Size` row while an async directory-size walk is running |
 
 ### Full Name Popup
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -109,6 +109,13 @@ DEFAULT CONFIGURATION ~
         enabled = true,
       },
     
+      inspect = {
+        dir_size = {
+          enabled = true,
+          cache_ttl_ms = 30000,
+        },
+      },
+    
       mark = {
         icon = "󰄲",        -- nf-md-checkbox_marked (U+F0132)
       },
@@ -468,6 +475,31 @@ FULL_NAME ~
     Show a floating window overlaying the cursor line when a filename is truncated
     in a narrow window. The popup displays the full line content (indent, icon,
     filename, and suffixes) with identical highlights.
+
+
+INSPECT ~
+
+`table`
+
+- `dir_size` `table` — Async directory size calculation shown by the `inspect`
+    action. When a directory node is inspected, a background recursive walk
+    computes the total byte count without blocking the UI, and an animated spinner
+    is shown in the `Size` field until the walk completes. Results are cached per
+    path for `cache_ttl_ms` and reused when sticky-mode cursor moves re-visit the
+    same directory within TTL. Cursor moves do NOT cancel in-flight walks; they run
+    to completion and populate the cache. Closing the float stops the spinner UI
+    but lets the walk complete in the background. There is no entry-count cap and
+    no per-walk timeout: very large trees may take a long time to resolve.
+    - `enabled` `boolean` (default: `true`) — Disable to restore the legacy
+        placeholder (`Size -`) with no async walk.
+    - `cache_ttl_ms` `integer` (default: `30000`) — Cache lifetime in
+        milliseconds. Raising this extends reuse across sticky-mode browsing at
+        the cost of freshness after filesystem changes.
+    Example display while a walk is in progress (the spinner cycles through 10
+    Braille frames at 100 ms per step):
+    >
+        Size          ⠋ calculating...
+    <
 
 
 MARK ~
@@ -848,7 +880,10 @@ MISC ~
     re-pressing the key. Pressing `<leader>i` again toggles the float
     closed. Leaving the explorer buffer closes the float as well, except
     when you deliberately focus the float via `<C-w>w` (in which case
-    `q` / `<Esc>` close it).
+    `q` / `<Esc>` close it). Directory size is resolved asynchronously
+    (see `inspect.dir_size`); an animated spinner appears in the `Size`
+    field until the walk completes, and the result is cached briefly
+    for sticky re-visits.
     Default mapping: `<leader>i`
 - **help** — Show keybinding help in a floating window.
 - **split** — Open a new explorer split pane with the same root.
@@ -1240,6 +1275,10 @@ INSPECT FLOAT ~
 
   EdaInspectError        DiagnosticError   Error value (e.g. (stat failed),
                                            broken symlink)
+
+  EdaInspectSpinner      Comment           Animated spinner frame in the Size row
+                                           while an async directory-size walk is
+                                           running
   -------------------------------------------------------------------------------
 
 FULL NAME POPUP ~

--- a/lua/eda/buffer/dir_size.lua
+++ b/lua/eda/buffer/dir_size.lua
@@ -1,0 +1,149 @@
+---Async recursive directory-size calculator with TTL cache.
+---
+---Contract:
+---  Dedup: concurrent ensure(path) calls while a walk is in-flight do not
+---  launch a second walk. No-cancel: an in-flight walk always runs to
+---  completion (M._clear_cache does not interrupt it). Callback-less: ensure
+---  returns a snapshot of current state; callers poll on their own schedule.
+---
+---Symlink handling: entries reported by fs_readdir with type "link" are
+---counted using their own lstat size and the link target is NOT followed.
+---This prevents cycles and double-counting of reachable content.
+
+local M = {}
+
+---@class eda.DirSizeEntry
+---@field bytes integer
+---@field computed_at_ms integer
+
+local _defaults = { cache_ttl_ms = 30000 }
+local _config = vim.deepcopy(_defaults)
+local _cache = {} ---@type table<string, eda.DirSizeEntry>
+local _active = {} ---@type table<string, true>
+
+---@param opts { cache_ttl_ms?: integer }?
+function M.setup(opts)
+  _config = vim.tbl_extend("force", vim.deepcopy(_defaults), opts or {})
+end
+
+---Test-only accessor for the current resolved config snapshot.
+---@return { cache_ttl_ms: integer }
+function M._get_config()
+  return _config
+end
+
+---True iff at least one walk is currently in-flight.
+---@return boolean
+function M.is_computing()
+  return next(_active) ~= nil
+end
+
+---Drop all cached entries. In-flight walks continue and will repopulate.
+---Exposed with a leading underscore to signal test-only / debug usage.
+function M._clear_cache()
+  _cache = {}
+end
+
+---Start an async walk for `path`. Exposed as a module field so tests can
+---monkey-patch it for call-count assertions (see test_dir_size.lua).
+---@param path string
+function M._start_walk(path)
+  local state = { bytes = 0, in_flight = 0 }
+  local root_errored = false
+
+  local process_dir
+  local descend_nested
+
+  local function try_finish()
+    if state.in_flight ~= 0 then
+      return
+    end
+    if not root_errored then
+      _cache[path] = { bytes = state.bytes, computed_at_ms = vim.uv.now() }
+    end
+    _active[path] = nil
+  end
+
+  process_dir = function(p, dir)
+    local function read_batch()
+      vim.uv.fs_readdir(dir, function(read_err, ents)
+        if read_err or not ents then
+          vim.uv.fs_closedir(dir, function()
+            vim.schedule(function()
+              state.in_flight = state.in_flight - 1
+              try_finish()
+            end)
+          end)
+          return
+        end
+        for _, ent in ipairs(ents) do
+          local child = p .. "/" .. ent.name
+          if ent.type == "directory" then
+            descend_nested(child)
+          else
+            state.in_flight = state.in_flight + 1
+            vim.uv.fs_lstat(child, function(_, stat)
+              vim.schedule(function()
+                if stat and stat.size then
+                  state.bytes = state.bytes + stat.size
+                end
+                state.in_flight = state.in_flight - 1
+                try_finish()
+              end)
+            end)
+          end
+        end
+        read_batch()
+      end)
+    end
+    read_batch()
+  end
+
+  descend_nested = function(p)
+    state.in_flight = state.in_flight + 1
+    vim.uv.fs_opendir(p, function(err, dir)
+      if err or not dir then
+        -- Nested error: skip this subtree, continue parent walk.
+        vim.schedule(function()
+          state.in_flight = state.in_flight - 1
+          try_finish()
+        end)
+        return
+      end
+      process_dir(p, dir)
+    end, 64)
+  end
+
+  -- Root
+  state.in_flight = state.in_flight + 1
+  vim.uv.fs_opendir(path, function(err, dir)
+    if err or not dir then
+      vim.schedule(function()
+        root_errored = true
+        state.in_flight = state.in_flight - 1
+        try_finish()
+      end)
+      return
+    end
+    process_dir(path, dir)
+  end, 64)
+end
+
+---Snapshot current state for `path`. Starts a walk if cache miss and no
+---in-flight walk for the same path.
+---@param path string absolute path
+---@return { state: "cached"|"computing", bytes: integer? }
+function M.ensure(path)
+  local c = _cache[path]
+  if c and (vim.uv.now() - c.computed_at_ms) < _config.cache_ttl_ms then
+    return { state = "cached", bytes = c.bytes }
+  end
+  if _active[path] then
+    return { state = "computing" }
+  end
+  _active[path] = true
+  M._start_walk(path)
+  return { state = "computing" }
+end
+
+return M

--- a/lua/eda/buffer/inspect.lua
+++ b/lua/eda/buffer/inspect.lua
@@ -6,11 +6,24 @@ local M = {}
 ---@field winid integer
 ---@field bufnr integer
 ---@field node_path string
+---@field node eda.TreeNode cached for spinner-tick re-render
+---@field ctx table? cached for spinner-tick re-render
+---@field lstat table? cached fs_lstat result (spinner tick reuses this)
+---@field target_stat table? cached fs_stat for symlink targets
+---@field dir_count table? cached scan_direct_children result
 
 ---@type eda.InspectState?
 local _state = nil
 
 local _ns_hl = vim.api.nvim_create_namespace("eda_inspect_hl")
+
+-- Braille spinner frames rendered in the Size field while an async directory
+-- size walk is in progress. Plain BMP characters (U+2800-U+28FF) so panvimdoc
+-- and fixed-width renderers handle them correctly.
+local _SPINNER_FRAMES = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
+local _SPINNER_INTERVAL_MS = 100
+local _spinner_timer = nil
+local _spinner_frame = 1
 
 -- ========== Pure helpers ==========
 
@@ -233,8 +246,10 @@ end
 ---@param dir_count table? scan_direct_children result (directories only)
 ---@param root_path string?
 ---@param now integer? epoch seconds for relative-time rendering (default: os.time())
+---@param dir_size_info { state: "cached"|"computing", bytes: integer? }? optional directory size snapshot
+---@param spinner_frame integer? 1-based index into `_SPINNER_FRAMES` (default: 1)
 ---@return eda.InspectBuild
-local function build_lines(node, lstat, target_stat, dir_count, root_path, now)
+local function build_lines(node, lstat, target_stat, dir_count, root_path, now, dir_size_info, spinner_frame)
   now = now or os.time()
   local lines = {}
   local extmarks = {}
@@ -281,7 +296,15 @@ local function build_lines(node, lstat, target_stat, dir_count, root_path, now)
   push_kv("Path", format_relative_path(node.path, root_path))
   push_kv("Type", format_type(node))
   if node.type == "directory" then
-    push_kv("Size", "-")
+    if dir_size_info and dir_size_info.state == "cached" then
+      local size_main, size_muted = format_size(dir_size_info.bytes)
+      push_kv("Size", size_main, size_muted)
+    elseif dir_size_info and dir_size_info.state == "computing" then
+      local frame = _SPINNER_FRAMES[spinner_frame or 1] or _SPINNER_FRAMES[1]
+      push_kv("Size", frame .. " calculating...", nil, "EdaInspectSpinner")
+    else
+      push_kv("Size", "-")
+    end
   else
     local size_main, size_muted = format_size(lstat.size)
     push_kv("Size", size_main, size_muted)
@@ -407,31 +430,66 @@ function M.is_visible()
   return _state ~= nil and vim.api.nvim_win_is_valid(_state.winid)
 end
 
+local function _stop_spinner_timer()
+  if _spinner_timer then
+    _spinner_timer:stop()
+    _spinner_timer:close()
+    _spinner_timer = nil
+  end
+end
+
 ---Close the inspect float (no-op if not visible).
 function M.close()
+  _stop_spinner_timer()
   if _state and util.is_valid_win(_state.winid) then
     vim.api.nvim_win_close(_state.winid, true)
   end
   _state = nil
 end
 
+---@class eda.InspectMeta
+---@field lstat table?
+---@field target_stat table?
+---@field dir_count table?
+---@field dir_size_info { state: "cached"|"computing", bytes: integer? }?
+
 ---Build the content for a node: stat + extra + rendered lines/extmarks.
+---Optionally reuse cached fs results (spinner tick path) to avoid synchronous IO.
 ---@param ctx table?
 ---@param node eda.TreeNode
----@return eda.InspectBuild
-local function build_for_node(ctx, node)
-  ---@diagnostic disable-next-line: param-type-mismatch
-  local lstat = vim.uv.fs_lstat(node.path)
-  local target_stat = lstat
-  if node.type == "link" and not node.link_broken then
-    target_stat = vim.uv.fs_stat(node.path)
+---@param opts { cached_lstat: table?, cached_target_stat: table?, cached_dir_count: table? }?
+---@return eda.InspectBuild build
+---@return eda.InspectMeta meta
+local function build_for_node(ctx, node, opts)
+  opts = opts or {}
+  local lstat = opts.cached_lstat
+  if lstat == nil then
+    ---@diagnostic disable-next-line: param-type-mismatch
+    lstat = vim.uv.fs_lstat(node.path)
   end
-  local dir_count = nil
-  if node.type == "directory" then
+  local target_stat = opts.cached_target_stat
+  if target_stat == nil then
+    target_stat = lstat
+    if node.type == "link" and not node.link_broken then
+      target_stat = vim.uv.fs_stat(node.path)
+    end
+  end
+  local dir_count = opts.cached_dir_count
+  if dir_count == nil and node.type == "directory" then
     dir_count = scan_direct_children(node.path)
   end
+
+  local dir_size_info
+  if node.type == "directory" then
+    local cfg = require("eda.config").get()
+    if cfg and cfg.inspect and cfg.inspect.dir_size and cfg.inspect.dir_size.enabled then
+      dir_size_info = require("eda.buffer.dir_size").ensure(node.path)
+    end
+  end
+
   local root_path = root_path_from_ctx(ctx)
-  return build_lines(node, lstat, target_stat, dir_count, root_path)
+  local build = build_lines(node, lstat, target_stat, dir_count, root_path, nil, dir_size_info, _spinner_frame)
+  return build, { lstat = lstat, target_stat = target_stat, dir_count = dir_count, dir_size_info = dir_size_info }
 end
 
 ---Current editor layout context (for compute_inspect_layout).
@@ -445,13 +503,15 @@ local function current_editor_ctx()
   }
 end
 
+local _ensure_spinner_timer -- forward declared; definition below _spinner_tick.
+
 ---Open an inspect float for the given node.
 ---@param ctx table?
 ---@param node eda.TreeNode
 function M.show(ctx, node)
   M.close()
 
-  local build = build_for_node(ctx, node)
+  local build, meta = build_for_node(ctx, node)
   local layout = compute_inspect_layout(build, current_editor_ctx())
 
   local buf = vim.api.nvim_create_buf(false, true)
@@ -473,12 +533,21 @@ function M.show(ctx, node)
     winid = win,
     bufnr = buf,
     node_path = node.path,
+    node = node,
+    ctx = ctx,
+    lstat = meta.lstat,
+    target_stat = meta.target_stat,
+    dir_count = meta.dir_count,
   }
 
   local map_opts = { buffer = buf, nowait = true, silent = true }
   vim.keymap.set("n", "q", M.close, map_opts)
   vim.keymap.set("n", "<Esc>", M.close, map_opts)
   vim.keymap.set("n", "<leader>i", M.close, map_opts)
+
+  if meta.dir_size_info and meta.dir_size_info.state == "computing" then
+    _ensure_spinner_timer()
+  end
 end
 
 ---Update the currently-open inspect float for a new node. No-op if hidden;
@@ -494,7 +563,7 @@ function M.update(ctx, node)
     return
   end
   ---@cast _state eda.InspectState
-  local build = build_for_node(ctx, node)
+  local build, meta = build_for_node(ctx, node)
   local layout = compute_inspect_layout(build, current_editor_ctx())
 
   vim.bo[_state.bufnr].modifiable = true
@@ -503,12 +572,67 @@ function M.update(ctx, node)
   apply_extmarks(_state.bufnr, build.extmarks)
 
   _state.node_path = node.path
+  _state.node = node
+  _state.ctx = ctx
+  _state.lstat = meta.lstat
+  _state.target_stat = meta.target_stat
+  _state.dir_count = meta.dir_count
 
   if layout.width < 10 or layout.height < 3 then
     M.close()
     return
   end
   vim.api.nvim_win_set_config(_state.winid, layout)
+
+  if meta.dir_size_info and meta.dir_size_info.state == "computing" then
+    _ensure_spinner_timer()
+  end
+end
+
+---Re-render the inspect float using cached meta from `_state` (no fresh IO).
+---Used by the spinner tick to advance the frame or render final size when the
+---async walk completes.
+function M._render_with_cached_meta()
+  if not M.is_visible() or not _state or not _state.node then
+    return
+  end
+  ---@cast _state eda.InspectState
+  local build = build_for_node(_state.ctx, _state.node, {
+    cached_lstat = _state.lstat,
+    cached_target_stat = _state.target_stat,
+    cached_dir_count = _state.dir_count,
+  })
+  vim.bo[_state.bufnr].modifiable = true
+  vim.api.nvim_buf_set_lines(_state.bufnr, 0, -1, false, build.lines)
+  vim.bo[_state.bufnr].modifiable = false
+  apply_extmarks(_state.bufnr, build.extmarks)
+end
+
+---Advance the spinner frame and re-render. Stops the timer when there is no
+---directory still computing for the currently-shown node.
+---Exposed for unit tests.
+function M._spinner_tick()
+  _spinner_frame = (_spinner_frame % #_SPINNER_FRAMES) + 1
+
+  if not M.is_visible() or not _state or not _state.node or _state.node.type ~= "directory" then
+    _stop_spinner_timer()
+    return
+  end
+
+  local info = require("eda.buffer.dir_size").ensure(_state.node_path)
+  M._render_with_cached_meta()
+  if info.state ~= "computing" then
+    _stop_spinner_timer()
+  end
+end
+
+_ensure_spinner_timer = function()
+  if _spinner_timer then
+    return
+  end
+  local timer = assert(vim.uv.new_timer(), "failed to create spinner timer")
+  _spinner_timer = timer
+  timer:start(_SPINNER_INTERVAL_MS, _SPINNER_INTERVAL_MS, vim.schedule_wrap(M._spinner_tick))
 end
 
 ---Toggle the inspect float for a node (close if visible, else show).
@@ -550,5 +674,18 @@ M._format_relative_time = format_relative_time
 M._build_lines = build_lines
 M._scan_direct_children = scan_direct_children
 M._compute_inspect_layout = compute_inspect_layout
+M._SPINNER_FRAMES = _SPINNER_FRAMES
+M._SPINNER_INTERVAL_MS = _SPINNER_INTERVAL_MS
+
+---Whether the spinner timer is currently active. Test-only.
+---@return boolean
+function M._has_spinner_timer()
+  return _spinner_timer ~= nil
+end
+
+---Reset the spinner frame counter so tests start from a known index.
+function M._reset_spinner_frame()
+  _spinner_frame = 0
+end
 
 return M

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -42,6 +42,7 @@ local M = {}
 ---@field indent eda.IndentConfig
 ---@field preview eda.PreviewConfig
 ---@field full_name eda.FullNameConfig
+---@field inspect eda.InspectConfig
 ---@field mark eda.MarkConfig
 ---@field quickfix eda.QuickfixConfig
 ---@field header eda.HeaderConfig|false
@@ -97,6 +98,13 @@ local M = {}
 
 ---@class eda.FullNameConfig
 ---@field enabled boolean
+
+---@class eda.DirSizeConfig
+---@field enabled boolean
+---@field cache_ttl_ms integer
+
+---@class eda.InspectConfig
+---@field dir_size eda.DirSizeConfig
 
 ---@class eda.MarkConfig
 ---@field icon string
@@ -192,6 +200,13 @@ local defaults = {
 
   full_name = {
     enabled = true,
+  },
+
+  inspect = {
+    dir_size = {
+      enabled = true,
+      cache_ttl_ms = 30000,
+    },
   },
 
   mark = {

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -120,6 +120,7 @@ local highlight_groups = {
   EdaInspectValue = { link = "Normal" },
   EdaInspectValueMuted = { link = "Comment" },
   EdaInspectError = { link = "DiagnosticError" },
+  EdaInspectSpinner = { link = "Comment" },
   EdaFullNameNormal = { link = "EdaCursorLine" },
 }
 
@@ -368,6 +369,7 @@ end
 ---@param opts? table
 function M.setup(opts)
   config.setup(opts)
+  require("eda.buffer.dir_size").setup(config.get().inspect.dir_size)
   setup_highlights()
 
   -- Re-apply highlights on :colorscheme to survive :hi clear.

--- a/tests/buffer/test_dir_size.lua
+++ b/tests/buffer/test_dir_size.lua
@@ -1,0 +1,209 @@
+local DirSize = require("eda.buffer.dir_size")
+local helpers = require("helpers")
+
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      DirSize.setup({ cache_ttl_ms = 30000 })
+      DirSize._clear_cache()
+    end,
+  },
+})
+
+T["ensure returns computing on cache miss, then populates cache"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "hello") -- 5 bytes
+  helpers.create_file(tmp .. "/b.txt", "world!!") -- 7 bytes
+
+  local r1 = DirSize.ensure(tmp)
+  MiniTest.expect.equality(r1.state, "computing")
+
+  local final
+  helpers.wait_for(2000, function()
+    final = DirSize.ensure(tmp)
+    return final.state == "cached"
+  end)
+  MiniTest.expect.equality(final.state, "cached")
+  MiniTest.expect.equality(final.bytes, 12)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["ensure walks nested directories and sums all descendant file sizes"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_dir(tmp .. "/sub")
+  helpers.create_dir(tmp .. "/sub/deep")
+  helpers.create_file(tmp .. "/a.txt", "aaaa") -- 4
+  helpers.create_file(tmp .. "/sub/b.txt", "bbbbbbbb") -- 8
+  helpers.create_file(tmp .. "/sub/deep/c.txt", "cccccccccccc") -- 12
+
+  DirSize.ensure(tmp)
+  local final
+  helpers.wait_for(2000, function()
+    final = DirSize.ensure(tmp)
+    return final.state == "cached"
+  end)
+  MiniTest.expect.equality(final.state, "cached")
+  MiniTest.expect.equality(final.bytes, 24)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["ensure returns cached within TTL without relaunching walk"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "hi")
+
+  DirSize.ensure(tmp)
+  helpers.wait_for(2000, function()
+    return DirSize.ensure(tmp).state == "cached"
+  end)
+
+  local call_count = 0
+  local orig = DirSize._start_walk
+  DirSize._start_walk = function(p)
+    call_count = call_count + 1
+    orig(p)
+  end
+
+  local r = DirSize.ensure(tmp)
+  MiniTest.expect.equality(r.state, "cached")
+  MiniTest.expect.equality(call_count, 0)
+
+  DirSize._start_walk = orig
+  helpers.remove_temp_dir(tmp)
+end
+
+T["ensure re-launches walk after TTL expiry"] = function()
+  DirSize.setup({ cache_ttl_ms = 20 })
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "hi")
+
+  DirSize.ensure(tmp)
+  helpers.wait_for(2000, function()
+    return DirSize.ensure(tmp).state == "cached"
+  end)
+  vim.uv.sleep(60)
+
+  local call_count = 0
+  local orig = DirSize._start_walk
+  DirSize._start_walk = function(p)
+    call_count = call_count + 1
+    orig(p)
+  end
+
+  local r = DirSize.ensure(tmp)
+  MiniTest.expect.equality(r.state, "computing")
+  MiniTest.expect.equality(call_count, 1)
+
+  DirSize._start_walk = orig
+  helpers.wait_for(2000, function()
+    return DirSize.ensure(tmp).state == "cached"
+  end)
+  helpers.remove_temp_dir(tmp)
+end
+
+T["dedup: second ensure while walking does not relaunch"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "hi")
+
+  local call_count = 0
+  local orig = DirSize._start_walk
+  DirSize._start_walk = function(p)
+    call_count = call_count + 1
+    orig(p)
+  end
+
+  local r1 = DirSize.ensure(tmp)
+  local r2 = DirSize.ensure(tmp)
+  MiniTest.expect.equality(r1.state, "computing")
+  MiniTest.expect.equality(r2.state, "computing")
+  MiniTest.expect.equality(call_count, 1)
+
+  DirSize._start_walk = orig
+  helpers.wait_for(2000, function()
+    return DirSize.ensure(tmp).state == "cached"
+  end)
+  helpers.remove_temp_dir(tmp)
+end
+
+T["symlink entry counted as link-own size, target not followed"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_dir(tmp .. "/target")
+  helpers.create_file(tmp .. "/target/big.bin", string.rep("x", 10000)) -- 10000 bytes
+
+  local ok = pcall(vim.uv.fs_symlink, tmp .. "/target", tmp .. "/link")
+  if not ok then
+    return
+  end
+
+  DirSize.ensure(tmp)
+  local final
+  helpers.wait_for(2000, function()
+    final = DirSize.ensure(tmp)
+    return final.state == "cached"
+  end)
+  MiniTest.expect.equality(final.state, "cached")
+  -- If link were followed: 10000 (target real) + 10000 (via link) + link lstat size = 20000+.
+  -- Link NOT followed: 10000 (target/big.bin) + link's own lstat size (a few dozen bytes).
+  MiniTest.expect.equality(final.bytes >= 10000, true)
+  MiniTest.expect.equality(final.bytes < 15000, true)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["root opendir error: no cache written, retry is allowed"] = function()
+  local nonexistent = "/tmp/dir_size_nonexistent_" .. tostring(vim.uv.hrtime())
+  local r = DirSize.ensure(nonexistent)
+  MiniTest.expect.equality(r.state, "computing")
+
+  helpers.wait_for(1000, function()
+    return not DirSize.is_computing()
+  end)
+
+  local call_count = 0
+  local orig = DirSize._start_walk
+  DirSize._start_walk = function(p)
+    call_count = call_count + 1
+    orig(p)
+  end
+
+  local r2 = DirSize.ensure(nonexistent)
+  MiniTest.expect.equality(r2.state, "computing")
+  MiniTest.expect.equality(call_count, 1)
+
+  DirSize._start_walk = orig
+  helpers.wait_for(1000, function()
+    return not DirSize.is_computing()
+  end)
+end
+
+T["_clear_cache empties cache; subsequent ensure on same path relaunches walk"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "hi")
+
+  DirSize.ensure(tmp)
+  helpers.wait_for(2000, function()
+    return DirSize.ensure(tmp).state == "cached"
+  end)
+
+  DirSize._clear_cache()
+
+  local call_count = 0
+  local orig = DirSize._start_walk
+  DirSize._start_walk = function(p)
+    call_count = call_count + 1
+    orig(p)
+  end
+
+  local r = DirSize.ensure(tmp)
+  MiniTest.expect.equality(r.state, "computing")
+  MiniTest.expect.equality(call_count, 1)
+
+  DirSize._start_walk = orig
+  helpers.wait_for(2000, function()
+    return DirSize.ensure(tmp).state == "cached"
+  end)
+  helpers.remove_temp_dir(tmp)
+end
+
+return T

--- a/tests/buffer/test_inspect.lua
+++ b/tests/buffer/test_inspect.lua
@@ -623,4 +623,265 @@ T["close keymap q closes the inspect float when focused"] = function()
   helpers.remove_temp_dir(tmp)
 end
 
+-- ===== build_lines directory size branches =====
+
+---Locate the Size line text in a build result.
+---@param build eda.InspectBuild
+---@return string? text
+local function find_size_line(build)
+  for _, line in ipairs(build.lines) do
+    if line:match("^%s%sSize%s+") then
+      return line
+    end
+  end
+  return nil
+end
+
+---Find the extmark covering the main-value column of the Size row.
+---Size labels land on the second row of the body after Path and Type.
+local function find_size_main_hl(build)
+  local size_row
+  for i, line in ipairs(build.lines) do
+    if line:match("^%s%sSize%s+") then
+      size_row = i - 1 -- 0-indexed
+      break
+    end
+  end
+  if not size_row then
+    return nil
+  end
+  -- push_kv renders "  Size" padded to column 16 before the main value.
+  for _, mark in ipairs(build.extmarks) do
+    if mark.row == size_row and mark.col_start == 16 then
+      return mark.hl
+    end
+  end
+  return nil
+end
+
+T["build_lines directory Size falls back to '-' when dir_size_info is nil"] = function()
+  local node = { name = "d", path = "/tmp/d", type = "directory" }
+  local build = Inspect._build_lines(node, mock_lstat({ type = "directory" }), nil, nil, nil, 1700000000, nil, nil)
+  local line = find_size_line(build)
+  MiniTest.expect.equality(line ~= nil, true)
+  MiniTest.expect.equality(line:match("Size%s+(.*)$"), "-")
+end
+
+T["build_lines directory Size renders cached bytes with muted byte count"] = function()
+  local node = { name = "d", path = "/tmp/d", type = "directory" }
+  local build = Inspect._build_lines(
+    node,
+    mock_lstat({ type = "directory" }),
+    nil,
+    nil,
+    nil,
+    1700000000,
+    { state = "cached", bytes = 12345678 },
+    1
+  )
+  local line = find_size_line(build)
+  MiniTest.expect.equality(line ~= nil, true)
+  MiniTest.expect.equality(line:find("11.77 MiB", 1, true) ~= nil, true)
+  MiniTest.expect.equality(line:find("(12,345,678 bytes)", 1, true) ~= nil, true)
+end
+
+T["build_lines directory Size renders spinner frame with EdaInspectSpinner highlight"] = function()
+  local node = { name = "d", path = "/tmp/d", type = "directory" }
+  local build = Inspect._build_lines(
+    node,
+    mock_lstat({ type = "directory" }),
+    nil,
+    nil,
+    nil,
+    1700000000,
+    { state = "computing" },
+    1
+  )
+  local line = find_size_line(build)
+  MiniTest.expect.equality(line ~= nil, true)
+  MiniTest.expect.equality(line:find(Inspect._SPINNER_FRAMES[1], 1, true) ~= nil, true)
+  MiniTest.expect.equality(line:find("calculating...", 1, true) ~= nil, true)
+  MiniTest.expect.equality(find_size_main_hl(build), "EdaInspectSpinner")
+end
+
+T["build_lines directory Size advances with spinner_frame index"] = function()
+  local node = { name = "d", path = "/tmp/d", type = "directory" }
+  local build = Inspect._build_lines(
+    node,
+    mock_lstat({ type = "directory" }),
+    nil,
+    nil,
+    nil,
+    1700000000,
+    { state = "computing" },
+    5
+  )
+  local line = find_size_line(build)
+  MiniTest.expect.equality(line ~= nil, true)
+  MiniTest.expect.equality(line:find(Inspect._SPINNER_FRAMES[5], 1, true) ~= nil, true)
+end
+
+-- ===== spinner timer + dir_size integration =====
+
+---Run `body()` with `DirSize.ensure` stubbed to `stub`, restoring the original
+---function even when an assertion inside `body` fails.
+---@param stub fun(path: string): { state: "cached"|"computing", bytes: integer? }
+---@param body fun()
+local function with_stubbed_ensure(stub, body)
+  local DirSize = require("eda.buffer.dir_size")
+  local orig = DirSize.ensure
+  DirSize.ensure = stub
+  local ok, err = pcall(body)
+  DirSize.ensure = orig
+  if not ok then
+    error(err)
+  end
+end
+
+T["spinner_tick advances frame and re-renders while computing"] = function()
+  require("eda").setup({ inspect = { dir_size = { cache_ttl_ms = 30000 } } })
+  require("eda.buffer.dir_size")._clear_cache()
+
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "x")
+  local node = { name = vim.fn.fnamemodify(tmp, ":t"), path = tmp, type = "directory" }
+
+  with_stubbed_ensure(function()
+    return { state = "computing" }
+  end, function()
+    Inspect._reset_spinner_frame()
+    Inspect.show(nil, node)
+
+    Inspect._spinner_tick()
+    local _, buf = find_inspect_window()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local has_frame_1 = false
+    for _, line in ipairs(lines) do
+      if line:find(Inspect._SPINNER_FRAMES[1], 1, true) then
+        has_frame_1 = true
+        break
+      end
+    end
+    MiniTest.expect.equality(has_frame_1, true)
+
+    Inspect._spinner_tick()
+    lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local has_frame_2 = false
+    for _, line in ipairs(lines) do
+      if line:find(Inspect._SPINNER_FRAMES[2], 1, true) then
+        has_frame_2 = true
+        break
+      end
+    end
+    MiniTest.expect.equality(has_frame_2, true)
+    Inspect.close()
+  end)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["spinner_tick renders final size and stops timer when state transitions to cached"] = function()
+  require("eda").setup({ inspect = { dir_size = { cache_ttl_ms = 30000 } } })
+  require("eda.buffer.dir_size")._clear_cache()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "x")
+  local node = { name = vim.fn.fnamemodify(tmp, ":t"), path = tmp, type = "directory" }
+
+  local state_to_return = { state = "computing" }
+  with_stubbed_ensure(function()
+    return state_to_return
+  end, function()
+    Inspect.show(nil, node)
+    MiniTest.expect.equality(Inspect._has_spinner_timer(), true)
+
+    state_to_return = { state = "cached", bytes = 2048 }
+    Inspect._spinner_tick()
+
+    local _, buf = find_inspect_window()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local has_size = false
+    for _, line in ipairs(lines) do
+      if line:find("2.00 KiB", 1, true) then
+        has_size = true
+        break
+      end
+    end
+    MiniTest.expect.equality(has_size, true)
+    MiniTest.expect.equality(Inspect._has_spinner_timer(), false)
+    Inspect.close()
+  end)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["close stops the spinner timer"] = function()
+  require("eda").setup({})
+  require("eda.buffer.dir_size")._clear_cache()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "x")
+  local node = { name = vim.fn.fnamemodify(tmp, ":t"), path = tmp, type = "directory" }
+
+  with_stubbed_ensure(function()
+    return { state = "computing" }
+  end, function()
+    Inspect.show(nil, node)
+    MiniTest.expect.equality(Inspect._has_spinner_timer(), true)
+    Inspect.close()
+    MiniTest.expect.equality(Inspect._has_spinner_timer(), false)
+  end)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["spinner_tick does not re-invoke fs_lstat (uses cached meta)"] = function()
+  require("eda").setup({})
+  require("eda.buffer.dir_size")._clear_cache()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/a.txt", "x")
+  local node = { name = vim.fn.fnamemodify(tmp, ":t"), path = tmp, type = "directory" }
+
+  with_stubbed_ensure(function()
+    return { state = "computing" }
+  end, function()
+    Inspect.show(nil, node)
+
+    local lstat_calls = 0
+    local orig_lstat = vim.uv.fs_lstat
+    ---@diagnostic disable-next-line: duplicate-set-field
+    vim.uv.fs_lstat = function(...)
+      lstat_calls = lstat_calls + 1
+      return orig_lstat(...)
+    end
+    local ok, err = pcall(function()
+      Inspect._spinner_tick()
+      Inspect._spinner_tick()
+      Inspect._spinner_tick()
+      MiniTest.expect.equality(lstat_calls, 0)
+    end)
+    vim.uv.fs_lstat = orig_lstat
+    if not ok then
+      error(err)
+    end
+    Inspect.close()
+  end)
+
+  helpers.remove_temp_dir(tmp)
+end
+
+T["build_lines file Size unaffected by dir_size_info"] = function()
+  local node = { name = "a.txt", path = "/tmp/a.txt", type = "file" }
+  local build = Inspect._build_lines(
+    node,
+    mock_lstat({ size = 2048, type = "file" }),
+    nil,
+    nil,
+    nil,
+    1700000000,
+    { state = "computing" }, -- should be ignored for files
+    1
+  )
+  local line = find_size_line(build)
+  MiniTest.expect.equality(line:find("2.00 KiB", 1, true) ~= nil, true)
+end
+
 return T

--- a/tests/e2e/test_inspect_float.lua
+++ b/tests/e2e/test_inspect_float.lua
@@ -79,6 +79,11 @@ T["inspect float"] = MiniTest.new_set({
       e2e.create_file(tmp .. "/sample.txt", string.rep("x", 2048))
       e2e.create_file(tmp .. "/other.txt", "hi")
       e2e.create_dir(tmp .. "/subdir")
+      -- Known-total dir contents (100 + 200 + 300 = 600 bytes) for the async
+      -- dir-size walk assertion in case K.
+      e2e.create_file(tmp .. "/subdir/a.bin", string.rep("a", 100))
+      e2e.create_file(tmp .. "/subdir/b.bin", string.rep("b", 200))
+      e2e.create_file(tmp .. "/subdir/c.bin", string.rep("c", 300))
       -- sample.link -> sample.txt
       vim.uv.fs_symlink(tmp .. "/sample.txt", tmp .. "/sample.link")
       -- dangling.link -> /nonexistent
@@ -345,6 +350,44 @@ T["inspect float"]["I: focus stays in the eda buffer after open"] = function()
 
   local current_ft = e2e.exec(child, "return vim.bo[vim.api.nvim_get_current_buf()].filetype")
   MiniTest.expect.no_equality(current_ft, "eda_inspect")
+end
+
+T["inspect float"]["K: directory inspect resolves to real size via async walk"] = function()
+  cursor_to(child, "subdir")
+  e2e.feed(child, "\\i")
+
+  local count_predicate = [[(function()
+    local n = 0
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      local buf = vim.api.nvim_win_get_buf(win)
+      if vim.bo[buf].filetype == "eda_inspect" then n = n + 1 end
+    end
+    return n
+  end)()]]
+  e2e.wait_until(child, string.format("return (%s) == 1", count_predicate))
+
+  -- Wait for Size line to transition from "-" (legacy) / spinner ("calculating") to
+  -- resolved bytes. subdir contains exactly 600 bytes (100+200+300).
+  e2e.wait_until(
+    child,
+    [[
+    return (function()
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.bo[buf].filetype == "eda_inspect" then
+          local text = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+          return text:find("600 B", 1, true) ~= nil
+        end
+      end
+      return false
+    end)()
+  ]],
+    3000
+  )
+
+  local text = inspect_buf_text(child)
+  MiniTest.expect.no_equality(text, nil)
+  MiniTest.expect.equality(text:find("600 B", 1, true) ~= nil, true)
 end
 
 T["inspect float"]["H: K triggers debug action (no inspect float opened)"] = function()

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -215,6 +215,37 @@ T["normalize_confirm"]["create 0 becomes false"] = function()
   })
 end
 
+T["setup"]["inspect.dir_size has defaults"] = function()
+  config.setup()
+  local c = config.get()
+  MiniTest.expect.equality(type(c.inspect), "table")
+  MiniTest.expect.equality(type(c.inspect.dir_size), "table")
+  MiniTest.expect.equality(c.inspect.dir_size.enabled, true)
+  MiniTest.expect.equality(c.inspect.dir_size.cache_ttl_ms, 30000)
+end
+
+T["setup"]["inspect.dir_size merges user override"] = function()
+  config.setup({ inspect = { dir_size = { cache_ttl_ms = 5000 } } })
+  local c = config.get()
+  MiniTest.expect.equality(c.inspect.dir_size.enabled, true) -- default preserved
+  MiniTest.expect.equality(c.inspect.dir_size.cache_ttl_ms, 5000)
+end
+
+T["setup"]["inspect.dir_size can be disabled"] = function()
+  config.setup({ inspect = { dir_size = { enabled = false } } })
+  local c = config.get()
+  MiniTest.expect.equality(c.inspect.dir_size.enabled, false)
+  MiniTest.expect.equality(c.inspect.dir_size.cache_ttl_ms, 30000)
+end
+
+T["setup"]["eda.setup propagates inspect.dir_size to dir_size module"] = function()
+  require("eda").setup({ inspect = { dir_size = { cache_ttl_ms = 5000 } } })
+  local dir_size = require("eda.buffer.dir_size")
+  MiniTest.expect.equality(dir_size._get_config().cache_ttl_ms, 5000)
+  -- Restore defaults so later tests start from a known state.
+  require("eda").setup({})
+end
+
 T["get"] = MiniTest.new_set()
 
 T["get"]["returns config table"] = function()


### PR DESCRIPTION
## Summary

Add async directory size calculation to the inspect float. The Size field for directory nodes previously always rendered `"-"` because a recursive size walk was too expensive to run synchronously. This change performs the walk in the background via `vim.uv.fs_opendir`/`fs_readdir`/`fs_lstat` and shows an animated spinner in the Size field until the result is ready.

- New module `lua/eda/buffer/dir_size.lua`: recursive sizer with per-path dedup, no-cancel semantics, and a path-keyed TTL cache (default 30s). Callback-less poll API — callers sample `ensure(path)` each tick. Symlinks are not followed; the link's own `lstat` size is counted to prevent cycles.
- `inspect.lua` integration: 100ms spinner timer drives the re-render. `_state` caches `lstat` / `target_stat` / `dir_count` so ticks perform zero fs IO. The timer stops on cache/error transition, on float close, or when the cursor leaves a directory node.
- Config surface: `inspect.dir_size = { enabled = true, cache_ttl_ms = 30000 }` (propagated through `config.setup` → `dir_size.setup`).
- Highlight: `EdaInspectSpinner` (default `link = "Comment"`).
- Tests: 8 unit tests for the sizer (happy path / nested / TTL / dedup / symlink / root error / clear-cache), 14 tests for inspect (branch rendering + spinner tick + close-stops-timer + cached-meta-avoids-fs), 4 config tests (defaults / override / propagation), 1 E2E test (directory inspect resolves to `600 B`).
- Docs: `doc/eda.md` updated (default-config block, `### inspect` section, `EdaInspectSpinner` entry, `inspect` action note); vimdoc regenerated via `just doc`.

Verified on multi-GB real directories — UI remains responsive during the walk.

## References

- n/a
