### PR TITLE
feat: add yank_tree action to copy selected nodes as ASCII tree

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -124,6 +124,7 @@ require("eda").setup({
     ["yp"] = "yank_path",
     ["yP"] = "yank_path_absolute",
     ["yn"] = "yank_name",
+    ["yt"] = "yank_tree",
     ["<C-l>"] = "refresh",
     ["<C-h>"] = "collapse_node",
     ["g."] = "toggle_hidden",
@@ -668,6 +669,7 @@ configuration option.
 | `yp`    | yank_path          | Yank relative path            |
 | `yP`    | yank_path_absolute | Yank absolute path            |
 | `yn`    | yank_name          | Yank filename                 |
+| `yt`    | yank_tree          | Yank selected nodes as ASCII tree (Visual > marks > cursor) |
 | `<C-l>` | refresh            | Refresh explorer              |
 | `<C-h>` | collapse_node      | Collapse or move to parent    |
 | `g.`    | toggle_hidden      | Toggle hidden files           |
@@ -731,6 +733,7 @@ previously visited root restores its prior expansion.
 - **yank_path** — Yank the relative path to the system clipboard.
 - **yank_path_absolute** — Yank the absolute path to the system clipboard.
 - **yank_name** — Yank the filename to the system clipboard.
+- **yank_tree** — Yank the selected node set as an ASCII tree (Visual > marks > cursor) for pasting into PR descriptions. Uses Box Drawing characters compatible with GitHub-flavored Markdown code blocks. When a single node is selected, copies the relative path without tree glyphs.
 
 ### File Operations
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -143,6 +143,7 @@ DEFAULT CONFIGURATION ~
         ["yp"] = "yank_path",
         ["yP"] = "yank_path_absolute",
         ["yn"] = "yank_name",
+        ["yt"] = "yank_tree",
         ["<C-l>"] = "refresh",
         ["<C-h>"] = "collapse_node",
         ["g."] = "toggle_hidden",
@@ -709,6 +710,9 @@ configuration option.
 
   yn              yank_name               Yank filename
 
+  yt              yank_tree               Yank selected nodes as ASCII tree
+                                          (Visual > marks > cursor)
+
   <C-l>           refresh                 Refresh explorer
 
   <C-h>           collapse_node           Collapse or move to parent
@@ -806,6 +810,7 @@ YANK ~
 - **yank_path** — Yank the relative path to the system clipboard.
 - **yank_path_absolute** — Yank the absolute path to the system clipboard.
 - **yank_name** — Yank the filename to the system clipboard.
+- **yank_tree** — Yank the selected node set as an ASCII tree (Visual > marks > cursor) for pasting into PR descriptions. Uses Box Drawing characters compatible with GitHub-flavored Markdown code blocks. When a single node is selected, copies the relative path without tree glyphs.
 
 
 FILE OPERATIONS ~

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -1076,6 +1076,26 @@ action.register("copy", function(ctx)
   vim.notify("Copied " .. #paths .. " item(s)")
 end, { desc = "Copy target nodes (Visual > marks > cursor)" })
 
+action.register("yank_tree", function(ctx)
+  local ascii = require("eda.tree.ascii")
+  local target = get_target_nodes(ctx)
+  if #target.nodes == 0 then
+    vim.notify("yank_tree: no nodes selected", vim.log.levels.WARN)
+    return
+  end
+  local rendered = ascii.render(target.nodes, ctx.explorer.root_path)
+  vim.fn.setreg("+", rendered)
+  if #target.nodes == 1 then
+    vim.notify("Yanked: " .. rendered)
+  else
+    vim.notify("Yanked tree (" .. #target.nodes .. " item(s))")
+  end
+  if target.origin == "marks" then
+    clear_marks(ctx.store)
+    refresh(ctx)
+  end
+end, { desc = "Yank selected nodes as ASCII tree (Visual > marks > cursor)" })
+
 action.register("quickfix", function(ctx)
   local target = get_target_nodes(ctx)
   if #target.nodes == 0 then

--- a/lua/eda/buffer/init.lua
+++ b/lua/eda/buffer/init.lua
@@ -259,6 +259,7 @@ local visual_mode_actions = {
   copy = true,
   quickfix = true,
   mark_toggle = true,
+  yank_tree = true,
 }
 
 ---Set keymaps on the buffer.

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -242,6 +242,7 @@ local defaults = {
     ["yp"] = "yank_path",
     ["yP"] = "yank_path_absolute",
     ["yn"] = "yank_name",
+    ["yt"] = "yank_tree",
     ["<C-l>"] = "refresh",
     ["<C-h>"] = "collapse_node",
     ["g."] = "toggle_hidden",

--- a/lua/eda/tree/ascii.lua
+++ b/lua/eda/tree/ascii.lua
@@ -1,0 +1,169 @@
+local Node = require("eda.tree.node")
+local Store = require("eda.tree.store")
+
+local M = {}
+
+---@param path string
+---@param root_path string Explorer root (no trailing slash, except for "/")
+---@return string
+local function relative(path, root_path)
+  return path:sub(#root_path + 2)
+end
+
+---Split a path into its segments. Empty input yields an empty array.
+---@param rel string
+---@return string[]
+local function split_segments(rel)
+  local segments = {}
+  for seg in rel:gmatch("[^/]+") do
+    segments[#segments + 1] = seg
+  end
+  return segments
+end
+
+---Sort comparator matching `Store:children` (directories first, then natural sort).
+---@param a { name: string, is_dir: boolean }
+---@param b { name: string, is_dir: boolean }
+---@return boolean
+local function compare_entries(a, b)
+  if a.is_dir ~= b.is_dir then
+    return a.is_dir
+  end
+  return Store.natural_sort_key(a.name) < Store.natural_sort_key(b.name)
+end
+
+---Render the tree rooted at `tree_node`'s ordered children into `out`.
+---@param children { name: string, is_dir: boolean, children: table[]? }[]
+---@param prefix string Pre-computed indent prefix for this depth
+---@param out string[]
+local function render_children(children, prefix, out)
+  local sorted = {}
+  for _, child in ipairs(children) do
+    sorted[#sorted + 1] = child
+  end
+  table.sort(sorted, compare_entries)
+
+  for idx, child in ipairs(sorted) do
+    local is_last = idx == #sorted
+    local connector = is_last and "└── " or "├── "
+    local name = child.is_dir and (child.name .. "/") or child.name
+    out[#out + 1] = prefix .. connector .. name
+    if child.children and #child.children > 0 then
+      local next_prefix = prefix .. (is_last and "    " or "│   ")
+      render_children(child.children, next_prefix, out)
+    end
+  end
+end
+
+---Render selected nodes as an ASCII tree string suitable for pasting into
+---GitHub-flavored Markdown code blocks.
+---
+--- - Empty input returns "".
+--- - Single node short-circuits to `<relative path>` (directories suffixed with "/").
+--- - Multiple nodes are rendered as a tree rooted at their common ancestor.
+---   Header is "./" when the common ancestor is the explorer root.
+--- - Scaffold and explicitly-selected directories render identically (both with "/").
+--- - Children at each level are ordered directories-first, then natural sort,
+---   matching `Store:children` (the visible order in the explorer).
+---@param nodes eda.TreeNode[]
+---@param root_path string Explorer root path (no trailing slash, except "/")
+---@return string ASCII tree without a trailing newline
+function M.render(nodes, root_path)
+  if #nodes == 0 then
+    return ""
+  end
+
+  if #nodes == 1 then
+    local rel = relative(nodes[1].path, root_path)
+    if Node.is_dir(nodes[1]) then
+      return rel .. "/"
+    end
+    return rel
+  end
+
+  -- Build per-node segments + dir flag.
+  local entries = {}
+  for _, n in ipairs(nodes) do
+    entries[#entries + 1] = {
+      segments = split_segments(relative(n.path, root_path)),
+      is_dir = Node.is_dir(n),
+    }
+  end
+
+  -- Longest common segment prefix across all entries.
+  local common_len = #entries[1].segments
+  for i = 2, #entries do
+    local other = entries[i].segments
+    local max_match = math.min(common_len, #other)
+    local match = 0
+    for j = 1, max_match do
+      if entries[1].segments[j] == other[j] then
+        match = j
+      else
+        break
+      end
+    end
+    common_len = match
+    if common_len == 0 then
+      break
+    end
+  end
+
+  -- Header line: "./" if common prefix is empty, else "<common>/".
+  local header
+  if common_len == 0 then
+    header = "./"
+  else
+    local parts = {}
+    for j = 1, common_len do
+      parts[#parts + 1] = entries[1].segments[j]
+    end
+    header = table.concat(parts, "/") .. "/"
+  end
+
+  -- Insert each entry (with the common prefix stripped) into a tree.
+  -- Intermediate nodes are scaffold directories; the terminal segment carries
+  -- the explicit is_dir flag. Re-inserting the same path is idempotent: dir-ness
+  -- only ever upgrades (a parent of any selected node IS a directory).
+  local root = { children = {}, index = {} }
+
+  local function insert(entry)
+    local node = root
+    for j = common_len + 1, #entry.segments do
+      local seg = entry.segments[j]
+      local child = node.index[seg]
+      if not child then
+        local is_terminal = j == #entry.segments
+        local seg_is_dir
+        if is_terminal then
+          seg_is_dir = entry.is_dir
+        else
+          seg_is_dir = true
+        end
+        child = {
+          name = seg,
+          is_dir = seg_is_dir,
+          children = {},
+          index = {},
+        }
+        node.index[seg] = child
+        node.children[#node.children + 1] = child
+      end
+      node = child
+    end
+  end
+
+  for _, entry in ipairs(entries) do
+    -- Entries with no remaining segments after stripping the common prefix
+    -- (i.e. the entry's full path == common prefix) collapse into the header.
+    if #entry.segments > common_len then
+      insert(entry)
+    end
+  end
+
+  local out = { header }
+  render_children(root.children, "", out)
+  return table.concat(out, "\n")
+end
+
+return M

--- a/lua/eda/tree/store.lua
+++ b/lua/eda/tree/store.lua
@@ -275,4 +275,9 @@ function Store:next_generation()
   return self.generation
 end
 
+---Natural sort comparator key.
+---Exposed so other modules (e.g. `eda.tree.ascii`) can share the same name ordering
+---as the explorer's visible children sort, avoiding drift between rendered views.
+Store.natural_sort_key = natural_sort_key
+
 return Store

--- a/tests/action/test_builtin.lua
+++ b/tests/action/test_builtin.lua
@@ -862,4 +862,129 @@ T["mark_clear_all: no-op (no refresh) when no marks exist"] = function()
   MiniTest.expect.equality(ctx._render_called(), false)
 end
 
+-- ===============================================================
+-- yank_tree tests
+-- ===============================================================
+
+--- Capture vim.fn.setreg + vim.notify calls and return a teardown function.
+---@return { reg_calls: { reg: string, val: string }[], notify_calls: { msg: string, level: integer? }[] }, fun()
+local function capture_yank_io()
+  local captures = { reg_calls = {}, notify_calls = {} }
+  local orig_setreg = vim.fn.setreg
+  local orig_notify = vim.notify
+  vim.fn.setreg = function(reg, val)
+    table.insert(captures.reg_calls, { reg = reg, val = val })
+  end
+  vim.notify = function(msg, level)
+    table.insert(captures.notify_calls, { msg = msg, level = level })
+  end
+  return captures, function()
+    vim.fn.setreg = orig_setreg
+    vim.notify = orig_notify
+  end
+end
+
+T["yank_tree: action is registered"] = function()
+  -- RED-marker: pinpoints the failure reason when the action is missing.
+  MiniTest.expect.equality(type(action.get("yank_tree")), "function")
+end
+
+T["yank_tree: cursor single node yanks relative path verbatim"] = function()
+  local ctx = make_target_ctx(3) -- file_a at /project/dir_a/file_a.lua
+  local captures, teardown = capture_yank_io()
+  action.dispatch("yank_tree", ctx)
+  teardown()
+
+  MiniTest.expect.equality(#captures.reg_calls, 1)
+  MiniTest.expect.equality(captures.reg_calls[1].reg, "+")
+  MiniTest.expect.equality(captures.reg_calls[1].val, "dir_a/file_a.lua")
+  MiniTest.expect.equality(#captures.notify_calls, 1)
+  MiniTest.expect.equality(captures.notify_calls[1].msg, "Yanked: dir_a/file_a.lua")
+end
+
+T["yank_tree: marks render ASCII tree and notify pluralised"] = function()
+  local ctx, store = make_target_ctx(nil)
+  -- Mark file_a (/project/dir_a/file_a.lua) and file_c (/project/file_c.lua)
+  store:get(3)._marked = true
+  store:get(7)._marked = true
+  local captures, teardown = capture_yank_io()
+  action.dispatch("yank_tree", ctx)
+  teardown()
+
+  MiniTest.expect.equality(#captures.reg_calls, 1)
+  MiniTest.expect.equality(captures.reg_calls[1].reg, "+")
+  local expected_tree = table.concat({
+    "./",
+    "├── dir_a/",
+    "│   └── file_a.lua",
+    "└── file_c.lua",
+  }, "\n")
+  MiniTest.expect.equality(captures.reg_calls[1].val, expected_tree)
+  MiniTest.expect.equality(#captures.notify_calls, 1)
+  MiniTest.expect.equality(captures.notify_calls[1].msg, "Yanked tree (2 item(s))")
+end
+
+T["yank_tree: visual range renders ASCII tree"] = function()
+  local ctx = make_target_ctx(nil)
+  local captures, teardown = capture_yank_io()
+  -- Visual lines 2..4: file_a (id=3), sub_dir (id=4), file_b (id=5)
+  with_visual_range("V", 2, 4, function()
+    action.dispatch("yank_tree", ctx)
+  end)
+  teardown()
+
+  MiniTest.expect.equality(#captures.reg_calls, 1)
+  MiniTest.expect.equality(captures.reg_calls[1].reg, "+")
+  -- Common ancestor is dir_a/; sub_dir is explicit AND parent of file_b (collapsed once).
+  local expected_tree = table.concat({
+    "dir_a/",
+    "├── sub_dir/",
+    "│   └── file_b.lua",
+    "└── file_a.lua",
+  }, "\n")
+  MiniTest.expect.equality(captures.reg_calls[1].val, expected_tree)
+  MiniTest.expect.equality(captures.notify_calls[1].msg, "Yanked tree (3 item(s))")
+end
+
+T["yank_tree: empty selection emits WARN notify and skips setreg"] = function()
+  -- No cursor, no marks → target is empty.
+  local ctx = make_target_ctx(nil)
+  local captures, teardown = capture_yank_io()
+  action.dispatch("yank_tree", ctx)
+  teardown()
+
+  MiniTest.expect.equality(#captures.reg_calls, 0)
+  MiniTest.expect.equality(#captures.notify_calls, 1)
+  MiniTest.expect.equality(captures.notify_calls[1].msg, "yank_tree: no nodes selected")
+  MiniTest.expect.equality(captures.notify_calls[1].level, vim.log.levels.WARN)
+end
+
+T["yank_tree: origin=marks clears _marked on yanked nodes"] = function()
+  local ctx, store = make_target_ctx(nil)
+  store:get(3)._marked = true
+  store:get(7)._marked = true
+  local _, teardown = capture_yank_io()
+  action.dispatch("yank_tree", ctx)
+  teardown()
+
+  MiniTest.expect.equality(store:get(3)._marked, nil)
+  MiniTest.expect.equality(store:get(7)._marked, nil)
+end
+
+-- (Cursor + pre-existing marks is structurally impossible: the resolver promotes
+-- marks over cursor whenever both are present. The visual-vs-marks case below is
+-- the only observable scenario where clear_marks must NOT fire.)
+
+T["yank_tree: origin=visual leaves marks intact"] = function()
+  local ctx, store = make_target_ctx(nil)
+  store:get(7)._marked = true -- marked node OUTSIDE the visual range
+  local _, teardown = capture_yank_io()
+  with_visual_range("V", 2, 3, function()
+    action.dispatch("yank_tree", ctx)
+  end)
+  teardown()
+
+  MiniTest.expect.equality(store:get(7)._marked, true)
+end
+
 return T

--- a/tests/e2e/test_yank_tree.lua
+++ b/tests/e2e/test_yank_tree.lua
@@ -1,0 +1,202 @@
+local e2e = require("e2e.helpers")
+
+local T = MiniTest.new_set()
+
+local child, tmp
+
+---Inject a mock clipboard provider so vim.fn.setreg("+", ...) writes to
+---_G.__yank_tree_clip instead of the OS clipboard (which is provider-dependent
+---in --clean --headless and would pollute the developer machine on macOS).
+local function inject_mock_clipboard(c)
+  e2e.exec(
+    c,
+    [[
+    _G.__yank_tree_clip = nil
+    vim.g.clipboard = {
+      name = "yank_tree_test_mock",
+      copy = {
+        ["+"] = function(lines, _) _G.__yank_tree_clip = table.concat(lines, "\n") end,
+        ["*"] = function(lines, _) _G.__yank_tree_clip = table.concat(lines, "\n") end,
+      },
+      paste = {
+        ["+"] = function() return vim.split(_G.__yank_tree_clip or "", "\n"), "v" end,
+        ["*"] = function() return vim.split(_G.__yank_tree_clip or "", "\n"), "v" end,
+      },
+      cache_enabled = 0,
+    }
+  ]]
+  )
+end
+
+T["yank_tree"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      inject_mock_clipboard(child)
+      e2e.setup_eda(child)
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_dir(tmp .. "/src")
+      e2e.create_file(tmp .. "/src/foo.ts", "foo")
+      e2e.create_file(tmp .. "/src/bar.ts", "bar")
+      e2e.create_dir(tmp .. "/tests")
+      e2e.create_file(tmp .. "/tests/baz.ts", "baz")
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+---Reset the mock clipboard buffer so each case is independent.
+local function reset_clip()
+  e2e.exec(child, "_G.__yank_tree_clip = nil")
+end
+
+---Read the mock clipboard buffer (post-yank).
+---@return string|nil
+local function read_clip()
+  return e2e.exec(child, "return _G.__yank_tree_clip")
+end
+
+---Move the eda cursor to the line containing the given basename.
+---Relies on the explorer being fully expanded (gE) before calling.
+local function cursor_to(name)
+  e2e.exec(
+    child,
+    string.format(
+      [[
+      local buf = vim.api.nvim_get_current_buf()
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      for i, l in ipairs(lines) do
+        if l:find(%q, 1, true) then
+          vim.api.nvim_win_set_cursor(0, { i, 0 })
+          return
+        end
+      end
+      error("no line containing " .. %q)
+    ]],
+      name,
+      name
+    )
+  )
+end
+
+T["yank_tree"]["cursor: single node short-circuits to relative path"] = function()
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    local has_foo, has_baz = false, false
+    for _, l in ipairs(lines) do
+      if l:find("foo.ts", 1, true) then has_foo = true end
+      if l:find("baz.ts", 1, true) then has_baz = true end
+    end
+    return has_foo and has_baz
+  ]]
+  )
+
+  reset_clip()
+  cursor_to("foo.ts")
+  e2e.feed(child, "yt")
+  e2e.exec(child, "vim.wait(50)")
+
+  MiniTest.expect.equality(read_clip(), "src/foo.ts")
+end
+
+T["yank_tree"]["marks: cross-directory selection renders ASCII tree and clears marks"] = function()
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    local has_foo, has_baz = false, false
+    for _, l in ipairs(lines) do
+      if l:find("foo.ts", 1, true) then has_foo = true end
+      if l:find("baz.ts", 1, true) then has_baz = true end
+    end
+    return has_foo and has_baz
+  ]]
+  )
+
+  -- Mark src/foo.ts + tests/baz.ts (cross-directory).
+  cursor_to("foo.ts")
+  e2e.feed(child, "m")
+  cursor_to("baz.ts")
+  e2e.feed(child, "m")
+
+  e2e.wait_until(
+    child,
+    [[
+    local buf = require("eda").get_current().buffer
+    local count = 0
+    for _, fl in ipairs(buf.flat_lines) do
+      if fl.node._marked then count = count + 1 end
+    end
+    return count == 2
+  ]]
+  )
+
+  reset_clip()
+  e2e.feed(child, "yt")
+  e2e.exec(child, "vim.wait(50)")
+
+  local expected = table.concat({
+    "./",
+    "├── src/",
+    "│   └── foo.ts",
+    "└── tests/",
+    "    └── baz.ts",
+  }, "\n")
+  MiniTest.expect.equality(read_clip(), expected)
+
+  -- Marks must be cleared after a marks-origin yank.
+  e2e.wait_until(
+    child,
+    [[
+    local buf = require("eda").get_current().buffer
+    for _, fl in ipairs(buf.flat_lines) do
+      if fl.node._marked then return false end
+    end
+    return true
+  ]]
+  )
+end
+
+T["yank_tree"]["visual: V-line range renders ASCII tree under common ancestor"] = function()
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  e2e.wait_until(
+    child,
+    [[
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    local has_bar, has_foo = false, false
+    for _, l in ipairs(lines) do
+      if l:find("bar.ts", 1, true) then has_bar = true end
+      if l:find("foo.ts", 1, true) then has_foo = true end
+    end
+    return has_bar and has_foo
+  ]]
+  )
+
+  -- Move cursor to bar.ts, then V-line down to foo.ts (siblings under src/).
+  cursor_to("bar.ts")
+  e2e.feed(child, "Vj")
+  e2e.exec(child, "vim.wait(20)")
+
+  reset_clip()
+  e2e.feed(child, "yt")
+  e2e.exec(child, "vim.wait(50)")
+
+  local expected = table.concat({
+    "src/",
+    "├── bar.ts",
+    "└── foo.ts",
+  }, "\n")
+  MiniTest.expect.equality(read_clip(), expected)
+end
+
+return T

--- a/tests/tree/test_ascii.lua
+++ b/tests/tree/test_ascii.lua
@@ -1,0 +1,152 @@
+local ascii = require("eda.tree.ascii")
+local Node = require("eda.tree.node")
+
+local T = MiniTest.new_set()
+
+local next_id = 0
+local function node(name, path, type)
+  next_id = next_id + 1
+  return Node.create({ id = next_id, name = name, path = path, type = type or "file" })
+end
+
+T["render"] = MiniTest.new_set()
+
+T["render"]["empty input returns empty string"] = function()
+  MiniTest.expect.equality(ascii.render({}, "/r"), "")
+end
+
+T["render"]["single file short-circuits to relative path without tree glyphs"] = function()
+  local n = node("foo.ts", "/r/src/foo.ts", "file")
+  MiniTest.expect.equality(ascii.render({ n }, "/r"), "src/foo.ts")
+end
+
+T["render"]["single directory short-circuits to relative path with trailing slash"] = function()
+  local n = node("src", "/r/src", "directory")
+  MiniTest.expect.equality(ascii.render({ n }, "/r"), "src/")
+end
+
+T["render"]["single root-direct file returns just the name"] = function()
+  local n = node("README.md", "/r/README.md", "file")
+  MiniTest.expect.equality(ascii.render({ n }, "/r"), "README.md")
+end
+
+T["render"]["canonical example: dir + child + sibling"] = function()
+  -- input: [src/, src/foo.ts, tests/bar.ts]
+  -- common ancestor = explorer root → "./" header
+  -- src/ is explicit AND a parent of selected child → rendered once as branch
+  local src_dir = node("src", "/r/src", "directory")
+  local foo_ts = node("foo.ts", "/r/src/foo.ts", "file")
+  local bar_ts = node("bar.ts", "/r/tests/bar.ts", "file")
+
+  local expected = table.concat({
+    "./",
+    "├── src/",
+    "│   └── foo.ts",
+    "└── tests/",
+    "    └── bar.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ src_dir, foo_ts, bar_ts }, "/r"), expected)
+end
+
+T["render"]["common ancestor is non-root directory"] = function()
+  -- input: [src/foo.ts, src/bar.ts] → header is "src/" not "./"
+  local foo_ts = node("foo.ts", "/r/src/foo.ts", "file")
+  local bar_ts = node("bar.ts", "/r/src/bar.ts", "file")
+
+  local expected = table.concat({
+    "src/",
+    "├── bar.ts",
+    "└── foo.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ foo_ts, bar_ts }, "/r"), expected)
+end
+
+T["render"]["directories only as leaves"] = function()
+  local src = node("src", "/r/src", "directory")
+  local tests_dir = node("tests", "/r/tests", "directory")
+
+  local expected = table.concat({
+    "./",
+    "├── src/",
+    "└── tests/",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ src, tests_dir }, "/r"), expected)
+end
+
+T["render"]["symlink rendered without suffix"] = function()
+  local link = node("alias.lua", "/r/src/alias.lua", "link")
+  local plain = node("foo.ts", "/r/src/foo.ts", "file")
+
+  local expected = table.concat({
+    "src/",
+    "├── alias.lua",
+    "└── foo.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ link, plain }, "/r"), expected)
+end
+
+T["render"]["mixed dir+file siblings: directories first then natural sort"] = function()
+  -- siblings under root: z.ts, a.ts (files), m/ src/ (dirs)
+  -- expected order: m/, src/, a.ts, z.ts (dirs-first, natural sort within group)
+  local z = node("z.ts", "/r/z.ts", "file")
+  local a = node("a.ts", "/r/a.ts", "file")
+  local m = node("m", "/r/m", "directory")
+  local src = node("src", "/r/src", "directory")
+
+  local expected = table.concat({
+    "./",
+    "├── m/",
+    "├── src/",
+    "├── a.ts",
+    "└── z.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ z, a, m, src }, "/r"), expected)
+end
+
+T["render"]["natural sort handles numeric segments"] = function()
+  -- file1, file2, file10 (numeric order, not lexical "file1 < file10 < file2")
+  local f10 = node("file10.ts", "/r/file10.ts", "file")
+  local f2 = node("file2.ts", "/r/file2.ts", "file")
+  local f1 = node("file1.ts", "/r/file1.ts", "file")
+
+  local expected = table.concat({
+    "./",
+    "├── file1.ts",
+    "├── file2.ts",
+    "└── file10.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ f10, f2, f1 }, "/r"), expected)
+end
+
+T["render"]["explicit dir + its child renders dir only once"] = function()
+  -- regression for the canonical decision: dir appears as branch, not duplicated as leaf
+  local src = node("src", "/r/src", "directory")
+  local foo = node("foo.ts", "/r/src/foo.ts", "file")
+
+  -- common ancestor is "src" → header "src/", child "foo.ts" as leaf
+  local expected = table.concat({
+    "src/",
+    "└── foo.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ src, foo }, "/r"), expected)
+end
+
+T["render"]["deeply nested scaffolding"] = function()
+  -- input: [src/a/b/c.ts, src/a/b/d.ts, src/x.ts]
+  -- common ancestor = src/
+  local c = node("c.ts", "/r/src/a/b/c.ts", "file")
+  local d = node("d.ts", "/r/src/a/b/d.ts", "file")
+  local x = node("x.ts", "/r/src/x.ts", "file")
+
+  local expected = table.concat({
+    "src/",
+    "├── a/",
+    "│   └── b/",
+    "│       ├── c.ts",
+    "│       └── d.ts",
+    "└── x.ts",
+  }, "\n")
+  MiniTest.expect.equality(ascii.render({ c, d, x }, "/r"), expected)
+end
+
+return T


### PR DESCRIPTION
## Summary

Adds a `yank_tree` action that copies the selected node set as an ASCII tree string to the system clipboard register `+`, intended for pasting into PR descriptions where Box Drawing characters (`├── └── │`) render correctly inside GitHub-flavored Markdown code blocks.

Selection works through all three existing input methods via the existing `Visual > marks > cursor` resolver — no new selection API was added:

- **cursor**: `yt` on a single line copies the relative path verbatim (short-circuit, no tree glyphs)
- **V-line**: `V`-select contiguous rows then `yt`
- **marks** (most useful for PR descriptions): mark files in different directories with `m`, then `yt` collects them all into one tree

Example output for marking `src/foo.ts` + `src/bar.ts` + `tests/baz.ts`:

```
./
├── src/
│   ├── bar.ts
│   └── foo.ts
└── tests/
    └── baz.ts
```

### Behavior details

- Common ancestor of the selection becomes the header row (`./` when the ancestor is the explorer root, otherwise the relative path)
- Scaffold and explicitly-selected directories render identically (`src/` is printed once even if both `src/` and `src/foo.ts` are selected)
- Children at each level are ordered directories-first + natural sort, matching the visible explorer order (`Store:children` convention, shared via the newly-exported `Store.natural_sort_key`)
- Symlinks render as the basename with no suffix
- When `origin == "marks"`, marks are cleared and the view is refreshed (mirroring `copy`'s conditional refresh, not `cut`'s unconditional one)
- Empty selection (e.g. V-line on the root header alone) emits a WARN notification instead of failing silently — yank actions need explicit feedback

### Default keymap

`yt` is added under the existing `yp` / `yP` / `yn` yank family. Disable per user preference with `mappings.yt = false`.

## Implementation notes

- `lua/eda/tree/ascii.lua` (new) — pure function `M.render(nodes, root_path)`, sorted-path + depth-stack algorithm (no trie). Handles the empty / single-node / multi-node / dir+child dedup / scaffold cases.
- `lua/eda/action/builtin.lua` — action placed after `copy` (Lua scoping requires `get_target_nodes` local to be in scope first)
- `lua/eda/buffer/init.lua` — `yank_tree` added to `visual_mode_actions` whitelist so the `yt` keymap binds in both normal and visual modes (without this, V-line + `y` falls back to vim's built-in operator and waits for a `t` motion character)
- `lua/eda/tree/store.lua` — `Store.natural_sort_key` exposed so the formatter shares the same comparator (avoids drift between rendered views)

## Test plan

- [x] `nix develop --command just test` — `tests/tree/test_ascii.lua` covers 11 scenarios (empty / single file / single directory / root-direct file / canonical example with dir+child dedup / non-root common ancestor / dirs-only / symlink / mixed dir+file natural sort / numeric segment natural sort / deeply nested scaffolding); `tests/action/test_builtin.lua` covers cursor / marks / V-line / empty WARN notify / marks-clear / visual-leaves-marks
- [x] `nix develop --command just test-e2e` — `tests/e2e/test_yank_tree.lua` injects a mock clipboard provider into the child Neovim and verifies all three origin paths produce the expected register content
- [x] `nix develop --command just format-check` / `lint` / `typecheck` — all clean
- [x] `nix develop --command just doc` — `doc/eda.nvim.txt` regenerated, 3 new hits for `yank_tree`

## References

- n/a
