### PR TITLE
fix: defer action dispatch until initial render completes

### DIFF
--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -38,6 +38,8 @@ local next_instance_id = 0
 ---@field _refresh_for_navigation fun()?
 ---@field _empty_state_rendered? boolean
 ---@field _no_repo_notified? boolean
+---@field _initial_scan_complete boolean
+---@field _pending_dispatch? { name: string, ctx: eda.ActionContext }
 
 ---@type eda.Explorer?
 M._current = nil
@@ -301,6 +303,23 @@ local function make_ctx(explorer)
   }
 end
 
+---Flip the pre-render dispatch gate to "complete" and dispatch any parked
+---action. Idempotent: a second call after the gate is already true is a no-op,
+---which keeps both async lifecycles (`open()` initial scan and `_change_root()`
+---rescan) symmetric without duplicating the drain logic.
+---@param explorer eda.Explorer
+local function drain_pending_dispatch(explorer)
+  if explorer._initial_scan_complete then
+    return
+  end
+  local pending = explorer._pending_dispatch
+  explorer._pending_dispatch = nil
+  explorer._initial_scan_complete = true
+  if pending then
+    action.dispatch(pending.name, pending.ctx)
+  end
+end
+
 ---@class eda.PublicContext
 ---@field get_node fun(): eda.TreeNode?
 ---@field get_root fun(): eda.TreeNode?
@@ -512,6 +531,8 @@ function M.open(opts)
     full_name = full_name,
     _render_gen = 0,
     _last_painted_gen = -1,
+    _initial_scan_complete = false,
+    _pending_dispatch = nil,
   }
 
   M._current = explorer
@@ -743,9 +764,17 @@ function M.open(opts)
   end
   explorer._refresh_for_navigation = refresh_for_navigation
 
-  -- Setup keymaps via action dispatch
+  -- Setup keymaps via action dispatch. When the user presses a mapped key in
+  -- the same tick as open() (cold start), the tree is still scanning and
+  -- `get_cursor_node` would resolve to nil. Park the dispatch in a single
+  -- slot and drain it in `on_initial_scan_complete` below; latest-write wins.
   buffer:set_mappings(cfg.mappings, function(action_name)
-    action.dispatch(action_name, make_ctx(explorer))
+    local ctx = make_ctx(explorer)
+    if not explorer._initial_scan_complete then
+      explorer._pending_dispatch = { name = action_name, ctx = ctx }
+      return
+    end
+    action.dispatch(action_name, ctx)
   end, function()
     return make_public_ctx(explorer)
   end)
@@ -885,6 +914,8 @@ function M.open(opts)
 
       mark_render_dirty()
       render_with_decorators()
+
+      drain_pending_dispatch(explorer)
 
       -- Restore cached state (directory open/close and cursor position)
       local cached = state_cache[root_path]
@@ -1136,6 +1167,12 @@ function M._change_root(explorer, new_path, opts)
   -- Increment generation to invalidate stale callbacks
   explorer.generation = explorer.generation + 1
 
+  -- Reset the pre-render dispatch gate: after a root change, the new scan is
+  -- in flight and `flat_lines` is empty until `on_scan_complete` below. Treat
+  -- it like a cold open for dispatch-parking purposes.
+  explorer._initial_scan_complete = false
+  explorer._pending_dispatch = nil
+
   -- Unwatch old root
   explorer.watcher:unwatch_all()
 
@@ -1175,6 +1212,8 @@ function M._change_root(explorer, new_path, opts)
       end
 
       explorer.buffer:render(explorer.store)
+
+      drain_pending_dispatch(explorer)
 
       -- Expand path from parent action
       if expand_path then

--- a/tests/e2e/test_action_cold_open_race.lua
+++ b/tests/e2e/test_action_cold_open_race.lua
@@ -1,0 +1,132 @@
+local e2e = require("e2e.helpers")
+
+local T = MiniTest.new_set()
+
+local child, tmp
+
+---Count windows whose buffer has filetype == "eda_inspect" in the child Neovim.
+---@param child_ table
+---@return integer
+local function inspect_win_count(child_)
+  return e2e.exec(
+    child_,
+    [[
+    return (function()
+      local n = 0
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.bo[buf].filetype == "eda_inspect" then
+          n = n + 1
+        end
+      end
+      return n
+    end)()
+  ]]
+  )
+end
+
+T["cold open race"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_file(tmp .. "/foo.txt", "hello")
+      e2e.create_dir(tmp .. "/bar")
+      -- setup only; DO NOT open_eda (it waits for initial render which masks the race)
+      e2e.setup_eda(child)
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+-- Regression: when the user presses the mapped inspect key in the same event
+-- tick as the explorer open (cold start), the initial scan is still in flight
+-- and `flat_lines` is empty. Previously the dispatch hit `get_cursor_node` ==
+-- nil and silently returned via the "no target at cursor" notify. After the
+-- fix, dispatches issued before initial render are parked and drained once
+-- the render completes, so the inspect float eventually opens.
+T["cold open race"]["A: <Leader>i pressed in the same tick as open still opens inspect"] = function()
+  -- Sanity: nothing open before.
+  MiniTest.expect.equality(inspect_win_count(child), 0)
+
+  -- Feed open + leader-i in a single child-side Lua call so they land in the
+  -- same event tick (no sleep/schedule between them).
+  e2e.exec(
+    child,
+    string.format(
+      [[
+      require("eda").open({ dir = %q })
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Leader>i", true, false, true), "mtx", false)
+      return true
+    ]],
+      tmp
+    )
+  )
+
+  -- With the fix in place: pending dispatch is drained on initial scan
+  -- completion, inspect float opens eventually (within poll deadline).
+  -- Without the fix: poll times out, inspect_win_count stays 0.
+  e2e.wait_until(
+    child,
+    [[
+    return (function()
+      local n = 0
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.bo[buf].filetype == "eda_inspect" then
+          n = n + 1
+        end
+      end
+      return n == 1
+    end)()
+  ]]
+  )
+
+  MiniTest.expect.equality(inspect_win_count(child), 1)
+end
+
+-- Regression: the same race also applies when the root changes on an already-
+-- open explorer (parent/cwd/cd actions go through `_change_root`). Pressing a
+-- mapped action key in the same tick as the root change used to hit the same
+-- empty-`flat_lines` gap until `_change_root` was taught to reset and drain
+-- the pending-dispatch slot.
+T["cold open race"]["B: <Leader>i pressed in the same tick as root change still opens inspect"] = function()
+  -- Open first, wait for initial render so we isolate the root-change path.
+  e2e.open_eda(child, tmp)
+  MiniTest.expect.equality(inspect_win_count(child), 0)
+
+  -- Close any pre-existing inspect float (none expected) and feed parent + leader-i
+  -- in a single event tick: `^` dispatches the `parent` action which triggers
+  -- `_change_root` (async scan), and `<Leader>i` immediately follows.
+  e2e.exec(
+    child,
+    [[
+      local ks = vim.api.nvim_replace_termcodes("^<Leader>i", true, false, true)
+      vim.api.nvim_feedkeys(ks, "mtx", false)
+      return true
+    ]]
+  )
+
+  e2e.wait_until(
+    child,
+    [[
+    return (function()
+      local n = 0
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.bo[buf].filetype == "eda_inspect" then
+          n = n + 1
+        end
+      end
+      return n == 1
+    end)()
+  ]]
+  )
+
+  MiniTest.expect.equality(inspect_win_count(child), 1)
+end
+
+return T


### PR DESCRIPTION
## Summary

Fixes a silent no-op when the first mapped action key is pressed in the same event tick as `eda.open()` / `_change_root()`.

### Root cause

`open()` / `_change_root()` create the buffer and install keymaps synchronously, but the tree scan / render is async (`vim.uv.fs_scandir` + `vim.schedule`). If the user presses a mapped action key before the initial render lands, `buffer.flat_lines` is empty, `Buffer:get_cursor_node` returns `nil`, and the action (e.g. `inspect`) short-circuits via `"eda: no target at cursor"` — the notify flashes past unnoticed, so the UX looks like the keypress was silently swallowed.

Reproduced deterministically with `<C-j>` followed immediately by `<Leader>i` in the same child-Neovim Lua call.

### Fix

- Add `_initial_scan_complete` + `_pending_dispatch` (single-slot, latest-write-wins) to the Explorer struct.
- The dispatch wrapper installed by `Buffer:set_mappings` parks the action when the initial scan is still in flight; normal post-scan dispatch is unchanged.
- Drain the parked action once the first `render_with_decorators()` finishes inside `on_initial_scan_complete`.
- `_change_root()` participates in the same lifecycle: reset the gate at entry, drain after the first `buffer:render(store)` of the new root — otherwise the race re-opens every time `parent` / `cwd` / `cd` swaps roots on a reused explorer.
- Shared `drain_pending_dispatch` helper keeps both async lifecycles mechanically identical.

### Tests

New `tests/e2e/test_action_cold_open_race.lua`:

- **A**: `require("eda").open()` + `<Leader>i` fed in the same child-side Lua call → inspect float opens.
- **B**: explorer already open, then `^<Leader>i` (parent action + inspect) fed in the same tick → inspect float opens on the new root.

Both cases fail before the fix and pass after.

## References

n/a
