### PR TITLE
feat: reopen float explorer in replace mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ require("eda").setup({
     ["gp"] = "paste",                -- Paste from register
     ["g?"] = "help",                 -- Show keymap help
     ["ga"] = "actions",              -- Open action picker
+    ["!"] = "open_replace",          -- Reopen float explorer in replace mode
     ["<C-f>"] = "preview_scroll_down", -- Scroll preview down (half page)
     ["<C-b>"] = "preview_scroll_up",   -- Scroll preview up (half page)
     ["<C-w>v"] = "split",            -- Open split pane
@@ -421,6 +422,7 @@ Target resolution is unified across `delete` / `cut` / `copy` / `duplicate`: **V
 | `help` | Show keybinding help in a floating window |
 | `split` | Open the explorer in a new vertical split with the same root |
 | `vsplit` | Open the explorer in a new horizontal split with the same root |
+| `open_replace` | Reopen a float explorer in the previous window using replace layout |
 | `actions` | Open an action picker listing every registered action |
 
 ### Defining Custom Actions

--- a/doc/eda.md
+++ b/doc/eda.md
@@ -142,6 +142,7 @@ require("eda").setup({
     ["gp"] = "paste",
     ["g?"] = "help",
     ["ga"] = "actions",
+    ["!"] = "open_replace",
     ["<C-f>"] = "preview_scroll_down",
     ["<C-b>"] = "preview_scroll_up",
     ["<C-w>v"] = "split",
@@ -687,6 +688,7 @@ configuration option.
 | `gq`    | quickfix           | Send target nodes to quickfix (Visual > marks > cursor) |
 | `g?`    | help               | Show help                     |
 | `ga`    | actions            | Open action picker            |
+| `!`     | open_replace       | Reopen float in replace mode  |
 | `<C-f>` | preview_scroll_down| Scroll preview down (half page) |
 | `<C-b>` | preview_scroll_up  | Scroll preview up (half page)   |
 | `<C-w>v`| split              | Open explorer in vertical split |
@@ -824,6 +826,11 @@ success (partial failures keep the marks for the failed/unattempted entries).
   Default mapping: `<C-w>v`
 - **vsplit** — Open a new explorer in a horizontal split pane with the same root.
   Default mapping: `<C-w>s`
+- **open_replace** — Reopen a float explorer in the previous window using the
+  `replace` layout. This is useful when you start in a temporary float and want
+  to switch into buffer-native editing for more involved file operations. The
+  action refuses to run if the explorer buffer has unsaved edits.
+  Default mapping: `!`
 - **actions** — Open an action picker via `vim.ui.select` showing all
   registered actions with descriptions.
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -161,6 +161,7 @@ DEFAULT CONFIGURATION ~
         ["gp"] = "paste",
         ["g?"] = "help",
         ["ga"] = "actions",
+        ["!"] = "open_replace",
         ["<C-f>"] = "preview_scroll_down",
         ["<C-b>"] = "preview_scroll_up",
         ["<C-w>v"] = "split",
@@ -754,6 +755,8 @@ configuration option.
 
   ga              actions                 Open action picker
 
+  !               open_replace            Reopen float in replace mode
+
   <C-f>           preview_scroll_down     Scroll preview down (half page)
 
   <C-b>           preview_scroll_up       Scroll preview up (half page)
@@ -901,6 +904,11 @@ MISC ~
     Default mapping: `<C-w>v`
 - **vsplit** — Open a new explorer in a horizontal split pane with the same root.
     Default mapping: `<C-w>s`
+- **open_replace** — Reopen a float explorer in the previous window using the
+    `replace` layout. This is useful when you start in a temporary float and want
+    to switch into buffer-native editing for more involved file operations. The
+    action refuses to run if the explorer buffer has unsaved edits.
+    Default mapping: `!`
 - **actions** — Open an action picker via `vim.ui.select` showing all
     registered actions with descriptions.
 

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -1198,6 +1198,10 @@ action.register("vsplit", function(ctx)
   get_eda().open_vsplit(ctx.explorer.root_path)
 end, { desc = "Open horizontal split pane" })
 
+action.register("open_replace", function(ctx)
+  get_eda().open_replace(ctx.explorer)
+end, { desc = "Reopen float explorer in replace mode" })
+
 action.register("actions", function(ctx)
   local items = {}
   for _, name in ipairs(action.list()) do

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -262,6 +262,7 @@ local defaults = {
     ["gq"] = "quickfix",
     ["g?"] = "help",
     ["ga"] = "actions",
+    ["!"] = "open_replace",
     ["<C-f>"] = "preview_scroll_down",
     ["<C-b>"] = "preview_scroll_up",
     ["<C-w>v"] = "split",

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -479,11 +479,14 @@ function M.open(opts)
 
   if M._current and not opts._new_instance then
     if M._current.window:is_visible() then
-      M._current.window:focus()
-      return
+      if opts._focus_existing ~= false then
+        M._current.window:focus()
+        return
+      end
+    else
+      -- Window was closed externally; clean up stale state
+      M.close()
     end
-    -- Window was closed externally; clean up stale state
-    M.close()
   end
 
   local cfg = config.get()
@@ -1506,6 +1509,45 @@ function M.open_vsplit(root_path)
   end
   vim.cmd("split")
   M.open({ dir = root_path, kind = "replace", _new_instance = true })
+end
+
+---Reopen the current float explorer in the target window using replace layout.
+---@param explorer eda.Explorer
+function M.open_replace(explorer)
+  if not explorer or M._current ~= explorer then
+    vim.notify("eda: cannot reopen stale explorer", vim.log.levels.WARN)
+    return
+  end
+  if explorer.window.kind ~= "float" then
+    vim.notify("eda: open_replace is only available from float windows", vim.log.levels.WARN)
+    return
+  end
+  if vim.bo[explorer.buffer.bufnr].modified then
+    vim.notify("eda: save or discard changes before reopening in replace mode", vim.log.levels.WARN)
+    return
+  end
+
+  local root_path = explorer.root_path
+  local target_win = explorer.window:get_target_winid()
+  if not root_path or target_win == nil then
+    vim.notify("eda: no target window available for replace mode", vim.log.levels.WARN)
+    return
+  end
+  ---@cast target_win integer
+  if not util.is_valid_win(target_win) then
+    vim.notify("eda: no target window available for replace mode", vim.log.levels.WARN)
+    return
+  end
+
+  M.close()
+  if util.is_valid_win(target_win) then
+    vim.api.nvim_set_current_win(target_win)
+  end
+
+  local ok, err = pcall(M.open, { dir = root_path, kind = "replace", _focus_existing = false })
+  if not ok then
+    vim.notify("eda: failed to reopen in replace mode: " .. tostring(err), vim.log.levels.ERROR)
+  end
 end
 
 return M

--- a/tests/e2e/test_window_modes.lua
+++ b/tests/e2e/test_window_modes.lua
@@ -67,6 +67,90 @@ T["window modes"]["float mode closes with q"] = function()
   e2e.wait_until(child, 'vim.bo.filetype ~= "eda"')
 end
 
+T["window modes"]["float mode reopens in replace mode with bang"] = function()
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = false },
+      icon = { provider = "none" },
+      window = { kind = "float" },
+      confirm = false,
+      header = false,
+    })
+  ]]
+  )
+
+  e2e.exec(child, string.format([[require("eda").open({ dir = %q })]], tmp))
+  e2e.wait_until(child, 'vim.bo.filetype == "eda" and #vim.api.nvim_list_wins() == 2')
+
+  e2e.feed(child, "!")
+  e2e.wait_until(
+    child,
+    [[
+    local has_file = false
+    for _, line in ipairs(vim.api.nvim_buf_get_lines(0, 0, -1, false)) do
+      if line:find("file.txt", 1, true) then
+        has_file = true
+        break
+      end
+    end
+    return vim.bo.filetype == "eda"
+      and #vim.api.nvim_list_wins() == 1
+      and require("eda").get_current().window.kind == "replace"
+      and require("eda").get_current().is_split == false
+      and #require("eda").get_all() == 1
+      and has_file
+  ]]
+  )
+end
+
+T["window modes"]["open_replace refuses modified float buffer"] = function()
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = false },
+      icon = { provider = "none" },
+      window = { kind = "float" },
+      confirm = false,
+      header = false,
+    })
+  ]]
+  )
+
+  e2e.exec(child, string.format([[require("eda").open({ dir = %q })]], tmp))
+  e2e.wait_until(child, 'vim.bo.filetype == "eda" and #vim.api.nvim_list_wins() == 2')
+
+  local result = e2e.exec(
+    child,
+    [[
+    local eda = require("eda")
+    local explorer = eda.get_current()
+    vim.bo[explorer.buffer.bufnr].modified = true
+    require("eda.action").dispatch("open_replace", {
+      store = explorer.store,
+      buffer = explorer.buffer,
+      window = explorer.window,
+      scanner = explorer.scanner,
+      config = require("eda.config").get(),
+      explorer = explorer,
+    })
+    return {
+      kind = eda.get_current().window.kind,
+      instances = #eda.get_all(),
+      windows = #vim.api.nvim_list_wins(),
+      modified = vim.bo[explorer.buffer.bufnr].modified,
+    }
+  ]]
+  )
+
+  MiniTest.expect.equality(result.kind, "float")
+  MiniTest.expect.equality(result.instances, 1)
+  MiniTest.expect.equality(result.windows, 2)
+  MiniTest.expect.equality(result.modified, true)
+end
+
 T["window modes"]["replace mode starts and shows filetype eda"] = function()
   e2e.exec(
     child,


### PR DESCRIPTION
## Summary

Adds an `open_replace` action that lets a float explorer reopen in the previous target window using replace mode. This is useful when starting in a float, then switching to a full-buffer explorer for more complex operations.

Also adds the default `!` mapping, updates the user documentation, and covers the behavior with E2E tests.

## References

- n/a
