### PR TITLE
feat: directory preview with eda tree rendering

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -448,6 +448,12 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
   },
   ```
 
+When the cursor sits on a directory, the preview pane shows that directory's
+contents using eda's tree rendering style (icons, git status, marks, etc.).
+A closed directory previews its direct children only; an open directory
+mirrors its expanded subtree from the main tree. `max_file_size` and binary
+detection do not apply to directory previews.
+
 ### full_name
 
 `table`

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -466,6 +466,12 @@ PREVIEW ~
         },
     <
 
+When the cursor sits on a directory, the preview pane shows that directory’s
+contents using eda’s tree rendering style (icons, git status, marks, etc.). A
+closed directory previews its direct children only; an open directory mirrors
+its expanded subtree from the main tree. `max_file_size` and binary detection
+do not apply to directory previews.
+
 
 FULL_NAME ~
 

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -837,7 +837,7 @@ function M.open(opts)
 
   -- Open window
   window:open(buffer.bufnr)
-  preview:attach(window)
+  preview:attach(window, { store = store, scanner = scanner, decorator_chain = chain })
 
   -- Register WinClosed handler for float windows
   if kind == "float" then

--- a/lua/eda/preview.lua
+++ b/lua/eda/preview.lua
@@ -1,3 +1,4 @@
+local Node = require("eda.tree.node")
 local util = require("eda.util")
 
 ---@class eda.Preview
@@ -5,9 +6,13 @@ local util = require("eda.util")
 ---@field bufnr integer?
 ---@field config eda.PreviewConfig
 ---@field window eda.Window?
----@field _debounced fun(path: string)?
----@field _pending_path string?
----@field _current_path string?
+---@field store eda.Store?
+---@field scanner eda.Scanner?
+---@field decorator_chain eda.DecoratorChain?
+---@field painter eda.Painter?
+---@field _debounced fun(node: eda.TreeNode)?
+---@field _pending_target integer|string|nil  Node id (dir mode) or path string (file mode)
+---@field _current_target integer|string|nil  Node id (dir mode) or path string (file mode)
 local Preview = {}
 Preview.__index = Preview
 
@@ -20,16 +25,27 @@ function Preview.new(config)
     bufnr = nil,
     config = config,
     window = nil,
+    store = nil,
+    scanner = nil,
+    decorator_chain = nil,
+    painter = nil,
     _debounced = nil,
-    _pending_path = nil,
-    _current_path = nil,
+    _pending_target = nil,
+    _current_target = nil,
   }, Preview)
 end
 
----Attach the filer window to this preview for layout computation.
+---Attach the filer window and (optionally) tree dependencies for directory preview.
+---When `deps` is omitted, only file preview is supported.
 ---@param window eda.Window
-function Preview:attach(window)
+---@param deps? { store: eda.Store, scanner: eda.Scanner, decorator_chain: eda.DecoratorChain }
+function Preview:attach(window, deps)
   self.window = window
+  if deps then
+    self.store = deps.store
+    self.scanner = deps.scanner
+    self.decorator_chain = deps.decorator_chain
+  end
 end
 
 ---Check if a file is binary (contains NUL byte in first 512 bytes).
@@ -46,6 +62,34 @@ local function is_binary(path)
     return false
   end
   return data:find("\0") ~= nil
+end
+
+---Ensure the preview buffer (and Painter) exist.
+function Preview:_ensure_buffer()
+  if not self.bufnr or not vim.api.nvim_buf_is_valid(self.bufnr) then
+    self.bufnr = vim.api.nvim_create_buf(false, true)
+    vim.bo[self.bufnr].bufhidden = "wipe"
+    self.painter = nil
+  end
+  if not self.painter then
+    local cfg = require("eda.config").get()
+    local indent_width = cfg.indent and cfg.indent.width or 2
+    self.painter = require("eda.render.painter").new(self.bufnr, indent_width)
+  end
+end
+
+---Open a fresh preview window or reuse the existing one.
+---@param layout { preview: table, filer: table? }
+function Preview:_open_or_reuse_window(layout)
+  if not util.is_valid_win(self.winid) then
+    -- Resize filer in float mode (first open only)
+    if layout.filer then
+      vim.api.nvim_win_set_config(self.window.winid, layout.filer)
+    end
+    self.winid = vim.api.nvim_open_win(self.bufnr, false, layout.preview)
+  else
+    vim.api.nvim_win_set_buf(self.winid, self.bufnr)
+  end
 end
 
 ---Show preview for a file.
@@ -79,7 +123,7 @@ function Preview:show(path)
   end
 
   -- Mark this path as pending for async guard
-  self._pending_path = path
+  self._pending_target = path
 
   -- Read file content asynchronously
   vim.uv.fs_open(path, "r", 438, function(err, fd)
@@ -93,7 +137,7 @@ function Preview:show(path)
       end
       vim.schedule(function()
         -- Guard against stale async callback
-        if path ~= self._pending_path then
+        if self._pending_target ~= path then
           return
         end
         if not self.window or not util.is_valid_win(self.window.winid) then
@@ -108,11 +152,9 @@ function Preview:show(path)
           return
         end
 
-        -- Create or reuse preview buffer
-        if not self.bufnr or not vim.api.nvim_buf_is_valid(self.bufnr) then
-          self.bufnr = vim.api.nvim_create_buf(false, true)
-          vim.bo[self.bufnr].bufhidden = "wipe"
-        end
+        self:_ensure_buffer()
+        -- Clear any stale tree-render state from a previous directory preview
+        self.painter:reset()
 
         -- Set file content
         local lines = vim.split(data, "\n", { plain = true })
@@ -121,26 +163,16 @@ function Preview:show(path)
         end
         vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, lines)
 
-        -- Set filetype for syntax highlighting
+        -- Set filetype for syntax highlighting (clear when no match so transitions
+        -- between files / directories do not leave stale filetype attached).
         local ft = vim.filetype.match({ filename = path, buf = self.bufnr })
-        if ft then
-          vim.bo[self.bufnr].filetype = ft
-        end
+        vim.bo[self.bufnr].filetype = ft or ""
 
-        -- Create or reuse preview window
-        if not util.is_valid_win(self.winid) then
-          -- Resize filer in float mode (first open only)
-          if layout.filer then
-            vim.api.nvim_win_set_config(self.window.winid, layout.filer)
-          end
-          self.winid = vim.api.nvim_open_win(self.bufnr, false, layout.preview)
-        else
-          vim.api.nvim_win_set_buf(self.winid, self.bufnr)
-        end
+        self:_open_or_reuse_window(layout)
 
-        -- Reset scroll position when switching files
-        if path ~= self._current_path then
-          self._current_path = path
+        -- Reset scroll position when switching targets
+        if path ~= self._current_target then
+          self._current_target = path
           if util.is_valid_win(self.winid) then
             vim.api.nvim_win_set_cursor(self.winid, { 1, 0 })
           end
@@ -148,6 +180,87 @@ function Preview:show(path)
       end)
     end)
   end)
+end
+
+---Show a directory preview using eda's tree-render style.
+---@param node eda.TreeNode
+function Preview:show_directory(node)
+  if not self.config.enabled then
+    return
+  end
+  if not self.window or not util.is_valid_win(self.window.winid) then
+    return
+  end
+  if not self.store or not self.scanner or not self.decorator_chain then
+    -- Tree deps not attached; cannot render directory preview.
+    return
+  end
+
+  self._pending_target = node.id
+
+  if node.children_state == "loaded" then
+    self:_render_directory(node)
+    return
+  end
+
+  self.scanner:scan(node.id, function()
+    vim.schedule(function()
+      if self._pending_target ~= node.id then
+        return
+      end
+      local fresh = self.store:get(node.id)
+      if not fresh or fresh.children_state ~= "loaded" then
+        return
+      end
+      self:_render_directory(fresh)
+    end)
+  end)
+end
+
+---Paint the directory subtree into the preview buffer.
+---@param node eda.TreeNode
+function Preview:_render_directory(node)
+  if self._pending_target ~= node.id then
+    return
+  end
+  if not self.window or not util.is_valid_win(self.window.winid) then
+    return
+  end
+
+  local Window = require("eda.window")
+  local layout = Window._compute_preview_layout(self.window.kind, self.window.winid, self.window.config)
+  if not layout then
+    self:close()
+    return
+  end
+
+  self:_ensure_buffer()
+  self.painter:reset()
+  vim.bo[self.bufnr].filetype = ""
+
+  local cfg = require("eda.config").get()
+  local root = self.store:get(self.store.root_id)
+  local git_status = root and require("eda.git").get_cached(root.path) or nil
+
+  local flat_lines = require("eda.render.flatten").flatten(self.store, node.id)
+  local ctx = { store = self.store, git_status = git_status, config = cfg }
+  local decorations = self.decorator_chain:decorate(flat_lines, ctx)
+
+  self.painter:paint(flat_lines, decorations, {
+    root_path = nil,
+    header = false,
+    kind = "preview",
+    icon = cfg.icon,
+  })
+
+  self:_open_or_reuse_window(layout)
+
+  if self._current_target ~= node.id then
+    self._current_target = node.id
+    if util.is_valid_win(self.winid) then
+      vim.api.nvim_win_set_cursor(self.winid, { 1, 0 })
+    end
+  end
 end
 
 ---Close the preview window.
@@ -241,25 +354,30 @@ function Preview:scroll_page_up()
   return true
 end
 
----Update preview based on cursor node (debounced).
+---Update preview based on cursor node (debounced). Routes directories to the
+---tree-render path and files to the byte-content path.
 ---@param node eda.TreeNode?
 function Preview:update(node)
   if not self.config.enabled then
     return
   end
 
-  if not node or node.type == "directory" then
+  if not node then
     self:close()
     return
   end
 
   if not self._debounced then
-    self._debounced = util.debounce(self.config.debounce, function(path)
-      self:show(path)
+    self._debounced = util.debounce(self.config.debounce, function(target)
+      if Node.is_dir(target) then
+        self:show_directory(target)
+      else
+        self:show(target.path)
+      end
     end)
   end
 
-  self._debounced(node.path)
+  self._debounced(node)
 end
 
 return Preview

--- a/lua/eda/render/painter.lua
+++ b/lua/eda/render/painter.lua
@@ -45,6 +45,7 @@ end
 ---@field _replaying boolean?
 ---@field paint fun(self: eda.Painter, flat_lines: eda.FlatLine[], decorations?: eda.Decoration[], opts?: table)
 ---@field paint_incremental fun(self: eda.Painter, flat_lines: eda.FlatLine[], decorations?: eda.Decoration[], opts?: table, hint: { toggled_node_id: integer }): boolean
+---@field reset fun(self: eda.Painter)
 ---@field get_snapshot fun(self: eda.Painter): eda.RenderSnapshot
 ---@field resync_highlights fun(self: eda.Painter)
 
@@ -155,6 +156,22 @@ function Painter.new(bufnr, indent_width)
   })
 
   return self
+end
+
+---Reset painter state and clear all owned extmark namespaces.
+---Use when reusing the same Painter on a buffer that should be repainted from
+---scratch (e.g. preview switching between file and directory render modes).
+---ns_hl is ephemeral and reset by the decoration provider on each redraw.
+function Painter:reset()
+  vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_icon, 0, -1)
+  vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_ids, 0, -1)
+  vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_header, 0, -1)
+  self._flat_lines = {}
+  self._line_lengths = {}
+  self._row_to_fl = {}
+  self._decoration_cache = {}
+  self.snapshot = { entries = {} }
+  self.header_lines = 0
 end
 
 ---Build header text from root_path and format setting.

--- a/lua/eda/tree/scanner.lua
+++ b/lua/eda/tree/scanner.lua
@@ -8,6 +8,7 @@ local Node = require("eda.tree.node")
 ---@field _max_concurrent_fds integer
 ---@field _node_gen table<integer, integer>
 ---@field _pending_scans { node_id: integer, callback: fun(err?: string), gen: integer }[]
+---@field _waiters table<integer, fun(err?: string)[]>
 local Scanner = {}
 Scanner.__index = Scanner
 
@@ -24,6 +25,7 @@ function Scanner.new(store, config)
     _active_fds = 0,
     _max_concurrent_fds = 32,
     _pending_scans = {},
+    _waiters = {},
   }, Scanner)
 end
 
@@ -70,8 +72,10 @@ function Scanner:scan(node_id, callback)
   end
 
   if self._scanning[node_id] then
+    -- Coalesce: queue callback so it fires when the in-flight scan settles.
     if callback then
-      callback("already scanning")
+      self._waiters[node_id] = self._waiters[node_id] or {}
+      table.insert(self._waiters[node_id], callback)
     end
     return
   end
@@ -87,6 +91,24 @@ function Scanner:scan(node_id, callback)
     self:_do_scan_io(node_id, callback, gen)
   else
     table.insert(self._pending_scans, { node_id = node_id, callback = callback, gen = gen })
+  end
+end
+
+---Settle a scan: invoke the original callback, then drain any coalesced waiters.
+---Waiters always fire even on abandoned (gen-mismatch) scans so callers cannot wait forever.
+---@private
+---@param node_id integer
+---@param callback fun(err?: string)?
+function Scanner:_settle(node_id, callback)
+  if callback then
+    callback()
+  end
+  local waiters = self._waiters[node_id]
+  if waiters then
+    self._waiters[node_id] = nil
+    for _, w in ipairs(waiters) do
+      w()
+    end
   end
 end
 
@@ -108,9 +130,7 @@ function Scanner:_do_scan_io(node_id, callback, gen)
         self:_release_fd()
         self._scanning[node_id] = nil
         if self._node_gen[node_id] ~= gen then
-          if callback then
-            callback()
-          end
+          self:_settle(node_id, callback)
           return
         end
         node.children_state = "loaded"
@@ -123,9 +143,7 @@ function Scanner:_do_scan_io(node_id, callback, gen)
           parent_id = node_id,
           error = "permission_denied",
         })
-        if callback then
-          callback()
-        end
+        self:_settle(node_id, callback)
       end)
       return
     end
@@ -140,15 +158,11 @@ function Scanner:_do_scan_io(node_id, callback, gen)
               self:_release_fd()
               self._scanning[node_id] = nil
               if self._node_gen[node_id] ~= gen then
-                if callback then
-                  callback()
-                end
+                self:_settle(node_id, callback)
                 return
               end
               self:_apply_entries(node_id, entries)
-              if callback then
-                callback()
-              end
+              self:_settle(node_id, callback)
             end)
           end)
           return

--- a/tests/e2e/test_preview.lua
+++ b/tests/e2e/test_preview.lua
@@ -168,6 +168,174 @@ T["preview"]["cursor move updates preview content"] = function()
   )
 end
 
+-- Directory preview tests
+local dir_child, dir_tmp
+
+T["dir_preview"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      dir_child = e2e.spawn()
+      dir_tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_dir(dir_tmp .. "/sub")
+      e2e.create_file(dir_tmp .. "/sub/x.txt", "hello dir preview")
+      e2e.create_file(dir_tmp .. "/top.txt", "root level")
+    end,
+    post_case = function()
+      e2e.stop(dir_child)
+      e2e.remove_temp_dir(dir_tmp)
+    end,
+  },
+})
+
+T["dir_preview"]["PR-D-E1 cursor on closed dir shows children"] = function()
+  e2e.exec(
+    dir_child,
+    [[
+    require("eda").setup({
+      git = { enabled = false },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      preview = { enabled = true, debounce = 0 },
+    })
+  ]]
+  )
+
+  e2e.open_eda(dir_child, dir_tmp)
+
+  -- Move cursor to the line containing "sub" (closed by default)
+  e2e.wait_until(
+    dir_child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for i, l in ipairs(lines) do
+      if l:find("sub", 1, true) then
+        vim.api.nvim_win_set_cursor(0, {i, 0})
+        return true
+      end
+    end
+    return false
+  ]]
+  )
+
+  -- Preview should appear and contain x.txt (1-level child of sub)
+  e2e.wait_until(
+    dir_child,
+    [[
+    local wins = vim.api.nvim_list_wins()
+    for _, w in ipairs(wins) do
+      local buf = vim.api.nvim_win_get_buf(w)
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      for _, l in ipairs(lines) do
+        if l:find("x.txt", 1, true) then return true end
+      end
+    end
+    return false
+  ]],
+    5000
+  )
+end
+
+T["dir_preview"]["PR-D-E2 open dir mirror after expand"] = function()
+  e2e.exec(
+    dir_child,
+    [[
+    require("eda").setup({
+      git = { enabled = false },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      preview = { enabled = true, debounce = 0 },
+    })
+  ]]
+  )
+
+  e2e.open_eda(dir_child, dir_tmp)
+
+  -- Move cursor to "sub" line and expand via select action
+  e2e.wait_until(
+    dir_child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for i, l in ipairs(lines) do
+      if l:find("sub", 1, true) then
+        vim.api.nvim_win_set_cursor(0, {i, 0})
+        return true
+      end
+    end
+    return false
+  ]]
+  )
+
+  e2e.exec(
+    dir_child,
+    [[
+    local action = require("eda.action")
+    local eda = require("eda")
+    local explorer = eda.get_current()
+    local ctx = {
+      store = explorer.store,
+      buffer = explorer.buffer,
+      window = explorer.window,
+      scanner = explorer.scanner,
+      config = require("eda.config").get(),
+      explorer = explorer,
+    }
+    action.dispatch("select", ctx)
+  ]]
+  )
+
+  -- Wait for sub to be open in main buffer (its child x.txt becomes visible there)
+  e2e.wait_until(
+    dir_child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, l in ipairs(lines) do
+      if l:find("x.txt", 1, true) then return true end
+    end
+    return false
+  ]],
+    5000
+  )
+
+  -- Re-position cursor onto "sub" (still open) so preview targets the sub node
+  e2e.wait_until(
+    dir_child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for i, l in ipairs(lines) do
+      if l:find("sub", 1, true) and not l:find("x.txt", 1, true) then
+        vim.api.nvim_win_set_cursor(0, {i, 0})
+        return true
+      end
+    end
+    return false
+  ]]
+  )
+
+  -- Preview window should show the expanded subtree (x.txt visible)
+  e2e.wait_until(
+    dir_child,
+    [[
+    local main_buf = vim.api.nvim_get_current_buf()
+    local wins = vim.api.nvim_list_wins()
+    for _, w in ipairs(wins) do
+      local buf = vim.api.nvim_win_get_buf(w)
+      if buf ~= main_buf then
+        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+        for _, l in ipairs(lines) do
+          if l:find("x.txt", 1, true) then return true end
+        end
+      end
+    end
+    return false
+  ]],
+    5000
+  )
+end
+
 -- max_file_size tests
 local mfs_child, mfs_tmp
 

--- a/tests/preview/test_preview.lua
+++ b/tests/preview/test_preview.lua
@@ -1,8 +1,51 @@
 local Preview = require("eda.preview")
 local config = require("eda.config")
 local helpers = require("helpers")
+local Store = require("eda.tree.store")
+local Scanner = require("eda.tree.scanner")
+local decorator_mod = require("eda.render.decorator")
 
 local T = MiniTest.new_set()
+
+-- Build a Store + Scanner + decorator chain rooted at `root_path`, mirroring
+-- the production decorator chain in lua/eda/init.lua. Returns store, scanner,
+-- chain, and a callback-style scan-root to await initial scan completion.
+local function build_tree_deps(root_path, cfg)
+  local store = Store.new()
+  store:set_root(root_path)
+  local scanner = Scanner.new(store, cfg)
+  local chain = decorator_mod.Chain.new()
+  chain:add(decorator_mod.icon_decorator)
+  chain:add(decorator_mod.symlink_decorator)
+  if cfg.git and cfg.git.enabled then
+    chain:add(decorator_mod.dotgit_decorator)
+    chain:add(decorator_mod.git_decorator)
+  end
+  chain:add(decorator_mod.cut_decorator)
+  chain:add(decorator_mod.mark_decorator)
+  return store, scanner, chain
+end
+
+-- Helper: synchronously scan a directory node and wait for completion (test only).
+local function scan_sync(scanner, node_id, timeout_ms)
+  local done = false
+  scanner:scan(node_id, function()
+    done = true
+  end)
+  helpers.wait_for(timeout_ms or 2000, function()
+    return done
+  end)
+  return done
+end
+
+-- Helper: build a buffer of preview body lines (excluding the painter header).
+local function preview_body_lines(p)
+  if not p.bufnr or not vim.api.nvim_buf_is_valid(p.bufnr) then
+    return {}
+  end
+  local offset = p.painter and p.painter.header_lines or 0
+  return vim.api.nvim_buf_get_lines(p.bufnr, offset, -1, false)
+end
 
 -- Helper: create a float window simulating the filer
 local function open_filer_float(cfg)
@@ -256,7 +299,7 @@ T["Preview scroll_page_up returns false when hidden"] = function()
   MiniTest.expect.equality(p:scroll_page_up(), false)
 end
 
-T["Preview _current_path tracks shown file"] = function()
+T["Preview _current_target tracks shown file"] = function()
   config.setup()
   local cfg = config.get()
   cfg.preview.enabled = true
@@ -269,15 +312,15 @@ T["Preview _current_path tracks shown file"] = function()
   p:attach(mock_window)
   p:show(test_file)
   helpers.wait_for(1000, function()
-    return p._current_path ~= nil
+    return p._current_target ~= nil
   end)
-  MiniTest.expect.equality(p._current_path, test_file)
+  MiniTest.expect.equality(p._current_target, test_file)
   p:close()
   cleanup({ { win = filer_winid, buf = filer_buf } })
   helpers.remove_temp_dir(temp_dir)
 end
 
-T["Preview _pending_path is set synchronously"] = function()
+T["Preview _pending_target is set synchronously"] = function()
   config.setup()
   local cfg = config.get()
   cfg.preview.enabled = true
@@ -289,7 +332,7 @@ T["Preview _pending_path is set synchronously"] = function()
   local mock_window = { winid = filer_winid, kind = "split_left", config = cfg }
   p:attach(mock_window)
   p:show(test_file)
-  MiniTest.expect.equality(p._pending_path, test_file)
+  MiniTest.expect.equality(p._pending_target, test_file)
   helpers.wait_for(1000, function()
     return p.winid ~= nil
   end)
@@ -320,6 +363,233 @@ T["Preview scroll returns true when visible"] = function()
   p:close()
   cleanup({ { win = filer_winid, buf = filer_buf } })
   helpers.remove_temp_dir(temp_dir)
+end
+
+-- PR-D1: closed directory preview shows direct children only (1 level deep).
+T["PR-D1 closed dir preview shows 1 level"] = function()
+  config.setup()
+  local cfg = config.get()
+  cfg.preview.enabled = true
+  cfg.git.enabled = false
+  local p = Preview.new(cfg.preview)
+
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_dir(tmp .. "/sub/b")
+  helpers.create_file(tmp .. "/sub/a.txt", "alpha")
+  helpers.create_file(tmp .. "/sub/b/c.txt", "grandchild")
+
+  local store, scanner, chain = build_tree_deps(tmp, cfg)
+  scan_sync(scanner, store.root_id)
+  local sub_node = store:get_by_path(tmp .. "/sub")
+  MiniTest.expect.no_equality(sub_node, nil)
+  scan_sync(scanner, sub_node.id) -- one level: sub is loaded; sub/b remains unloaded
+
+  local filer_winid, filer_buf = open_filer_split(cfg)
+  local mock_window = { winid = filer_winid, kind = "split_left", config = cfg }
+  p:attach(mock_window, { store = store, scanner = scanner, decorator_chain = chain })
+  p:show_directory(sub_node)
+  helpers.wait_for(2000, function()
+    return p.winid ~= nil
+  end)
+
+  MiniTest.expect.equality(p.winid ~= nil, true)
+  local body = preview_body_lines(p)
+  local joined = table.concat(body, "\n")
+  MiniTest.expect.equality(joined:find("a.txt", 1, true) ~= nil, true)
+  MiniTest.expect.equality(joined:find("b/", 1, true) ~= nil, true)
+  -- Grandchild must not be visible (sub/b is unloaded)
+  MiniTest.expect.equality(joined:find("c.txt", 1, true), nil)
+
+  p:close()
+  cleanup({ { win = filer_winid, buf = filer_buf } })
+  helpers.remove_temp_dir(tmp)
+end
+
+-- PR-D2: open directory preview mirrors the main tree's expanded subtree.
+T["PR-D2 open dir preview mirrors expanded subtree"] = function()
+  config.setup()
+  local cfg = config.get()
+  cfg.preview.enabled = true
+  cfg.git.enabled = false
+  local p = Preview.new(cfg.preview)
+
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_dir(tmp .. "/sub/b")
+  helpers.create_dir(tmp .. "/sub/d")
+  helpers.create_file(tmp .. "/sub/a.txt", "alpha")
+  helpers.create_file(tmp .. "/sub/b/c.txt", "beta-child")
+  helpers.create_file(tmp .. "/sub/d/e.txt", "delta-child")
+
+  local store, scanner, chain = build_tree_deps(tmp, cfg)
+  scan_sync(scanner, store.root_id)
+  local sub = store:get_by_path(tmp .. "/sub")
+  scan_sync(scanner, sub.id)
+  local sub_b = store:get_by_path(tmp .. "/sub/b")
+  scan_sync(scanner, sub_b.id)
+  local sub_d = store:get_by_path(tmp .. "/sub/d")
+  scan_sync(scanner, sub_d.id)
+
+  -- Mark sub and sub/b as open; sub/d remains closed
+  sub.open = true
+  sub_b.open = true
+
+  local filer_winid, filer_buf = open_filer_split(cfg)
+  local mock_window = { winid = filer_winid, kind = "split_left", config = cfg }
+  p:attach(mock_window, { store = store, scanner = scanner, decorator_chain = chain })
+  p:show_directory(sub)
+  helpers.wait_for(2000, function()
+    return p.winid ~= nil
+  end)
+
+  local body = preview_body_lines(p)
+  local joined = table.concat(body, "\n")
+  -- Open subtree expanded: a.txt, b/, c.txt visible
+  MiniTest.expect.equality(joined:find("a.txt", 1, true) ~= nil, true)
+  MiniTest.expect.equality(joined:find("b/", 1, true) ~= nil, true)
+  MiniTest.expect.equality(joined:find("c.txt", 1, true) ~= nil, true)
+  -- Closed sibling d/ visible but its children are not
+  MiniTest.expect.equality(joined:find("d/", 1, true) ~= nil, true)
+  MiniTest.expect.equality(joined:find("e.txt", 1, true), nil)
+
+  p:close()
+  cleanup({ { win = filer_winid, buf = filer_buf } })
+  helpers.remove_temp_dir(tmp)
+end
+
+-- PR-D3: file → dir → file transition leaves no stale filetype or painter state.
+T["PR-D3 file dir file transition cleans state"] = function()
+  config.setup()
+  local cfg = config.get()
+  cfg.preview.enabled = true
+  cfg.git.enabled = false
+  local p = Preview.new(cfg.preview)
+
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/x.lua", "local M = {}\nreturn M\n")
+  helpers.create_dir(tmp .. "/sub")
+  helpers.create_file(tmp .. "/sub/inside.txt", "hi")
+
+  local store, scanner, chain = build_tree_deps(tmp, cfg)
+  scan_sync(scanner, store.root_id)
+  local sub = store:get_by_path(tmp .. "/sub")
+  scan_sync(scanner, sub.id)
+
+  local filer_winid, filer_buf = open_filer_split(cfg)
+  local mock_window = { winid = filer_winid, kind = "split_left", config = cfg }
+  p:attach(mock_window, { store = store, scanner = scanner, decorator_chain = chain })
+
+  -- 1) File first → filetype lua
+  p:show(tmp .. "/x.lua")
+  helpers.wait_for(2000, function()
+    return p.winid ~= nil
+  end)
+  MiniTest.expect.equality(vim.bo[p.bufnr].filetype, "lua")
+
+  -- 2) Switch to directory → filetype cleared, painter populated
+  p:show_directory(sub)
+  helpers.wait_for(1000, function()
+    return p.painter and #p.painter._flat_lines > 0
+  end)
+  MiniTest.expect.equality(vim.bo[p.bufnr].filetype, "")
+  MiniTest.expect.equality(#p.painter._flat_lines > 0, true)
+
+  -- 3) Switch back to file → painter state cleared, no icon extmarks
+  p:show(tmp .. "/x.lua")
+  helpers.wait_for(2000, function()
+    return vim.bo[p.bufnr].filetype == "lua"
+  end)
+  MiniTest.expect.equality(#p.painter._flat_lines, 0)
+  local icon_marks = vim.api.nvim_buf_get_extmarks(p.bufnr, p.painter.ns_icon, 0, -1, {})
+  MiniTest.expect.equality(#icon_marks, 0)
+
+  p:close()
+  cleanup({ { win = filer_winid, buf = filer_buf } })
+  helpers.remove_temp_dir(tmp)
+end
+
+-- PR-D4: closed dir whose children_state is "unloaded" triggers an async scan
+-- and renders once the scan settles.
+T["PR-D4 closed dir async scan path"] = function()
+  config.setup()
+  local cfg = config.get()
+  cfg.preview.enabled = true
+  cfg.git.enabled = false
+  local p = Preview.new(cfg.preview)
+
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_dir(tmp .. "/sub")
+  helpers.create_file(tmp .. "/sub/x.txt", "x")
+
+  local store, scanner, chain = build_tree_deps(tmp, cfg)
+  scan_sync(scanner, store.root_id)
+  local sub = store:get_by_path(tmp .. "/sub")
+  MiniTest.expect.no_equality(sub, nil)
+  -- Sub has not been scanned yet → children_state must be "unloaded"
+  MiniTest.expect.equality(sub.children_state, "unloaded")
+
+  local filer_winid, filer_buf = open_filer_split(cfg)
+  local mock_window = { winid = filer_winid, kind = "split_left", config = cfg }
+  p:attach(mock_window, { store = store, scanner = scanner, decorator_chain = chain })
+
+  p:show_directory(sub)
+  helpers.wait_for(3000, function()
+    return p.winid ~= nil
+  end)
+
+  MiniTest.expect.equality(p.winid ~= nil, true)
+  local body = preview_body_lines(p)
+  local joined = table.concat(body, "\n")
+  MiniTest.expect.equality(joined:find("x.txt", 1, true) ~= nil, true)
+  -- Side-effect: main store now has the dir loaded (user accepted this in /plan).
+  MiniTest.expect.equality(store:get(sub.id).children_state, "loaded")
+
+  p:close()
+  cleanup({ { win = filer_winid, buf = filer_buf } })
+  helpers.remove_temp_dir(tmp)
+end
+
+-- PR-D5: debounce keeps only the latest update target — switching from a file
+-- to a dir within the debounce window must render the dir, not the file.
+T["PR-D5 debounce target switch keeps latest"] = function()
+  config.setup()
+  local cfg = config.get()
+  cfg.preview.enabled = true
+  cfg.preview.debounce = 50
+  cfg.git.enabled = false
+  local p = Preview.new(cfg.preview)
+
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_file(tmp .. "/f.txt", "FILE_CONTENT_MARKER")
+  helpers.create_dir(tmp .. "/sub")
+  helpers.create_file(tmp .. "/sub/a.txt", "alpha")
+
+  local store, scanner, chain = build_tree_deps(tmp, cfg)
+  scan_sync(scanner, store.root_id)
+  local sub = store:get_by_path(tmp .. "/sub")
+  scan_sync(scanner, sub.id)
+  local file_node = store:get_by_path(tmp .. "/f.txt")
+
+  local filer_winid, filer_buf = open_filer_split(cfg)
+  local mock_window = { winid = filer_winid, kind = "split_left", config = cfg }
+  p:attach(mock_window, { store = store, scanner = scanner, decorator_chain = chain })
+
+  -- Fire two updates back-to-back; the dir update is the latest one.
+  p:update(file_node)
+  p:update(sub)
+
+  helpers.wait_for(2000, function()
+    return p.painter and #p.painter._flat_lines > 0
+  end)
+
+  local body = preview_body_lines(p)
+  local joined = table.concat(body, "\n")
+  -- Latest target (sub) rendered; file content marker absent.
+  MiniTest.expect.equality(joined:find("a.txt", 1, true) ~= nil, true)
+  MiniTest.expect.equality(joined:find("FILE_CONTENT_MARKER", 1, true), nil)
+
+  p:close()
+  cleanup({ { win = filer_winid, buf = filer_buf } })
+  helpers.remove_temp_dir(tmp)
 end
 
 return T

--- a/tests/render/test_painter.lua
+++ b/tests/render/test_painter.lua
@@ -1239,4 +1239,40 @@ T["paint_incremental returns false for invalid state"] = function()
   vim.api.nvim_buf_delete(buf, { force = true })
 end
 
+-- PT-R1: Painter:reset clears all internal state and namespace extmarks.
+T["PT-R1 reset clears state and namespaces"] = function()
+  local store, root = build_store()
+  local flat_lines = Flatten.flatten(store, root)
+  local buf = vim.api.nvim_create_buf(false, true)
+  local painter = Painter.new(buf)
+
+  painter:paint(flat_lines, nil, {
+    root_path = "/project",
+    header = { format = "short", divider = false },
+    kind = "split_left",
+  })
+
+  -- Sanity: paint populated state
+  MiniTest.expect.equality(#painter._flat_lines > 0, true)
+  MiniTest.expect.equality(painter._decoration_cache ~= nil, true)
+  MiniTest.expect.equality(painter.header_lines >= 1, true)
+
+  painter:reset()
+
+  -- Internal Lua tables emptied
+  MiniTest.expect.equality(next(painter._flat_lines), nil)
+  MiniTest.expect.equality(next(painter._line_lengths), nil)
+  MiniTest.expect.equality(next(painter._row_to_fl), nil)
+  MiniTest.expect.equality(next(painter._decoration_cache), nil)
+  MiniTest.expect.equality(next(painter.snapshot.entries), nil)
+  MiniTest.expect.equality(painter.header_lines, 0)
+
+  -- Namespace extmarks cleared (ns_hl is ephemeral; not asserted here).
+  MiniTest.expect.equality(#vim.api.nvim_buf_get_extmarks(buf, painter.ns_ids, 0, -1, {}), 0)
+  MiniTest.expect.equality(#vim.api.nvim_buf_get_extmarks(buf, painter.ns_icon, 0, -1, {}), 0)
+  MiniTest.expect.equality(#vim.api.nvim_buf_get_extmarks(buf, painter.ns_header, 0, -1, {}), 0)
+
+  vim.api.nvim_buf_delete(buf, { force = true })
+end
+
 return T

--- a/tests/tree/test_scanner.lua
+++ b/tests/tree/test_scanner.lua
@@ -1,5 +1,6 @@
 local Store = require("eda.tree.store")
 local Scanner = require("eda.tree.scanner")
+local helpers = require("helpers")
 
 local T = MiniTest.new_set()
 
@@ -21,16 +22,65 @@ T["scan rejects non-directory"] = function()
   MiniTest.expect.equality(err_msg, "not a directory")
 end
 
-T["scan rejects already scanning"] = function()
+T["scan coalesces callback when already scanning"] = function()
   local store = Store.new()
   local id = store:add({ name = "d", path = "/nonexistent_dir_for_test", type = "directory" })
   local scanner = Scanner.new(store)
   scanner._scanning[id] = true
-  local err_msg
-  scanner:scan(id, function(err)
-    err_msg = err
+  local fired = false
+  scanner:scan(id, function()
+    fired = true
   end)
-  MiniTest.expect.equality(err_msg, "already scanning")
+  -- Callback must NOT fire synchronously when a scan is already in flight.
+  -- It is queued in the waiter list and would fire when the original scan settles.
+  MiniTest.expect.equality(fired, false)
+  MiniTest.expect.equality(type(scanner._waiters), "table")
+  MiniTest.expect.equality(#scanner._waiters[id], 1)
+end
+
+-- SC-W1: two parallel scan calls on the same node both observe completion.
+T["SC-W1 two parallel scans both observe completion"] = function()
+  local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+  helpers.create_dir(tmp .. "/dir")
+  helpers.create_file(tmp .. "/dir/a.txt", "a")
+  helpers.create_file(tmp .. "/dir/b.txt", "b")
+
+  local store = Store.new()
+  store:set_root(tmp)
+  local scanner = Scanner.new(store)
+
+  -- Scan root first so the dir node exists in the store
+  local root_done = false
+  scanner:scan(store.root_id, function()
+    root_done = true
+  end)
+  helpers.wait_for(2000, function()
+    return root_done
+  end)
+
+  local dir_node = store:get_by_path(tmp .. "/dir")
+  MiniTest.expect.no_equality(dir_node, nil)
+
+  -- Two parallel scan calls before settle. The second is queued as a waiter and
+  -- must observe completion after the first scan settles.
+  local first_fired = false
+  local second_fired = false
+  scanner:scan(dir_node.id, function()
+    first_fired = true
+  end)
+  scanner:scan(dir_node.id, function()
+    second_fired = true
+  end)
+
+  helpers.wait_for(5000, function()
+    return first_fired and second_fired
+  end)
+
+  MiniTest.expect.equality(first_fired, true)
+  MiniTest.expect.equality(second_fired, true)
+  MiniTest.expect.equality(dir_node.children_state, "loaded")
+
+  helpers.remove_temp_dir(tmp)
 end
 
 T["_apply_entries populates store"] = function()
@@ -78,8 +128,6 @@ T["_apply_entries replaces old children"] = function()
   MiniTest.expect.equality(#store:children(root_id), 2)
   MiniTest.expect.equality(store:get_by_path("/tmp/test_replace/old.lua"), nil)
 end
-
-local helpers = require("helpers")
 
 T["scan_open_unloaded iteratively scans 3-level nested directories"] = function()
   local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())


### PR DESCRIPTION
## Summary

Render the preview pane for directory targets using eda's existing tree pipeline (Painter + decorator chain) so the user gets a tree-aware preview when hovering directory entries. File preview keeps filetype-based highlighting unchanged.

- **Closed directory at cursor**: preview shows the directory's direct children only (1 level deep).
- **Open directory at cursor**: preview mirrors the main tree's expanded subtree for that directory.
- **File at cursor**: unchanged (filetype-based highlighting).

The implementation reuses the main store, the same `Scanner`, and the same decorator chain so the preview matches the main tree's look exactly (icons, git status, marks, symlinks, cut/dim).

### Implementation notes

- `Preview:attach(window, deps)` accepts an optional `{ store, scanner, decorator_chain }` and gains `show_directory(node)` / `_render_directory(node)`. `update(node)` routes directories to the new path and files to the existing one. Internal `_pending_path` / `_current_path` are unified into `_pending_target` / `_current_target` (integer node id for dir mode, string path for file mode).
- `Painter:reset()` clears `ns_icon` / `ns_ids` / `ns_header` extmarks and resets cached state. Called by the preview when switching between file and directory render modes so no stale extmarks or filetype leak across transitions.
- `Scanner:scan` coalesces concurrent callbacks via a per-node `_waiters` list and a new `_settle` helper that drains waiters in both completion paths (success and permission-denied). Previously, a second `scan()` on an in-flight node fired its callback synchronously with `"already scanning"` and missed the actual settlement; the preview's async path now reliably observes scan completion even under concurrent main-tree scans.
- `lua/eda/init.lua`: passes `{ store, scanner, decorator_chain }` to `preview:attach`.
- Documentation: new paragraph under `### preview` describing the directory behavior; vimdoc regenerated.

### Tests

- Unit (`tests/`): `SC-W1` (scanner waiter coalescing), `PT-R1` (painter reset), `PR-D1` (closed-dir 1 level), `PR-D2` (open-dir mirror), `PR-D3` (file ↔ dir transition cleanup), `PR-D4` (async closed-dir scan), `PR-D5` (debounce target switch). Existing scanner test for the old `"already scanning"` contract was rewritten for the new coalesce contract; preview tests for the renamed fields were updated.
- E2E (`tests/e2e/test_preview.lua`): `PR-D-E1` cursor on closed dir → preview shows children, `PR-D-E2` cursor on open dir after expand → preview mirrors expanded subtree.

`just format-check`, `just lint`, `just typecheck`, `just test`, `just test-e2e` all green.

## References

- n/a
