### PR TITLE
fix(e2e): stabilize flaky tests with deterministic observation helpers

### DIFF
--- a/lua/eda/buffer/init.lua
+++ b/lua/eda/buffer/init.lua
@@ -172,13 +172,24 @@ function Buffer:get_cursor_node(winid)
   end
 
   -- Buffer is modified: use extmarks to find the node at the cursor row.
-  -- Extmarks track line shifts from insert/delete operations.
-  local marks = vim.api.nvim_buf_get_extmarks(self.bufnr, self.painter.ns_ids, { row - 1, 0 }, { row - 1, 0 }, {})
-  if #marks > 0 then
-    local node_id = marks[1][1]
-    for _, f in ipairs(self.flat_lines) do
-      if f.node_id == node_id then
-        return f.node
+  -- Extmarks track line shifts from insert/delete operations. We must request
+  -- `details = true` so we can skip extmarks whose underlying line was replaced
+  -- (those report `invalid = true` per the same convention used in
+  -- Painter:_resync_on_redraw).
+  local marks = vim.api.nvim_buf_get_extmarks(
+    self.bufnr,
+    self.painter.ns_ids,
+    { row - 1, 0 },
+    { row - 1, 0 },
+    { details = true }
+  )
+  for _, m in ipairs(marks) do
+    if not (m[4] and m[4].invalid) then
+      local node_id = m[1]
+      for _, f in ipairs(self.flat_lines) do
+        if f.node_id == node_id then
+          return f.node
+        end
       end
     end
   end

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -748,6 +748,11 @@ function M.open(opts)
       edit_preserve.replay(buf.bufnr, buf.painter, capture, st)
       buf.flat_lines = buf.painter._flat_lines
     end
+    -- Fire after the full edit-preserve cycle (paint + optional replay) so
+    -- consumers can wait for the FINAL post-replay buffer state. Without this
+    -- signal, observing the snapshot or buffer mid-cycle yields inconsistent
+    -- views (e.g., new children visible but user-deleted lines not yet replayed).
+    fire_event("EdaRenderComplete", { mode = "preserving" })
   end
   explorer._render_preserving_edits = render_preserving_edits
 

--- a/tests/e2e/helpers.lua
+++ b/tests/e2e/helpers.lua
@@ -46,12 +46,16 @@ end
 
 ---Poll the child Neovim until a Lua predicate returns truthy.
 ---Uses vim.uv.sleep() instead of vim.wait() to avoid pumping the parent event loop.
+---Default timeout is 10000ms: e2e tests must absorb spikes from a heavily loaded
+---runner (Ubuntu GHA, parallel local runs) where the scan + paint chain can
+---legitimately exceed 5s. Per-call sites that need a tighter ceiling can pass
+---an explicit timeout_ms.
 ---@param child table child object from MiniTest.new_child_neovim()
 ---@param predicate_lua string Lua expression evaluated in the child Neovim
----@param timeout_ms? integer Maximum wait time (default 5000)
+---@param timeout_ms? integer Maximum wait time (default 10000)
 ---@param interval_ms? integer Poll interval (default 50)
 function M.wait_until(child, predicate_lua, timeout_ms, interval_ms)
-  timeout_ms = timeout_ms or 5000
+  timeout_ms = timeout_ms or 10000
   interval_ms = interval_ms or 50
   local deadline = vim.uv.hrtime() + timeout_ms * 1e6
 
@@ -136,6 +140,113 @@ end
 ---@return integer
 function M.get_tab_count(child)
   return M.exec(child, "return #vim.api.nvim_list_tabpages()")
+end
+
+---Wait until the node at `path` has been scanned (children_state == "loaded").
+---Source of truth: lua/eda/tree/scanner.lua sets "loaded" on completion.
+---@param child table child object from MiniTest.new_child_neovim()
+---@param path string Absolute path of the node to wait for
+---@param timeout_ms? integer Maximum wait time (default 5000)
+function M.wait_for_node_loaded(child, path, timeout_ms)
+  M.wait_until(
+    child,
+    string.format(
+      [[
+    local ok, eda = pcall(require, "eda")
+    if not ok then return false end
+    local explorer = eda.get_current()
+    if not explorer then return false end
+    local node = explorer.store:get_by_path(%q)
+    return node ~= nil and node.children_state == "loaded"
+  ]],
+      path
+    ),
+    timeout_ms
+  )
+end
+
+---Wait until a node with the given path is rendered (present in painter snapshot).
+---Source of truth: lua/eda/render/painter.lua:get_snapshot returns
+---{ entries = { [node_id] = { line, path } } }.
+---@param child table child object from MiniTest.new_child_neovim()
+---@param path string Absolute path of the rendered node to wait for
+---@param timeout_ms? integer Maximum wait time (default 5000)
+function M.wait_for_path_in_snapshot(child, path, timeout_ms)
+  M.wait_until(
+    child,
+    string.format(
+      [[
+    local ok, eda = pcall(require, "eda")
+    if not ok then return false end
+    local explorer = eda.get_current()
+    if not (explorer and explorer.buffer and explorer.buffer.painter) then return false end
+    local snap = explorer.buffer.painter:get_snapshot()
+    for _, entry in pairs(snap.entries or {}) do
+      if entry.path == %q then return true end
+    end
+    return false
+  ]],
+      path
+    ),
+    timeout_ms
+  )
+end
+
+---Press `<CR>` (the default eda `select` mapping) and wait for the full
+---edit-preserve render cycle (paint + optional replay) to complete. Driven
+---by the `User EdaRenderComplete` event fired in lua/eda/init.lua at the
+---tail of `render_preserving_edits`. Uses a persistent counter rather than a
+---one-shot autocmd: a stray event that fires between `arm` and `<CR>` still
+---bumps the counter, but the wait_until requires the counter to advance from
+---the snapshot taken AFTER `<CR>` is queued, so the dispatch we care about is
+---always observed.
+---@param child table child object from MiniTest.new_child_neovim()
+function M.expand_and_wait_for_render(child)
+  M.exec(
+    child,
+    [[
+    if not vim.g._eda_test_render_count_setup then
+      vim.g._eda_test_render_count = 0
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "EdaRenderComplete",
+        callback = function()
+          vim.g._eda_test_render_count = (vim.g._eda_test_render_count or 0) + 1
+        end,
+      })
+      vim.g._eda_test_render_count_setup = true
+    end
+  ]]
+  )
+  local before = M.exec(child, "return vim.g._eda_test_render_count or 0")
+  M.feed(child, "<CR>")
+  M.wait_until(child, string.format("vim.g._eda_test_render_count > %d", before))
+end
+
+---Set up a one-shot User autocmd that flips vim.g[flag_var] to true on fire.
+---Caller invokes BEFORE dispatching the trigger action, then waits with
+---wait_until(child, "vim.g[flag_var] == true") AFTER the dispatch.
+---event must match a fire_event site in lua/eda/init.lua, e.g. EdaTreeOpen,
+---EdaRootChanged, EdaTreeClose, EdaMutationPre, EdaMutationPost.
+---@param child table child object from MiniTest.new_child_neovim()
+---@param event string User autocmd pattern (e.g. "EdaRootChanged")
+---@param flag_var string Name of the vim.g key used as the completion flag
+function M.arm_user_event(child, event, flag_var)
+  M.exec(
+    child,
+    string.format(
+      [[
+    vim.g[%q] = false
+    vim.api.nvim_create_autocmd("User", {
+      pattern = %q,
+      once = true,
+      callback = function() vim.g[%q] = true end,
+    })
+  ]],
+      flag_var,
+      event,
+      flag_var
+    )
+  )
 end
 
 ---Initialize a git repository in the given directory.

--- a/tests/e2e/test_clipboard.lua
+++ b/tests/e2e/test_clipboard.lua
@@ -296,8 +296,11 @@ T["clipboard"]["paste does not overwrite existing _copy file"] = function()
   -- Paste with gp — collision should NOT overwrite source_copy.txt
   e2e.feed(child, "gp")
 
-  -- Wait for paste to complete (some file is created)
-  vim.uv.sleep(3000)
+  -- Wait for the paste to complete by observing register.clear() at the end of
+  -- the on_done chain (lua/eda/action/builtin.lua:1169 — only runs after all
+  -- copy callbacks land with no errors). This is more deterministic than a
+  -- fixed sleep and avoids fs_stat (the renamed dst path is not predictable).
+  e2e.wait_until(child, [[return require("eda.register").get() == nil]], 5000)
 
   -- The original source_copy.txt should still have "original_copy" content
   local content = vim.fn.readfile(tmp .. "/dest/source_copy.txt")

--- a/tests/e2e/test_config_options.lua
+++ b/tests/e2e/test_config_options.lua
@@ -366,8 +366,7 @@ T["follow_symlinks"]["follow_symlinks=false shows symlink as non-directory"] = f
   )
 
   e2e.feed(sym_child, "<CR>")
-  -- Brief wait to let any expansion attempt settle
-  vim.uv.sleep(200)
+  vim.uv.sleep(200) -- e2e-sleep-allowed: negative-assertion guard (symlink <CR> must not expand in eda buffer)
 
   -- Line count should remain the same (no expansion occurred in eda buffer)
   local eda_line_count = e2e.exec(

--- a/tests/e2e/test_edit_preserve.lua
+++ b/tests/e2e/test_edit_preserve.lua
@@ -76,21 +76,10 @@ T["edit preserving repaint"]["select toggle preserves inserted line"] = function
   -- Verify buffer is modified
   MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified"), true)
 
-  -- Toggle dir_b (a different directory) open via select
+  -- Toggle dir_b (a different directory) open via select; wait for the full
+  -- edit-preserve cycle (paint + replay) to complete.
   move_to_line(child, "dir_b/")
-  e2e.feed(child, "<CR>")
-
-  -- Wait for dir_b's child to appear (toggle succeeded)
-  e2e.wait_until(
-    child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_b.txt") then return true end
-    end
-    return false
-  ]]
-  )
+  e2e.expand_and_wait_for_render(child)
 
   -- The inserted new_entry.txt line should still exist
   MiniTest.expect.equality(buf_has_line(child, "new_entry.txt"), true)
@@ -109,21 +98,9 @@ T["edit preserving repaint"]["multiple consecutive creates preserve order"] = fu
   e2e.feed(child, "o")
   e2e.feed_insert(child, "second.txt")
 
-  -- Toggle dir_b open
+  -- Toggle dir_b open; wait for the full edit-preserve cycle (paint + replay).
   move_to_line(child, "dir_b/")
-  e2e.feed(child, "<CR>")
-
-  -- Wait for toggle to complete
-  e2e.wait_until(
-    child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_b.txt") then return true end
-    end
-    return false
-  ]]
-  )
+  e2e.expand_and_wait_for_render(child)
 
   -- Both lines should exist
   MiniTest.expect.equality(buf_has_line(child, "first.txt"), true)
@@ -156,21 +133,9 @@ T["edit preserving repaint"]["select toggle preserves renamed line"] = function(
   e2e.feed(child, "ciw")
   e2e.feed_insert(child, "renamed.txt")
 
-  -- Toggle dir_b open
+  -- Toggle dir_b open; wait for the full edit-preserve cycle (paint + replay).
   move_to_line(child, "dir_b/")
-  e2e.feed(child, "<CR>")
-
-  -- Wait for dir_b's child to appear
-  e2e.wait_until(
-    child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_b.txt") then return true end
-    end
-    return false
-  ]]
-  )
+  e2e.expand_and_wait_for_render(child)
 
   -- renamed.txt should still exist (not reverted to root.txt)
   MiniTest.expect.equality(buf_has_line(child, "renamed.txt"), true)
@@ -184,21 +149,9 @@ T["edit preserving repaint"]["select toggle preserves deleted line"] = function(
   move_to_line(child, "root.txt")
   e2e.feed(child, "dd")
 
-  -- Toggle dir_b open
+  -- Toggle dir_b open; wait for the full edit-preserve cycle (paint + replay).
   move_to_line(child, "dir_b/")
-  e2e.feed(child, "<CR>")
-
-  -- Wait for dir_b's child to appear
-  e2e.wait_until(
-    child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_b.txt") then return true end
-    end
-    return false
-  ]]
-  )
+  e2e.expand_and_wait_for_render(child)
 
   -- root.txt should NOT reappear
   MiniTest.expect.equality(buf_has_line(child, "root.txt"), false)
@@ -215,21 +168,9 @@ T["edit preserving repaint"]["save after toggle works correctly"] = function()
   e2e.feed(child, "o")
   e2e.feed_insert(child, "created.txt")
 
-  -- Toggle a directory to trigger edit-preserving repaint
+  -- Toggle a directory to trigger edit-preserving repaint; wait for the full cycle.
   move_to_line(child, "dir_b/")
-  e2e.feed(child, "<CR>")
-
-  -- Wait for toggle to complete
-  e2e.wait_until(
-    child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_b.txt") then return true end
-    end
-    return false
-  ]]
-  )
+  e2e.expand_and_wait_for_render(child)
 
   -- Save — should create the file on disk
   e2e.feed(child, ":w<CR>")
@@ -247,21 +188,9 @@ T["edit preserving repaint"]["insert after collapsed dir then expand that dir pl
   e2e.feed(child, "o")
   e2e.feed_insert(child, "new_entry.txt")
 
-  -- Expand dir_a/ by moving back to it and pressing <CR>
+  -- Expand dir_a/; wait for the full edit-preserve cycle (paint + replay).
   move_to_line(child, "dir_a/")
-  e2e.feed(child, "<CR>")
-
-  -- Wait for dir_a's child to appear (expansion succeeded)
-  e2e.wait_until(
-    child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_a.txt") then return true end
-    end
-    return false
-  ]]
-  )
+  e2e.expand_and_wait_for_render(child)
 
   -- new_entry.txt should still exist
   MiniTest.expect.equality(buf_has_line(child, "new_entry.txt"), true)
@@ -296,6 +225,7 @@ T["edit preserving repaint"]["clean buffer operations work as before"] = functio
   e2e.feed(child, "<CR>")
 
   -- file_a.txt should appear
+  e2e.wait_for_node_loaded(child, tmp .. "/dir_a")
   e2e.wait_until(
     child,
     [[
@@ -311,16 +241,20 @@ T["edit preserving repaint"]["clean buffer operations work as before"] = functio
   move_to_line(child, "dir_a/")
   e2e.feed(child, "<CR>")
 
-  -- file_a.txt should disappear
+  -- file_a.txt should disappear from the rendered snapshot (dir_a now collapsed).
   e2e.wait_until(
     child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("file_a.txt") then return false end
+    string.format(
+      [[
+    local explorer = require("eda").get_current()
+    local snap = explorer.buffer.painter:get_snapshot()
+    for _, entry in pairs(snap.entries or {}) do
+      if entry.path == %q then return false end
     end
     return true
-  ]]
+  ]],
+      tmp .. "/dir_a/file_a.txt"
+    )
   )
 end
 

--- a/tests/e2e/test_git.lua
+++ b/tests/e2e/test_git.lua
@@ -356,11 +356,32 @@ T["git"]["next_git_change wraps around on repeated presses"] = function()
   end
 
   local seen = {}
+  local prev_name = ""
   for _ = 1, 3 do
     dispatch(child, "next_git_change")
-    local name = wait_for_changed()
+    -- Wait until cursor lands on a changed file AND moves off the previous one.
+    -- Replaces a 100ms post-dispatch sleep — observing the transition itself
+    -- removes the race where the old cursor position is sampled before the
+    -- next dispatch resolves.
+    e2e.wait_until(
+      child,
+      string.format(
+        [[
+      local explorer = require("eda").get_current()
+      local node = explorer.buffer:get_cursor_node(explorer.window.winid)
+      if not node then return false end
+      local on_changed = node.name == "tracked.txt"
+        or node.name == "changed.txt"
+        or node.name == "untracked.txt"
+      return on_changed and node.name ~= %q
+    ]],
+        prev_name
+      ),
+      10000
+    )
+    local name = get_cursor_node_name(child)
     seen[#seen + 1] = name
-    vim.uv.sleep(100)
+    prev_name = name
   end
 
   -- Verify 3 distinct changed files were visited
@@ -421,10 +442,27 @@ T["git"]["next_git_change auto-expands closed dir to reach changed file"] = func
   -- (the target may be tracked.txt or untracked.txt depending on tree order; we just
   -- verify that after enough presses, we land on changed.txt).
   local reached_changed = false
+  local prev_name = get_cursor_node_name(child) or ""
   for _ = 1, 5 do
     e2e.feed(child, "]c")
-    vim.uv.sleep(100)
+    -- Wait until cursor name actually changes (covers both the normal advance
+    -- and the auto-expand-then-advance path). Replaces a 100ms sleep that
+    -- often fired before the auto-expand finished.
+    e2e.wait_until(
+      child,
+      string.format(
+        [[
+      local explorer = require("eda").get_current()
+      local node = explorer.buffer:get_cursor_node(explorer.window.winid)
+      if not node then return false end
+      return node.name ~= %q
+    ]],
+        prev_name
+      ),
+      5000
+    )
     local name = get_cursor_node_name(child)
+    prev_name = name or ""
     if name == "changed.txt" then
       reached_changed = true
       break
@@ -527,7 +565,7 @@ T["git"]["toggle_git_changes rejects non-git directory"] = function()
 
   -- Dispatch toggle_git_changes directly — should be a no-op (filter stays false)
   dispatch(child, "toggle_git_changes")
-  vim.uv.sleep(200)
+  vim.uv.sleep(200) -- e2e-sleep-allowed: negative-assertion guard (no-op toggle in no_repo case must not change show_only_git_changes)
   local is_filter_on = e2e.exec(child, [[return require("eda.config").get().show_only_git_changes]])
   MiniTest.expect.equality(is_filter_on, false)
 

--- a/tests/e2e/test_inspect_float.lua
+++ b/tests/e2e/test_inspect_float.lua
@@ -394,8 +394,7 @@ T["inspect float"]["H: K triggers debug action (no inspect float opened)"] = fun
   cursor_to(child, "sample%.txt")
   -- K should run the debug action, which calls vim.print but does NOT open the inspect float.
   e2e.feed(child, "K")
-  -- Brief sleep to allow any opening to have occurred; then assert count stays at 0.
-  e2e.exec(child, "vim.uv.sleep(50)")
+  e2e.exec(child, "vim.uv.sleep(50)") -- e2e-sleep-allowed: negative-assertion guard (K must not open inspect float)
   MiniTest.expect.equality(inspect_win_count(child), 0)
 end
 

--- a/tests/e2e/test_navigation.lua
+++ b/tests/e2e/test_navigation.lua
@@ -285,8 +285,7 @@ T["navigation"]["parent at filesystem root does not navigate further"] = functio
   -- Press ^ -- should stay at / since there is no parent
   e2e.feed(child, "^")
 
-  -- Small wait to ensure nothing breaks
-  vim.uv.sleep(500)
+  vim.uv.sleep(500) -- e2e-sleep-allowed: negative-assertion guard (parent at fs root must not change root_path)
 
   -- root_path should still be /
   local root_path = e2e.exec(child, [[return require("eda").get_all()[1].root_path]])

--- a/tests/e2e/test_preview.lua
+++ b/tests/e2e/test_preview.lua
@@ -287,18 +287,13 @@ T["dir_preview"]["PR-D-E2 open dir mirror after expand"] = function()
   ]]
   )
 
-  -- Wait for sub to be open in main buffer (its child x.txt becomes visible there)
-  e2e.wait_until(
-    dir_child,
-    [[
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    for _, l in ipairs(lines) do
-      if l:find("x.txt", 1, true) then return true end
-    end
-    return false
-  ]],
-    5000
-  )
+  -- Wait for sub's scan to complete and its child x.txt to be rendered.
+  -- Two-stage observation: scan completion (children_state == "loaded") and render
+  -- completion (snapshot entry for the child path) — both are required because
+  -- refresh_preserving runs through vim.schedule, leaving a window where the scan
+  -- is done but the buffer has not yet been repainted.
+  e2e.wait_for_node_loaded(dir_child, dir_tmp .. "/sub")
+  e2e.wait_for_path_in_snapshot(dir_child, dir_tmp .. "/sub/x.txt")
 
   -- Re-position cursor onto "sub" (still open) so preview targets the sub node
   e2e.wait_until(


### PR DESCRIPTION
## Summary

- Replace buffer-text polling in e2e tests with deterministic observation of production state (`children_state`, painter snapshot, `User Eda*` autocmds), addressing the [#24925357777](https://github.com/wadackel/eda.nvim/actions/runs/24925357777/job/72994301221) PR-D-E2 timeout and a broader pattern of dispatch+scan+render races.
- Two minimal production fixes: `get_cursor_node` now skips invalidated extmarks (mirroring `Painter:_resync_on_redraw`), and `render_preserving_edits` fires `User EdaRenderComplete` so tests can wait for the post-replay state instead of mid-cycle.
- Extends `wait_until` default timeout to 10000ms and tags negative-assertion guard sleeps with inline `e2e-sleep-allowed` markers so a single-line static check enforces the no-completion-signal-sleep rule.

## Behavior fixes

- `lua/eda/buffer/init.lua` — `get_cursor_node` requests `details=true` and skips extmarks with `invalid=true`. Without this, modified buffers (e.g., after several `o` inserts) intermittently returned a stale node from extmark lookup, causing `select` to early-return with no scan.
- `lua/eda/init.lua` — fires `User EdaRenderComplete` at the tail of `render_preserving_edits` so consumers can wait for the FULL paint+replay cycle. Prior to this, observing the buffer or snapshot mid-cycle yielded inconsistent views (e.g., new children visible but user-deleted lines not yet replayed).

## Test infrastructure

`tests/e2e/helpers.lua` adds:
- `wait_for_node_loaded(child, path)` — polls `store:get_by_path(path).children_state == "loaded"`.
- `wait_for_path_in_snapshot(child, path)` — polls `painter:get_snapshot()` entries.
- `arm_user_event(child, event, flag_var)` — registers a one-shot User autocmd before dispatch.
- `expand_and_wait_for_render(child)` — counter-based wait for `EdaRenderComplete` after `<CR>`. Counter pattern is immune to stray events firing between arm and dispatch.
- `wait_until` default timeout 5000 → 10000 ms.

## Per-test changes

| File | Change |
|---|---|
| `test_preview.lua` | PR-D-E2 uses `wait_for_node_loaded` + `wait_for_path_in_snapshot` instead of `string.find` on buffer text |
| `test_edit_preserve.lua` | 6 modified-buffer cases use `expand_and_wait_for_render` to wait for the post-replay buffer state |
| `test_clipboard.lua` | paste-no-overwrite uses `register.get() == nil` as completion signal (paste does not fire `EdaMutationPost`) |
| `test_git.lua` | `next_git_change` / `]c` loops observe cursor name transitions instead of fixed sleeps |
| `test_navigation.lua` / `test_git.lua` / `test_config_options.lua` / `test_inspect_float.lua` | Inline `-- e2e-sleep-allowed: <reason>` markers on negative-assertion guard sleeps |

## Static check

```bash
rg -n 'vim\.uv\.sleep\b' tests/e2e/ | rg -v '^tests/e2e/helpers\.lua' | rg -v 'e2e-sleep-allowed'
# expected: empty
```

## Test plan

- [x] `nix develop --command just format-check` — exit 0
- [x] `nix develop --command just lint` — 0 errors, 0 warnings
- [x] `nix develop --command just typecheck` — no problems found
- [x] `nix develop --command just test` — 597 cases, 0 fails
- [x] `nix develop --command just test-e2e` — 151 cases, 0 fails (single run)
- [x] 20-run stress: best 19/20 (95%), variance 70-95% — variance dominated by system load (test_marks visual-mode race + extreme-load deep timeouts remain as known follow-ups)
- [ ] Validate PR-D-E2 in GHA Ubuntu runner (CI will exercise it)

## Known follow-ups (out of scope)

- `test_marks.lua` visual-mode race (visual key processing vs mark dispatch) — affects "visual mark_toggle inverts mixed state per-node" / "copy action copies all marked nodes" / "mark toggle marks and unmarks a node" at ~5-10% rate.
- `test_edit_preserve.lua` under sustained stress load — `edit_preserve.diff` may fail to classify operations correctly at extreme load.
- PR-D-E2 itself can still time out at 10s under sustained stress (single-test execution is deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
