### PR TITLE
feat: center viewport on float explorer reopen

### DIFF
--- a/lua/eda/buffer/init.lua
+++ b/lua/eda/buffer/init.lua
@@ -8,6 +8,7 @@ local util = require("eda.util")
 ---@field config eda.Config
 ---@field flat_lines eda.FlatLine[]
 ---@field target_node_id integer?
+---@field focus_node_id integer?
 ---@field _augroup integer
 ---@field _write_handler fun()?
 local Buffer = {}
@@ -52,6 +53,7 @@ function Buffer.new(root_path, config, instance_id)
     config = config,
     flat_lines = {},
     target_node_id = nil,
+    focus_node_id = nil,
     _augroup = vim.api.nvim_create_augroup("eda_buffer_" .. bufnr, { clear = true }),
     _write_handler = nil,
   }, Buffer)
@@ -126,21 +128,36 @@ function Buffer:save_cursor(winid)
   end
 end
 
----Restore cursor to target_node_id position.
+---Restore cursor to the navigation target.
+---`focus_node_id` (set by external navigation events that jump to a possibly-far
+---node) wins over `target_node_id` (set by save_cursor for in-place preserve).
+---When `focus_node_id` is the source, the viewport is centered with `zz` so the
+---target line lands at the middle of the window instead of the edge — Neovim's
+---auto-center on large jumps clamps near EOF and pushes the cursor to the
+---bottom, which is the symptom this branch fixes.
 function Buffer:restore_cursor()
-  if not self.target_node_id then
+  local node_id = self.focus_node_id or self.target_node_id
+  if not node_id then
     return
   end
+  local should_center = self.focus_node_id ~= nil
   local header_lines = self.painter.header_lines or 0
   for i, fl in ipairs(self.flat_lines) do
-    if fl.node_id == self.target_node_id then
-      -- Find the window displaying this buffer
+    if fl.node_id == node_id then
       local target_row = i + header_lines
       for _, win in ipairs(vim.api.nvim_list_wins()) do
         if vim.api.nvim_win_get_buf(win) == self.bufnr then
+          if not vim.api.nvim_win_is_valid(win) then
+            return
+          end
           local line_count = vim.api.nvim_buf_line_count(self.bufnr)
           if target_row <= line_count then
             vim.api.nvim_win_set_cursor(win, { target_row, 0 })
+            if should_center then
+              vim.api.nvim_win_call(win, function()
+                vim.cmd("normal! zz")
+              end)
+            end
           end
           return
         end

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -567,7 +567,7 @@ function M.open(opts)
     if explorer._render_gen == explorer._last_painted_gen then
       return
     end
-    if not buf.target_node_id then
+    if not (buf.target_node_id or buf.focus_node_id) then
       buf:save_cursor(win.winid)
     end
     local git_status = git.get_cached(rp)
@@ -601,6 +601,7 @@ function M.open(opts)
         explorer._incremental_hint = nil
         explorer._empty_state_rendered = true
         buf.target_node_id = nil
+        buf.focus_node_id = nil
         -- Sync float title on this early-return path so toggling `gs` during
         -- loading still updates the indicator instead of waiting for the next
         -- full render.
@@ -696,6 +697,7 @@ function M.open(opts)
     end
     buf:restore_cursor()
     buf.target_node_id = nil
+    buf.focus_node_id = nil
     explorer._last_painted_gen = explorer._render_gen
     if k == "float" then
       refresh_float_title(explorer)
@@ -898,7 +900,7 @@ function M.open(opts)
       if target_path then
         local node = store:get_by_path(target_path)
         if node then
-          buffer.target_node_id = node.id
+          buffer.focus_node_id = node.id
         else
           -- Fallback: resolve real path through symlink nodes
           local resolved = store:resolve_symlink_path(target_path)
@@ -910,7 +912,7 @@ function M.open(opts)
                 end
                 local resolved_node = store:get_by_path(resolved)
                 if resolved_node then
-                  buffer.target_node_id = resolved_node.id
+                  buffer.focus_node_id = resolved_node.id
                 end
                 mark_render_dirty()
                 schedule_render()
@@ -945,7 +947,7 @@ function M.open(opts)
             if not target_path and cached.cursor_path then
               local cursor_node = store:get_by_path(cached.cursor_path)
               if cursor_node then
-                buffer.target_node_id = cursor_node.id
+                buffer.focus_node_id = cursor_node.id
               end
             end
             mark_render_dirty()
@@ -1432,7 +1434,7 @@ function M.navigate(path)
       end
       local node = explorer.store:get_by_path(path)
       if node then
-        explorer.buffer.target_node_id = node.id
+        explorer.buffer.focus_node_id = node.id
       end
       if explorer._refresh_for_navigation then
         explorer._refresh_for_navigation()

--- a/tests/buffer/test_buffer.lua
+++ b/tests/buffer/test_buffer.lua
@@ -203,6 +203,79 @@ T["save_cursor and restore_cursor preserve position by node ID"] = function()
   buf:destroy()
 end
 
+---Build a Buffer with `count` flat children under a unique root, plus a tall
+---window suitable for observing scroll position. The unique root avoids E95
+---(buffer name collision) when a prior test fails before its `buf:destroy()`
+---runs. Returns buf, winid, and a list of node IDs in flat-line order.
+local _scroll_fixture_seq = 0
+local function setup_scroll_fixture(count)
+  config.setup()
+  _scroll_fixture_seq = _scroll_fixture_seq + 1
+  local root_path = "/scroll_fixture_" .. _scroll_fixture_seq
+  local store = Store.new()
+  local root = store:set_root(root_path)
+  local node_ids = {}
+  for i = 1, count do
+    local name = string.format("f%03d.lua", i)
+    node_ids[i] = store:add({ name = name, path = root_path .. "/" .. name, type = "file", parent_id = root })
+  end
+  store:get(root).children_state = "loaded"
+
+  local cfg = config.get()
+  cfg.header = false
+  local buf = Buffer.new(root_path, cfg)
+  buf:render(store)
+
+  local winid =
+    vim.api.nvim_open_win(buf.bufnr, true, { relative = "editor", width = 40, height = 10, row = 0, col = 0 })
+
+  -- Deterministic viewport math: disable scrolloff on THIS window only so cursor
+  -- lands exactly on the last visible line when scrolled minimally. Window-local
+  -- avoids leaking the option into subsequent tests sharing the nvim process.
+  vim.wo[winid].scrolloff = 0
+
+  return buf, winid, node_ids, store
+end
+
+-- Both tests target the last row of an 80-line buffer in a 10-line window.
+-- Neovim's auto-center on a big jump clamps near EOF (viewport pinned to buffer
+-- end → cursor at viewport bottom). Explicit `zz` allows tildes past EOL → true
+-- center. The distinction shows up in `line("w0", winid)`:
+--   - centered (zz):  topline = cursor - 4 = 76 (cursor at viewport row 5)
+--   - preserve only:  topline = 80 - 9 = 71 (cursor at viewport row 10 = bottom)
+T["restore_cursor centers viewport when focus_node_id is set"] = function()
+  local buf, winid, node_ids, store = setup_scroll_fixture(80)
+  local target_row = 80
+  local target_id = node_ids[target_row]
+
+  buf.focus_node_id = target_id
+  buf:render(store)
+
+  local cursor = vim.api.nvim_win_get_cursor(winid)
+  MiniTest.expect.equality(cursor[1], target_row)
+  MiniTest.expect.equality(vim.fn.line("w0", winid), target_row - 4)
+
+  vim.api.nvim_win_close(winid, true)
+  buf:destroy()
+end
+
+T["restore_cursor does not center when only target_node_id is set"] = function()
+  local buf, winid, node_ids, store = setup_scroll_fixture(80)
+  local target_row = 80
+  local target_id = node_ids[target_row]
+
+  buf.target_node_id = target_id
+  buf:render(store)
+
+  local cursor = vim.api.nvim_win_get_cursor(winid)
+  MiniTest.expect.equality(cursor[1], target_row)
+  -- Auto-center clamps near EOF → cursor at viewport bottom (line 10), topline = 71.
+  MiniTest.expect.equality(vim.fn.line("w0", winid), target_row - 9)
+
+  vim.api.nvim_win_close(winid, true)
+  buf:destroy()
+end
+
 T["get_cursor_node returns correct node"] = function()
   config.setup()
   local store = Store.new()


### PR DESCRIPTION
## Summary

When a float-mode explorer is closed by selecting a file and then reopened, the cursor now lands on the previously-selected file with that row near the **vertical center** of the float window. Previously the row sat at the bottom edge of the float — Neovim's auto-center on a large cursor jump clamps near EOF and pushes the row to the viewport bottom.

The fix splits the existing `Buffer.target_node_id` field in two:

- `target_node_id` (unchanged) — set by `save_cursor` for in-place preserve across re-render. No centering.
- `focus_node_id` (new) — set at the four "navigation jump" call sites in `lua/eda/init.lua` (initial-open target_path, symlink resolution, `state_cache.cursor_path` restore, `M.navigate` via `update_focused_file`). After cursor lands, `restore_cursor()` issues `normal! zz` so the row is centered even when the target is near the end of the tree.

Adjacent navigation (`parent`, `collapse_node`, `expand_path`, paste-target actions) and the `save_cursor` preserve path keep using `target_node_id`, so they continue to behave as before with no unintended re-centering.

## References

- n/a
