### PR TITLE
fix: disable swapfile on eda buffer to prevent E325/E95 conflict

### DIFF
--- a/lua/eda/buffer/init.lua
+++ b/lua/eda/buffer/init.lua
@@ -20,6 +20,10 @@ Buffer.__index = Buffer
 ---@return eda.Buffer
 function Buffer.new(root_path, config, instance_id)
   local bufnr = vim.api.nvim_create_buf(false, false)
+  -- Disable swap before set_name: prevents E325/E95 when another nvim has the same
+  -- eda://<path> buffer active, or when a stale swap file remains on disk from a crash.
+  vim.bo[bufnr].swapfile = false
+
   local name = "eda://" .. root_path
   if instance_id then
     name = name .. "#" .. instance_id
@@ -31,6 +35,8 @@ function Buffer.new(root_path, config, instance_id)
   for k, v in pairs(config.window.buf_opts) do
     vim.bo[bufnr][k] = v
   end
+  -- Re-enforce after buf_opts: a user-supplied swapfile=true must not re-enable swap.
+  vim.bo[bufnr].swapfile = false
 
   -- Sync Neovim indent options with tree indent width so that native
   -- indent operations (>>, <<, <Tab>) match the visual tree indentation.

--- a/tests/buffer/test_buffer.lua
+++ b/tests/buffer/test_buffer.lua
@@ -9,7 +9,24 @@ T["new creates buffer with correct options"] = function()
   local buf = Buffer.new("/tmp/test_project", config.get())
   MiniTest.expect.equality(vim.bo[buf.bufnr].filetype, "eda")
   MiniTest.expect.equality(vim.bo[buf.bufnr].buftype, "acwrite")
+  MiniTest.expect.equality(vim.bo[buf.bufnr].swapfile, false)
   buf:destroy()
+end
+
+T["new disables swapfile even if user sets buf_opts.swapfile=true"] = function()
+  config.setup({
+    window = {
+      buf_opts = {
+        filetype = "eda",
+        buftype = "acwrite",
+        swapfile = true,
+      },
+    },
+  })
+  local buf = Buffer.new("/tmp/test_project_swap_override", config.get())
+  MiniTest.expect.equality(vim.bo[buf.bufnr].swapfile, false)
+  buf:destroy()
+  config.setup()
 end
 
 T["new sets buffer name"] = function()

--- a/tests/e2e/test_multi_instance.lua
+++ b/tests/e2e/test_multi_instance.lua
@@ -64,4 +64,46 @@ T["multi instance"]["split action creates two independent explorers"] = function
   MiniTest.expect.equality(both_eda, true)
 end
 
+local child_a, child_b, shared_tmp
+
+T["cross-process swap conflict"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      shared_tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_file(shared_tmp .. "/file.txt", "hello")
+      child_a = e2e.spawn()
+      e2e.setup_eda(child_a)
+      child_b = e2e.spawn()
+      e2e.setup_eda(child_b)
+    end,
+    post_case = function()
+      e2e.stop(child_a)
+      e2e.stop(child_b)
+      e2e.remove_temp_dir(shared_tmp)
+    end,
+  },
+})
+
+T["cross-process swap conflict"]["two child neovims open eda in the same directory without swap conflict"] = function()
+  -- child_a opens eda first; without the fix this creates a swap file at
+  -- ~/.local/state/nvim/swap/eda:%%%<encoded-path>.swp.
+  e2e.open_eda(child_a, shared_tmp)
+
+  -- child_b opens eda in the same directory while child_a is still alive.
+  -- Without the fix, nvim_buf_set_name triggers swap-file detection and raises
+  -- E325 ATTENTION (which can surface to the user as E95 after the dialog flow).
+  e2e.open_eda(child_b, shared_tmp)
+
+  -- Both children must end up with a valid eda buffer and swapfile disabled.
+  local a_swap = e2e.exec(child_a, "return vim.bo[require('eda').get_current().buffer.bufnr].swapfile")
+  local b_swap = e2e.exec(child_b, "return vim.bo[require('eda').get_current().buffer.bufnr].swapfile")
+  MiniTest.expect.equality(a_swap, false)
+  MiniTest.expect.equality(b_swap, false)
+
+  local a_ft = e2e.exec(child_a, "return vim.bo[require('eda').get_current().buffer.bufnr].filetype")
+  local b_ft = e2e.exec(child_b, "return vim.bo[require('eda').get_current().buffer.bufnr].filetype")
+  MiniTest.expect.equality(a_ft, "eda")
+  MiniTest.expect.equality(b_ft, "eda")
+end
+
 return T


### PR DESCRIPTION
## Summary

Two Neovim processes opening eda in the same directory hit `Vim:E95: Buffer with this name already exists` from `nvim_buf_set_name` (surfaced from `E325 ATTENTION` on swap-file detection).

The eda buffer is named `eda://<absolute-path>` and `buf_opts` only sets `buftype = "acwrite"`, which does not suppress swap files. Process A creates `~/.local/state/nvim/swap/eda:%%%<encoded-path>.swp`, then process B's `nvim_buf_set_name` matches the existing swap and raises E325 (E95 in some interactive flows).

`Buffer.new` now sets `vim.bo[bufnr].swapfile = false` twice:

1. Immediately after `nvim_create_buf` and **before** `nvim_buf_set_name`, so swap-file detection is skipped on cross-process / stale-swap collisions.
2. Immediately after the `buf_opts` apply loop, so a user-supplied `buf_opts.swapfile = true` cannot re-enable swap.

Tests added:

- `tests/buffer/test_buffer.lua` — basic invariant (`swapfile == false` after `Buffer.new`) plus the user-override defense (`buf_opts.swapfile = true` is overridden).
- `tests/e2e/test_multi_instance.lua` — `T["cross-process swap conflict"]` spawns two child Neovims sharing one realpath tmp directory, opens eda in both, and asserts each ends up with `swapfile = false` and `filetype = "eda"`.

## References

- n/a
