### PR TITLE
feat: preserve directory open state across root changes

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -703,6 +703,11 @@ can be mapped to keys, dispatched programmatically, or discovered via the
 - **cwd** — Change root to the current working directory.
 - **cd** — Change root to the directory under the cursor.
 
+Directory expansion state is preserved across `parent` / `cwd` / `cd` root
+changes: directories that were expanded in the previous tree stay expanded in
+the new one when their absolute paths remain visible, and returning to a
+previously visited root restores its prior expansion.
+
 ### Tree Manipulation
 
 - **collapse_all** — Collapse all directories except root.

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -775,6 +775,11 @@ NAVIGATION ~
 - **cwd** — Change root to the current working directory.
 - **cd** — Change root to the directory under the cursor.
 
+Directory expansion state is preserved across `parent` / `cwd` / `cd` root
+changes: directories that were expanded in the previous tree stay expanded in
+the new one when their absolute paths remain visible, and returning to a
+previously visited root restores its prior expansion.
+
 
 TREE MANIPULATION ~
 

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -1164,6 +1164,30 @@ function M._change_root(explorer, new_path, opts)
     return
   end
 
+  -- Snapshot current tree state into state_cache BEFORE reinit so a
+  -- subsequent root transition (or re-visit) can restore expanded directories.
+  -- Skips split instances, matching close() semantics.
+  local old_path = explorer.root_path
+  if not explorer.is_split then
+    local open_dirs = {}
+    for _, node in pairs(explorer.store.nodes) do
+      if node.type == "directory" and node.open and node.id ~= explorer.store.root_id then
+        open_dirs[node.path] = true
+      end
+    end
+    local cursor_path = nil
+    if util.is_valid_win(explorer.window.winid) then
+      local cursor_node = explorer.buffer:get_cursor_node(explorer.window.winid)
+      if cursor_node then
+        cursor_path = cursor_node.path
+      end
+    end
+    state_cache[old_path] = {
+      open_dirs = open_dirs,
+      cursor_path = cursor_path,
+    }
+  end
+
   -- Increment generation to invalidate stale callbacks
   explorer.generation = explorer.generation + 1
 
@@ -1215,7 +1239,35 @@ function M._change_root(explorer, new_path, opts)
 
       drain_pending_dispatch(explorer)
 
-      -- Expand path from parent action
+      -- Merge cached open_dirs from old and new roots. Paths are absolute, so
+      -- parent-up (new ⊃ old), cd-descent (new ⊂ old), and revisits all
+      -- funnel through a single union. `scan_open_unloaded` silently skips
+      -- paths that do not resolve in the new store's index.
+      local merged_open_dirs = {}
+      for _, key in ipairs({ old_path, new_path }) do
+        local cached = state_cache[key]
+        if cached and cached.open_dirs then
+          for p in pairs(cached.open_dirs) do
+            merged_open_dirs[p] = true
+          end
+        end
+      end
+
+      local function restore_open_dirs_then_render()
+        explorer.scanner:scan_open_unloaded(merged_open_dirs, function()
+          vim.schedule(function()
+            if explorer.generation ~= gen then
+              return
+            end
+            if not util.is_valid_buf(explorer.buffer.bufnr) then
+              return
+            end
+            explorer.buffer:render(explorer.store)
+          end)
+        end)
+      end
+
+      -- Expand path (parent action) → scan_open_unloaded → final render.
       if expand_path then
         explorer.scanner:scan_ancestors(expand_path, function()
           vim.schedule(function()
@@ -1241,9 +1293,11 @@ function M._change_root(explorer, new_path, opts)
               end
               explorer.buffer.target_node_id = ep_node.id
             end
-            explorer.buffer:render(explorer.store)
+            restore_open_dirs_then_render()
           end)
         end)
+      else
+        restore_open_dirs_then_render()
       end
 
       -- Fetch git status

--- a/tests/e2e/test_navigation.lua
+++ b/tests/e2e/test_navigation.lua
@@ -293,6 +293,161 @@ T["navigation"]["parent at filesystem root does not navigate further"] = functio
   MiniTest.expect.equality(root_path, "/")
 end
 
+T["navigation"]["parent preserves deep expansion"] = function()
+  -- Build nested fixtures: tmp/x/a/b/deep/deep2/leaf.txt
+  local old_root = tmp .. "/x"
+  e2e.create_dir(old_root .. "/a/b/deep/deep2")
+  e2e.create_file(old_root .. "/a/b/deep/deep2/leaf.txt", "leaf")
+
+  -- Open eda at the old root and expand all nested directories
+  e2e.open_eda(child, old_root)
+  e2e.feed(child, "gE")
+
+  -- leaf.txt visible proves a/, a/b/, a/b/deep/, a/b/deep/deep2/ are open
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("leaf.txt") then return true end
+    end
+    return false
+  ]],
+    10000
+  )
+
+  -- Move cursor to the root line and parent-up
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {1, 0})")
+  e2e.feed(child, "^")
+
+  -- Root should change to tmp
+  e2e.wait_until(child, string.format([[require("eda").get_all()[1].root_path == %q]], tmp), 10000)
+
+  -- Wait for the new tree to render with sibling fixtures (root.txt from pre_case)
+  -- so we know _expand_path processing has completed and the old buffer is replaced.
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("root%.txt") then return true end
+    end
+    return false
+  ]],
+    10000
+  )
+
+  -- Verify deep expansion is preserved: the deepest directory node exists
+  -- in the new store and is marked open. Without the fix, /tmp/.../x/a is
+  -- neither scanned nor open, so this node lookup returns nil.
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+    local explorer = require("eda").get_all()[1]
+    local n = explorer.store:get_by_path(%q .. "/x/a/b/deep/deep2")
+    return n ~= nil and n.type == "directory" and n.open == true
+  ]],
+      tmp
+    ),
+    10000
+  )
+
+  -- leaf.txt should now appear in the buffer (children of the deepest open dir)
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("leaf%.txt") then return true end
+    end
+    return false
+  ]],
+    10000
+  )
+
+  -- Cursor should be on the old root (x/) — _expand_path cursor behavior preserved
+  e2e.wait_until(
+    child,
+    [[
+    local row = vim.api.nvim_win_get_cursor(0)[1]
+    local line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1]
+    return line ~= nil and line:find("x/") ~= nil
+  ]],
+    10000
+  )
+end
+
+T["navigation"]["cwd round-trip restores cached expansion state"] = function()
+  -- Two disjoint trees under tmp
+  local work = tmp .. "/work"
+  local other = tmp .. "/other"
+  e2e.create_dir(work .. "/a/b")
+  e2e.create_file(work .. "/a/b/file.txt", "f")
+  e2e.create_dir(other)
+  e2e.create_file(other .. "/stuff.txt", "s")
+
+  -- cd into work and open eda there
+  e2e.exec(child, string.format("vim.cmd('cd %s')", work))
+  e2e.open_eda(child, work)
+
+  -- Expand all (a/ and a/b/ open)
+  e2e.feed(child, "gE")
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("file.txt") then return true end
+    end
+    return false
+  ]],
+    10000
+  )
+
+  -- Switch cwd to an unrelated tree, then invoke cwd action
+  e2e.exec(child, string.format("vim.cmd('cd %s')", other))
+  e2e.feed(child, "~")
+  e2e.wait_until(child, string.format([[require("eda").get_all()[1].root_path == %q]], other), 10000)
+
+  -- stuff.txt should appear under the new root
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("stuff.txt") then return true end
+    end
+    return false
+  ]],
+    10000
+  )
+
+  -- Sanity: file.txt from the previous tree must not leak into the new root
+  local lines_other = e2e.exec(child, [[return vim.api.nvim_buf_get_lines(0, 0, -1, false)]])
+  for _, l in ipairs(lines_other) do
+    MiniTest.expect.equality(l:find("file%.txt") == nil, true)
+  end
+
+  -- cd back to work and invoke cwd again
+  e2e.exec(child, string.format("vim.cmd('cd %s')", work))
+  e2e.feed(child, "~")
+  e2e.wait_until(child, string.format([[require("eda").get_all()[1].root_path == %q]], work), 10000)
+
+  -- Cached state should restore: file.txt visible again without manual re-expand
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("file.txt") then return true end
+    end
+    return false
+  ]],
+    10000
+  )
+end
+
 T["navigation"]["cwd returns to original directory after parent navigation"] = function()
   -- Set CWD to sub directory
   local sub_dir = tmp .. "/sub"


### PR DESCRIPTION
## Summary

Preserve directory open/close state across `parent` / `cd` / `cwd` root changes so the explorer no longer collapses deeply expanded subtrees on every root transition.

- `_change_root` now snapshots the current `open_dirs` and `cursor_path` into `state_cache[old_root]` before generation increment, matching `close()` semantics (skipped for split instances).
- `on_scan_complete` unions `state_cache[old_root]` and `state_cache[new_root]` and hands the merged absolute paths to `scan_open_unloaded`. Non-existent paths are dropped by the path index, so the same mechanism covers `parent` (new ⊃ old), `cd` (new ⊂ old), and revisiting a previously-rooted path.
- Async ordering inside `on_scan_complete` is serialized: initial render → `drain_pending_dispatch` → `scan_ancestors(expand_path)` when present → `scan_open_unloaded(merged)` → final render. Every new `vim.schedule` closure carries both the `generation` and `is_valid_buf` guards already used elsewhere.
- Parent-up cursor behavior (`_expand_path` target) is unchanged. Cursor restoration from `state_cache` for `cd` / `cwd` is intentionally out of scope.

## Tests

- `tests/e2e/test_navigation.lua` — `parent preserves deep expansion`: expand `a/b/deep/deep2`, navigate parent, verify the deep directory node exists and is `open` in the new store, `leaf.txt` is visible, and cursor lands on the old root.
- `tests/e2e/test_navigation.lua` — `cwd round-trip restores cached expansion state`: expand, switch cwd to an unrelated tree (and assert the old tree does not leak), switch back, and verify expanded paths are restored without re-expanding manually.

Both added tests were confirmed RED before the implementation and GREEN after (`just test-all` reports `Fails (0)` across unit and E2E suites). `just format-check` / `just lint` / `just typecheck` all pass.

## Docs

`doc/eda.md` gains a short paragraph near the `parent` / `cwd` / `cd` Navigation actions documenting the new preservation behavior. `doc/eda.nvim.txt` is regenerated via `nix develop --command just doc`.

## References

- n/a
