### PR TITLE
feat: add open_in_browser action for GitHub/GHE

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -101,6 +101,11 @@ require("eda").setup({
     icon = "󰄲",        -- nf-md-checkbox_marked (U+F0132)
   },
 
+  open_in_browser = {
+    ref = "branch",
+    url_builder = nil,
+  },
+
   header = {
     format = "short",
     position = "left",
@@ -135,6 +140,7 @@ require("eda").setup({
     ["m"] = "mark_toggle",
     ["D"] = "delete",
     ["go"] = "system_open",
+    ["gO"] = "open_in_browser",
     ["K"] = "debug",
     ["<leader>i"] = "inspect",
     ["gd"] = "duplicate",
@@ -517,6 +523,48 @@ detection do not apply to directory previews.
 To remove the default `gq` mapping entirely, set
 `mappings = { ["gq"] = false }`.
 
+### open_in_browser
+
+`table`
+
+Configuration for the `open_in_browser` action that opens the selected node on
+the remote repository host (GitHub.com / GitHub Enterprise).
+
+- `ref` `"branch"|"sha"|"default_branch"` (default: `"branch"`)
+  Which git ref to embed in the URL. `branch` uses the current branch and its
+  remote tracking name; on detached HEAD or when no upstream is configured it
+  falls back to the SHA, then to the default branch. `sha` always builds a
+  permalink to the current HEAD (best for sharing). `default_branch` resolves
+  via `origin/HEAD`, falling back to `origin/main` then `origin/master`.
+
+- `url_builder` `function?` (default: `nil`)
+  Custom URL composer. Signature: `fun(ctx: OpenInBrowserCtx): string?`.
+  Return a string to use it as the URL, or `nil` to let the built-in GitHub
+  composer handle it. The built-in only knows GitHub-style URLs
+  (`/blob/<ref>/<path>` and `/tree/<ref>/<path>`); for GitLab, Bitbucket, or
+  other hosts, supply this builder. The `ctx` table is a stable contract with
+  the following keys:
+  - `node` — the `eda.TreeNode` being opened.
+  - `relative_path` — path relative to the **git repository root** (empty for the
+    repository root itself). When eda is opened in a subdirectory of the repo,
+    this still starts from the git root so the resulting URL matches the remote
+    layout.
+  - `ref` — the resolved ref string (branch name, SHA, or default branch).
+  - `ref_kind` — `"branch"|"sha"|"default_branch"`.
+  - `remote_url` — the raw `origin` remote URL.
+  - `host`, `owner`, `repo` — parsed components of `remote_url`.
+  - `kind` — `"blob"` for files, `"tree"` for directories.
+
+The current node's git status gates the action: untracked / added (staged) /
+gitignored files are blocked with a notification, since the URL would 404.
+
+`git remote.origin.url.insteadOf` and SSH config Host aliases are not resolved
+automatically — set `url_builder` if your remote URL needs translation before
+parsing.
+
+To remove the default `gO` mapping entirely, set
+`mappings = { ["gO"] = false }`.
+
 ### header
 
 `table|false`
@@ -681,6 +729,7 @@ configuration option.
 | `M`     | mark_clear_all     | Clear all marks               |
 | `D`     | delete             | Delete target nodes (Visual > marks > cursor) |
 | `go`    | system_open        | Open with system default app  |
+| `gO`    | open_in_browser    | Open on the remote repository host (GitHub/GHE) |
 | `K`     | debug              | Print node data for debugging |
 | `<leader>i` | inspect        | Show node stat in a floating window |
 | `gd`    | duplicate          | Duplicate target nodes (Visual > marks > cursor) |
@@ -809,6 +858,15 @@ success (partial failures keep the marks for the failed/unattempted entries).
 - **close** — Close the explorer window.
 - **system_open** — Open the file with the system default application
   (`open` on macOS, `xdg-open` on Linux).
+- **open_in_browser** — Open the selected node on the remote repository host
+  (GitHub.com or GitHub Enterprise). Single target only; multiple-selection
+  via Visual or marks is rejected. Blocks files whose git status is
+  untracked / added / ignored (would 404 on the remote). Ref resolution falls
+  back through branch → SHA → default branch. The buffer-local mapping `gO`
+  overrides Neovim's built-in `gO` (table of contents) inside `eda` buffers
+  and is the network counterpart to `go` / `system_open`. Customize via the
+  `open_in_browser` config (see `### open_in_browser`).
+  Default mapping: `gO`
 - **debug** — Print the node data to the console (developer API).
   Default mapping: `K`
 - **inspect** — Show node stat (size, permissions, timestamps, symlink

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -120,6 +120,11 @@ DEFAULT CONFIGURATION ~
         icon = "󰄲",        -- nf-md-checkbox_marked (U+F0132)
       },
     
+      open_in_browser = {
+        ref = "branch",
+        url_builder = nil,
+      },
+    
       header = {
         format = "short",
         position = "left",
@@ -154,6 +159,7 @@ DEFAULT CONFIGURATION ~
         ["m"] = "mark_toggle",
         ["D"] = "delete",
         ["go"] = "system_open",
+        ["gO"] = "open_in_browser",
         ["K"] = "debug",
         ["<leader>i"] = "inspect",
         ["gd"] = "duplicate",
@@ -535,6 +541,47 @@ To remove the default `gq` mapping entirely, set `mappings = { ["gq"] = false
 }`.
 
 
+OPEN_IN_BROWSER ~
+
+`table`
+
+Configuration for the `open_in_browser` action that opens the selected node on
+the remote repository host (GitHub.com / GitHub Enterprise).
+
+- `ref` `"branch"|"sha"|"default_branch"` (default: `"branch"`) Which git ref to
+    embed in the URL. `branch` uses the current branch and its remote tracking
+    name; on detached HEAD or when no upstream is configured it falls back to the
+    SHA, then to the default branch. `sha` always builds a permalink to the current
+    HEAD (best for sharing). `default_branch` resolves via `origin/HEAD`, falling
+    back to `origin/main` then `origin/master`.
+- `url_builder` `function?` (default: `nil`) Custom URL composer. Signature:
+    `fun(ctx: OpenInBrowserCtx): string?`. Return a string to use it as the URL, or
+    `nil` to let the built-in GitHub composer handle it. The built-in only knows
+    GitHub-style URLs (`/blob/<ref>/<path>` and `/tree/<ref>/<path>`); for GitLab,
+    Bitbucket, or other hosts, supply this builder. The `ctx` table is a stable
+    contract with the following keys:
+    - `node` — the `eda.TreeNode` being opened.
+    - `relative_path` — path relative to the **git repository root** (empty for the
+        repository root itself). When eda is opened in a subdirectory of the repo,
+        this still starts from the git root so the resulting URL matches the remote
+        layout.
+    - `ref` — the resolved ref string (branch name, SHA, or default branch).
+    - `ref_kind` — `"branch"|"sha"|"default_branch"`.
+    - `remote_url` — the raw `origin` remote URL.
+    - `host`, `owner`, `repo` — parsed components of `remote_url`.
+    - `kind` — `"blob"` for files, `"tree"` for directories.
+
+The current node’s git status gates the action: untracked / added (staged) /
+gitignored files are blocked with a notification, since the URL would 404.
+
+`git remote.origin.url.insteadOf` and SSH config Host aliases are not resolved
+automatically — set `url_builder` if your remote URL needs translation before
+parsing.
+
+To remove the default `gO` mapping entirely, set `mappings = { ["gO"] = false
+}`.
+
+
 HEADER ~
 
 `table|false`
@@ -737,6 +784,9 @@ configuration option.
 
   go              system_open             Open with system default app
 
+  gO              open_in_browser         Open on the remote repository host
+                                          (GitHub/GHE)
+
   K               debug                   Print node data for debugging
 
   <leader>i       inspect                 Show node stat in a floating window
@@ -889,6 +939,15 @@ MISC ~
 - **close** — Close the explorer window.
 - **system_open** — Open the file with the system default application
     (`open` on macOS, `xdg-open` on Linux).
+- **open_in_browser** — Open the selected node on the remote repository host
+    (GitHub.com or GitHub Enterprise). Single target only; multiple-selection
+    via Visual or marks is rejected. Blocks files whose git status is
+    untracked / added / ignored (would 404 on the remote). Ref resolution falls
+    back through branch → SHA → default branch. The buffer-local mapping `gO`
+    overrides Neovim’s built-in `gO` (table of contents) inside `eda` buffers
+    and is the network counterpart to `go` / `system_open`. Customize via the
+    `open_in_browser` config (see `### open_in_browser`).
+    Default mapping: `gO`
 - **debug** — Print the node data to the console (developer API).
     Default mapping: `K`
 - **inspect** — Show node stat (size, permissions, timestamps, symlink

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -1096,6 +1096,94 @@ action.register("yank_tree", function(ctx)
   end
 end, { desc = "Yank selected nodes as ASCII tree (Visual > marks > cursor)" })
 
+action.register("open_in_browser", function(ctx)
+  local git_url = require("eda.git_url")
+  local target = get_target_nodes(ctx)
+  if #target.nodes == 0 then
+    return
+  end
+  if #target.nodes > 1 then
+    vim.notify(git_url.MSG.multi_target, vim.log.levels.ERROR)
+    return
+  end
+
+  local node = target.nodes[1]
+  local root = ctx.explorer.root_path
+
+  local git_root = git.find_git_root(root)
+  if not git_root then
+    vim.notify(git_url.MSG.no_repo, vim.log.levels.ERROR)
+    return
+  end
+
+  if ctx.config.git and ctx.config.git.enabled then
+    local ready = git.get_status_ready(root)
+    if ready == "loading" then
+      vim.notify(git_url.MSG.loading, vim.log.levels.WARN)
+      return
+    end
+    if ready == "no_repo" then
+      vim.notify(git_url.MSG.no_repo, vim.log.levels.ERROR)
+      return
+    end
+    local statuses = git.get_cached(root) or {}
+    local status = statuses[node.path]
+    if status == "?" then
+      vim.notify(git_url.MSG.untracked, vim.log.levels.ERROR)
+      return
+    elseif status == "A" then
+      vim.notify(git_url.MSG.added, vim.log.levels.ERROR)
+      return
+    elseif status == "!" then
+      vim.notify(git_url.MSG.ignored, vim.log.levels.ERROR)
+      return
+    end
+  end
+
+  -- URL paths are relative to git_root, not the eda explorer root: when eda
+  -- opens a subdirectory of a repo, the remote tree still starts at git_root.
+  local relative_path
+  if node.path == git_root then
+    relative_path = ""
+  else
+    relative_path = node.path:sub(#git_root + 2)
+  end
+
+  local node_type = node.type == "directory" and "tree" or "blob"
+
+  local remote_url = git_url.resolve_remote_url(git_root)
+  if not remote_url then
+    vim.notify(git_url.MSG.no_remote, vim.log.levels.ERROR)
+    return
+  end
+
+  local parsed = git_url.parse_remote(remote_url)
+  if not parsed then
+    vim.notify(git_url.MSG.unparseable_remote, vim.log.levels.ERROR)
+    return
+  end
+
+  local ref_info = git_url.resolve_ref(git_root, ctx.config.open_in_browser.ref)
+  if not ref_info then
+    vim.notify(git_url.MSG.no_resolvable_ref, vim.log.levels.ERROR)
+    return
+  end
+
+  local ctx_table = {
+    node = node,
+    relative_path = relative_path,
+    ref = ref_info.ref,
+    ref_kind = ref_info.ref_kind,
+    remote_url = remote_url,
+    host = parsed.host,
+    owner = parsed.owner,
+    repo = parsed.repo,
+    kind = node_type,
+  }
+  local url = git_url.build_url(ctx_table, ctx.config.open_in_browser)
+  vim.ui.open(url)
+end, { desc = "Open the selected node on the remote repository host (GitHub/GHE)" })
+
 action.register("quickfix", function(ctx)
   local target = get_target_nodes(ctx)
   if #target.nodes == 0 then

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -45,6 +45,7 @@ local M = {}
 ---@field inspect eda.InspectConfig
 ---@field mark eda.MarkConfig
 ---@field quickfix eda.QuickfixConfig
+---@field open_in_browser eda.OpenInBrowserConfig
 ---@field header eda.HeaderConfig|false
 ---@field expand_depth integer
 ---@field update_focused_file eda.UpdateFocusedFileConfig
@@ -111,6 +112,21 @@ local M = {}
 
 ---@class eda.QuickfixConfig
 ---@field auto_open boolean
+
+---@class eda.OpenInBrowserCtx
+---@field node eda.TreeNode
+---@field relative_path string
+---@field ref string
+---@field ref_kind "branch"|"sha"|"default_branch"
+---@field remote_url string
+---@field host string
+---@field owner string
+---@field repo string
+---@field kind "blob"|"tree"
+
+---@class eda.OpenInBrowserConfig
+---@field ref "branch"|"sha"|"default_branch"
+---@field url_builder? fun(ctx: eda.OpenInBrowserCtx): string?
 
 ---@alias eda.HeaderPosition "left" | "center" | "right"
 
@@ -219,6 +235,11 @@ local defaults = {
     auto_open = true,
   },
 
+  open_in_browser = {
+    ref = "branch",
+    url_builder = nil,
+  },
+
   header = {
     format = "short",
     position = "left",
@@ -254,6 +275,7 @@ local defaults = {
     ["M"] = "mark_clear_all",
     ["D"] = "delete",
     ["go"] = "system_open",
+    ["gO"] = "open_in_browser",
     ["K"] = "debug",
     ["<leader>i"] = "inspect",
     ["gd"] = "duplicate",

--- a/lua/eda/git.lua
+++ b/lua/eda/git.lua
@@ -110,6 +110,13 @@ local function find_git_root(root)
   return git_root
 end
 
+---Public alias for find_git_root.
+---@param root string
+---@return string?
+function M.find_git_root(root)
+  return find_git_root(root)
+end
+
 ---Get git status for a directory asynchronously.
 ---@param root string Root directory path
 ---@param cb fun(status: table<string, string>?)

--- a/lua/eda/git_url.lua
+++ b/lua/eda/git_url.lua
@@ -1,0 +1,277 @@
+local M = {}
+
+---@class eda.GitUrlBuildArgs
+---@field host string
+---@field owner string
+---@field repo string
+---@field ref string
+---@field rel_path string
+---@field node_type "file"|"directory"
+
+---@class eda.GitUrlExecResult
+---@field stdout string
+---@field code integer
+
+M.MSG = {
+  untracked = "open_in_browser: file is untracked, not on remote",
+  added = "open_in_browser: file is added (staged), not committed yet",
+  ignored = "open_in_browser: file is gitignored, not on remote",
+  multi_target = "open_in_browser: select a single node (multi-selection is not supported)",
+  no_remote = "open_in_browser: cannot find origin remote",
+  no_repo = "open_in_browser: not in a git repository",
+  loading = "open_in_browser: git status not ready, retry shortly",
+  no_resolvable_ref = "open_in_browser: cannot resolve a remote-known ref. Push the branch or set open_in_browser.ref.",
+  unparseable_remote = "open_in_browser: cannot parse remote URL. Set open_in_browser.url_builder for custom hosts.",
+  url_builder_error = "open_in_browser: url_builder error",
+  timeout = "open_in_browser: git command timed out",
+}
+
+---@param s string
+---@return string
+local function trim(s)
+  return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+---Run a git subcommand inside `git_root`. Exposed as a table field for test injection.
+--- Synchronous on purpose: action is user-initiated, runs at most ~5 git calls per
+--- invocation, and keeps the fallback logic readable. The 2s per-call timeout caps
+--- the worst case. On timeout, this function emits MSG.timeout directly so the
+--- caller does not need to distinguish hang from other failures.
+---@param git_root string
+---@param args string[]
+---@return eda.GitUrlExecResult
+function M._exec(git_root, args)
+  local cmd = { "git", "-C", git_root }
+  for _, a in ipairs(args) do
+    table.insert(cmd, a)
+  end
+  local result = vim.system(cmd, { text = true, timeout = 2000 }):wait()
+  -- vim.system kills the process with SIGKILL (signal 9) when timeout expires.
+  if result.signal == 9 then
+    vim.notify(M.MSG.timeout, vim.log.levels.ERROR)
+  end
+  return { stdout = result.stdout or "", code = result.code or 1 }
+end
+
+---Percent-encode a URL path segment (RFC 3986 unreserved set is preserved).
+---Multi-byte UTF-8 characters are encoded byte-by-byte.
+---@param s string
+---@return string
+local function encode_segment(s)
+  return (s:gsub("([^A-Za-z0-9%-._~])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
+---Encode a path that may contain `/` separators: each segment is encoded; `/` itself is kept.
+---@param path string
+---@return string
+local function encode_path(path)
+  if path == "" then
+    return ""
+  end
+  local segs = {}
+  for seg in path:gmatch("[^/]+") do
+    table.insert(segs, encode_segment(seg))
+  end
+  return table.concat(segs, "/")
+end
+
+---Encode a git ref name. `/` is preserved (branches like `feature/foo` are valid refs).
+---@param ref string
+---@return string
+local function encode_ref(ref)
+  return (ref:gsub("([^A-Za-z0-9%-._~/])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
+---Parse a git remote URL into `{host, owner, repo}`.
+---Supports ssh://, git@host:, https://, http://, and git:// schemes.
+---Strips `.git` suffix and drops port. Returns `nil` for unparseable input.
+---@param url string?
+---@return {host: string, owner: string, repo: string}?
+function M.parse_remote(url)
+  if not url or url == "" then
+    return nil
+  end
+
+  -- ssh://[user@]host[:port]/owner/repo(.git)?
+  local rest = url:match("^ssh://(.+)$")
+  if rest then
+    rest = rest:gsub("^[^@/]+@", "")
+    rest = rest:gsub("^([^/]+):%d+/", "%1/")
+    local host, owner, repo = rest:match("^([^/]+)/([^/]+)/([^/]+)$")
+    if host then
+      return { host = host, owner = owner, repo = (repo:gsub("%.git$", "")) }
+    end
+    return nil
+  end
+
+  -- git@host:owner/repo(.git)?
+  do
+    local host, owner, repo = url:match("^git@([^:]+):([^/]+)/(.+)$")
+    if host then
+      return { host = host, owner = owner, repo = (repo:gsub("%.git$", "")) }
+    end
+  end
+
+  -- https?://[user@]?host/owner/repo(.git)?
+  do
+    local scheme_rest = url:match("^https?://(.+)$")
+    if scheme_rest then
+      scheme_rest = scheme_rest:gsub("^[^@/]+@", "")
+      local host, owner, repo = scheme_rest:match("^([^/]+)/([^/]+)/([^/]+)$")
+      if host then
+        return { host = host, owner = owner, repo = (repo:gsub("%.git$", "")) }
+      end
+    end
+  end
+
+  -- git://host/owner/repo(.git)?
+  do
+    local host, owner, repo = url:match("^git://([^/]+)/([^/]+)/([^/]+)$")
+    if host then
+      return { host = host, owner = owner, repo = (repo:gsub("%.git$", "")) }
+    end
+  end
+
+  return nil
+end
+
+---Fetch the origin remote URL via `git remote get-url origin`.
+---@param git_root string
+---@return string?
+function M.resolve_remote_url(git_root)
+  local result = M._exec(git_root, { "remote", "get-url", "origin" })
+  if result.code ~= 0 then
+    return nil
+  end
+  local url = trim(result.stdout)
+  if url == "" then
+    return nil
+  end
+  return url
+end
+
+---Probe `origin/main` and `origin/master` as last-resort default branch fallback.
+---@param git_root string
+---@return {ref: string, ref_kind: "default_branch"}?
+local function resolve_default_branch_probe(git_root)
+  local origin_head = M._exec(git_root, { "symbolic-ref", "--short", "refs/remotes/origin/HEAD" })
+  if origin_head.code == 0 then
+    local head = trim(origin_head.stdout)
+    local _, branch = head:match("^([^/]+)/(.+)$")
+    if branch and branch ~= "" then
+      return { ref = branch, ref_kind = "default_branch" }
+    end
+  end
+  for _, name in ipairs({ "main", "master" }) do
+    local probe = M._exec(git_root, { "rev-parse", "--verify", "origin/" .. name })
+    if probe.code == 0 then
+      return { ref = name, ref_kind = "default_branch" }
+    end
+  end
+  return nil
+end
+
+---Resolve the ref name to embed in the URL, following the fallback chain:
+---  branch → (no upstream or detached) → sha → (unpushed) → default_branch → nil.
+---@param git_root string
+---@param config_ref "branch"|"sha"|"default_branch"
+---@return {ref: string, ref_kind: "branch"|"sha"|"default_branch"}?
+function M.resolve_ref(git_root, config_ref)
+  if config_ref == "branch" then
+    local branch_result = M._exec(git_root, { "rev-parse", "--abbrev-ref", "HEAD" })
+    if branch_result.code == 0 then
+      local branch = trim(branch_result.stdout)
+      if branch ~= "" and branch ~= "HEAD" then
+        local upstream = M._exec(git_root, { "rev-parse", "--abbrev-ref", branch .. "@{upstream}" })
+        if upstream.code == 0 then
+          local up = trim(upstream.stdout)
+          local _, remote_branch = up:match("^([^/]+)/(.+)$")
+          if remote_branch and remote_branch ~= "" then
+            return { ref = remote_branch, ref_kind = "branch" }
+          end
+        end
+      end
+    end
+    config_ref = "sha"
+  end
+
+  if config_ref == "sha" then
+    local sha_result = M._exec(git_root, { "rev-parse", "HEAD" })
+    if sha_result.code == 0 then
+      local sha = trim(sha_result.stdout)
+      if sha ~= "" then
+        local contains = M._exec(git_root, { "branch", "-r", "--contains", sha })
+        if contains.code == 0 and contains.stdout:match("origin/") then
+          return { ref = sha, ref_kind = "sha" }
+        end
+      end
+    end
+    config_ref = "default_branch"
+  end
+
+  if config_ref == "default_branch" then
+    return resolve_default_branch_probe(git_root)
+  end
+
+  return nil
+end
+
+---Compose a GitHub-style URL: `https://<host>/<owner>/<repo>/<kind>/<ref>/<rel_path>`.
+---Both `ref` and `rel_path` are encoded per-segment; `/` inside ref names is preserved.
+---@param args eda.GitUrlBuildArgs
+---@return string
+function M.build_github_url(args)
+  local kind = (args.node_type == "directory") and "tree" or "blob"
+  local encoded_ref = encode_ref(args.ref)
+  local encoded_path = encode_path(args.rel_path or "")
+  if encoded_path == "" then
+    return string.format("https://%s/%s/%s/%s/%s/", args.host, args.owner, args.repo, kind, encoded_ref)
+  end
+  return string.format("https://%s/%s/%s/%s/%s/%s", args.host, args.owner, args.repo, kind, encoded_ref, encoded_path)
+end
+
+---Public URL composer. Applies `url_builder` override with `pcall` safety, otherwise
+---falls back to the built-in GitHub URL composer.
+---@param ctx eda.OpenInBrowserCtx
+---@param config eda.OpenInBrowserConfig
+---@return string
+function M.build_url(ctx, config)
+  local function builtin()
+    return M.build_github_url({
+      host = ctx.host,
+      owner = ctx.owner,
+      repo = ctx.repo,
+      ref = ctx.ref,
+      rel_path = ctx.relative_path,
+      node_type = ctx.kind == "tree" and "directory" or "file",
+    })
+  end
+
+  if config.url_builder == nil then
+    return builtin()
+  end
+
+  local ok, result = pcall(config.url_builder, ctx)
+  if not ok then
+    vim.notify(M.MSG.url_builder_error .. ": " .. tostring(result), vim.log.levels.ERROR)
+    return builtin()
+  end
+  if type(result) == "string" then
+    if result ~= "" then
+      return result
+    end
+    vim.notify(M.MSG.url_builder_error .. ": empty string returned", vim.log.levels.ERROR)
+    return builtin()
+  end
+  if result ~= nil then
+    vim.notify(M.MSG.url_builder_error .. ": expected string, got " .. type(result), vim.log.levels.ERROR)
+    return builtin()
+  end
+  return builtin()
+end
+
+return M

--- a/tests/action/test_open_in_browser.lua
+++ b/tests/action/test_open_in_browser.lua
@@ -1,0 +1,330 @@
+local action = require("eda.action")
+local Store = require("eda.tree.store")
+
+require("eda.action.builtin")
+
+local T = MiniTest.new_set()
+
+local TEST_URL = "https://github.com/foo/bar/blob/main/file.lua"
+
+--- Captured state per test. `before_each` / `after_each` reset this and the
+--- vim.ui.open / module stubs around each case.
+---@class TestState
+---@field opened string[]
+---@field notified {msg: string, level: integer}[]
+
+---@type TestState
+local state = { opened = {}, notified = {} }
+
+local original = {
+  ui_open = nil,
+  notify = nil,
+  git = nil,
+  git_url = nil,
+}
+
+local function reset_state()
+  state.opened = {}
+  state.notified = {}
+end
+
+local function install_stubs(stub_config)
+  stub_config = stub_config or {}
+  reset_state()
+
+  -- Stub vim.ui.open
+  original.ui_open = vim.ui.open
+  vim.ui.open = function(url)
+    table.insert(state.opened, url)
+  end
+
+  -- Stub vim.notify
+  original.notify = vim.notify
+  vim.notify = function(msg, level)
+    table.insert(state.notified, { msg = msg, level = level })
+  end
+
+  -- Stub eda.git (function-level overrides on the module table)
+  local git = require("eda.git")
+  original.git = {
+    find_git_root = git.find_git_root,
+    get_status_ready = git.get_status_ready,
+    get_cached = git.get_cached,
+  }
+  git.find_git_root = function(_)
+    return stub_config.git_root or "/repo"
+  end
+  git.get_status_ready = function(_)
+    return stub_config.status_ready or "ready"
+  end
+  git.get_cached = function(_)
+    return stub_config.statuses or {}
+  end
+
+  -- Stub eda.git_url
+  local git_url = require("eda.git_url")
+  original.git_url = {
+    resolve_remote_url = git_url.resolve_remote_url,
+    parse_remote = git_url.parse_remote,
+    resolve_ref = git_url.resolve_ref,
+    build_url = git_url.build_url,
+  }
+  git_url.resolve_remote_url = function(_)
+    return stub_config.remote_url or "git@github.com:foo/bar.git"
+  end
+  git_url.parse_remote = function(_)
+    if stub_config.parse_remote_nil then
+      return nil
+    end
+    return { host = "github.com", owner = "foo", repo = "bar" }
+  end
+  git_url.resolve_ref = function(_, _)
+    if stub_config.resolve_ref_nil then
+      return nil
+    end
+    return { ref = "main", ref_kind = "branch" }
+  end
+  git_url.build_url = function(_, _)
+    return TEST_URL
+  end
+end
+
+local function restore_stubs()
+  vim.ui.open = original.ui_open
+  vim.notify = original.notify
+  if original.git then
+    local git = require("eda.git")
+    for k, v in pairs(original.git) do
+      git[k] = v
+    end
+  end
+  if original.git_url then
+    local git_url = require("eda.git_url")
+    for k, v in pairs(original.git_url) do
+      git_url[k] = v
+    end
+  end
+end
+
+--- Build a minimal context with one or more nodes targeted via cursor / marks / visual.
+---@param opts { cursor_id?: integer, marked_ids?: integer[], visual_ids?: integer[], config?: table }
+---@return table
+local function make_ctx(opts)
+  opts = opts or {}
+  local store = Store.new()
+  local root = store:set_root("/repo")
+  store:add({ name = "file1.lua", path = "/repo/file1.lua", type = "file", parent_id = root })
+  store:add({ name = "file2.lua", path = "/repo/file2.lua", type = "file", parent_id = root })
+  store:add({ name = "dir_a", path = "/repo/dir_a", type = "directory", parent_id = root, open = true })
+
+  for _, id in ipairs(opts.marked_ids or {}) do
+    store:get(id)._marked = true
+  end
+
+  local cursor_node = opts.cursor_id and store:get(opts.cursor_id) or nil
+
+  local mock_bufnr = vim.api.nvim_create_buf(false, true)
+
+  local visual_ids = opts.visual_ids
+  local flat_lines = {}
+  if visual_ids then
+    for i, id in ipairs(visual_ids) do
+      flat_lines[i] = { node_id = id }
+    end
+  end
+
+  local ctx = {
+    store = store,
+    buffer = {
+      bufnr = mock_bufnr,
+      get_cursor_node = function()
+        return cursor_node
+      end,
+      flat_lines = flat_lines,
+      header_lines = 0,
+    },
+    window = { winid = 0 },
+    scanner = {},
+    config = opts.config or {
+      git = { enabled = true },
+      open_in_browser = { ref = "branch", url_builder = nil },
+    },
+    explorer = { root_path = "/repo" },
+  }
+  return ctx
+end
+
+local function find_notify(predicate)
+  for _, n in ipairs(state.notified) do
+    if predicate(n.msg) then
+      return n
+    end
+  end
+  return nil
+end
+
+--- A test hook that activates visual mode (line-wise) over a given line range
+--- so `_get_visual_targets` in builtin.lua reads the correct range. We sidestep
+--- the real visual range by patching `get_cursor_node` plus using flat_lines and
+--- letting the action grab marked/cursor first instead. For multi-target Visual
+--- tests we route via marks (origin == "marks" with 2 nodes) — equivalent for
+--- the "single only" assertion.
+local function setup_marks_two(opts)
+  install_stubs(opts)
+  return make_ctx({ marked_ids = { 2, 3 } })
+end
+
+-- Hook setup: restore stubs after every case to prevent leakage.
+T = MiniTest.new_set({
+  hooks = {
+    post_case = function()
+      restore_stubs()
+    end,
+  },
+})
+
+-----------------------------------------------------------
+-- ctx empty / multi-target
+-----------------------------------------------------------
+T["ctx_empty_is_silent_no_op"] = function()
+  install_stubs()
+  local ctx = make_ctx({}) -- no cursor, no marks, no visual
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  MiniTest.expect.equality(#state.notified, 0)
+end
+
+T["multi_marks_notifies_and_does_not_open"] = function()
+  local ctx = setup_marks_two({})
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("single node", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+-----------------------------------------------------------
+-- git status block: ? / A / !
+-----------------------------------------------------------
+T["status_untracked_is_blocked"] = function()
+  install_stubs({ statuses = { ["/repo/file1.lua"] = "?" } })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("untracked", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+T["status_added_is_blocked"] = function()
+  install_stubs({ statuses = { ["/repo/file1.lua"] = "A" } })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("added", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+T["status_ignored_is_blocked"] = function()
+  install_stubs({ statuses = { ["/repo/file1.lua"] = "!" } })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("gitignored", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+-----------------------------------------------------------
+-- happy paths: M / clean / R
+-----------------------------------------------------------
+T["status_modified_opens_url"] = function()
+  install_stubs({ statuses = { ["/repo/file1.lua"] = "M" } })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(state.opened, { TEST_URL })
+end
+
+T["status_clean_opens_url"] = function()
+  install_stubs({ statuses = {} })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(state.opened, { TEST_URL })
+end
+
+T["status_renamed_opens_url"] = function()
+  install_stubs({ statuses = { ["/repo/file1.lua"] = "R" } })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(state.opened, { TEST_URL })
+end
+
+-----------------------------------------------------------
+-- config bypass + git readiness
+-----------------------------------------------------------
+T["git_disabled_bypasses_status_check"] = function()
+  install_stubs({ statuses = { ["/repo/file1.lua"] = "?" } }) -- untracked but we expect bypass
+  local ctx = make_ctx({
+    cursor_id = 2,
+    config = {
+      git = { enabled = false },
+      open_in_browser = { ref = "branch", url_builder = nil },
+    },
+  })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(state.opened, { TEST_URL })
+end
+
+T["git_loading_notifies_and_blocks"] = function()
+  install_stubs({ status_ready = "loading" })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("not ready", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+T["git_no_repo_notifies_and_blocks"] = function()
+  install_stubs({ status_ready = "no_repo" })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("not in a git repository", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+-----------------------------------------------------------
+-- URL composition failures
+-----------------------------------------------------------
+T["unparseable_remote_notifies_and_blocks"] = function()
+  install_stubs({ parse_remote_nil = true })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("parse remote", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+T["unresolvable_ref_notifies_and_blocks"] = function()
+  install_stubs({ resolve_ref_nil = true })
+  local ctx = make_ctx({ cursor_id = 2 })
+  action.dispatch("open_in_browser", ctx)
+  MiniTest.expect.equality(#state.opened, 0)
+  local m = find_notify(function(msg)
+    return msg:find("remote-known ref", 1, true) ~= nil
+  end)
+  MiniTest.expect.no_equality(m, nil)
+end
+
+return T

--- a/tests/e2e/test_open_in_browser.lua
+++ b/tests/e2e/test_open_in_browser.lua
@@ -1,0 +1,344 @@
+local e2e = require("e2e.helpers")
+
+local T = MiniTest.new_set()
+
+local child, tmp
+
+local function sh(args)
+  return vim.fn.system(args)
+end
+
+local function trim(s)
+  return (s:gsub("%s+$", ""))
+end
+
+--- Initialize a git repo at `dir` on branch `main` with one committed file
+--- (src/foo.lua) and a sub-directory src/. Returns the commit SHA.
+---@param dir string
+---@return string sha
+local function init_repo(dir)
+  sh({ "git", "init", "-b", "main", dir })
+  sh({ "git", "-C", dir, "config", "user.email", "test@test.com" })
+  sh({ "git", "-C", dir, "config", "user.name", "Test" })
+  e2e.create_dir(dir .. "/src")
+  e2e.create_file(dir .. "/src/foo.lua", "return 1\n")
+  sh({ "git", "-C", dir, "add", "." })
+  sh({ "git", "-C", dir, "commit", "-m", "init" })
+  return trim(sh({ "git", "-C", dir, "rev-parse", "HEAD" }))
+end
+
+--- Add `origin` remote (with the given URL) and seed remote-tracking refs so
+--- branch / SHA / default-branch fallbacks all have a happy local path.
+---@param dir string
+---@param sha string
+---@param remote_url? string
+local function seed_origin(dir, sha, remote_url)
+  remote_url = remote_url or "git@github.com:foo/bar.git"
+  sh({ "git", "-C", dir, "remote", "add", "origin", remote_url })
+  sh({ "git", "-C", dir, "update-ref", "refs/remotes/origin/main", sha })
+  sh({ "git", "-C", dir, "branch", "--set-upstream-to=origin/main", "main" })
+  sh({ "git", "-C", dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main" })
+end
+
+local function setup_eda_with_git(c)
+  e2e.exec(
+    c,
+    [[
+    require("eda").setup({
+      git = { enabled = true },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      open_in_browser = { ref = "branch", url_builder = nil },
+    })
+  ]]
+  )
+end
+
+local function inject_ui_open_stub(c)
+  e2e.exec(
+    c,
+    [[
+    _G.__eda_open_url = nil
+    _G.__eda_notify = {}
+    vim.ui.open = function(url) _G.__eda_open_url = url end
+    local orig = vim.notify
+    vim.notify = function(msg, level)
+      table.insert(_G.__eda_notify, { msg = msg, level = level })
+    end
+    _G.__eda_notify_orig = orig
+  ]]
+  )
+end
+
+local function wait_for_git_ready()
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+      local g = require("eda.git")
+      return g.get_status_ready(%q) == "ready"
+    ]],
+      tmp
+    )
+  )
+end
+
+local function wait_for_file_in_buffer(name)
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+      for _, l in ipairs(vim.api.nvim_buf_get_lines(0, 0, -1, false)) do
+        if l:find(%q, 1, true) then return true end
+      end
+      return false
+    ]],
+      name
+    )
+  )
+end
+
+local function cursor_to(name)
+  e2e.exec(
+    child,
+    string.format(
+      [[
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      for i, l in ipairs(lines) do
+        if l:find(%q, 1, true) then
+          vim.api.nvim_win_set_cursor(0, { i, 0 })
+          return
+        end
+      end
+      error("no line containing " .. %q)
+    ]],
+      name,
+      name
+    )
+  )
+end
+
+local function captured_url()
+  return e2e.exec(child, "return _G.__eda_open_url")
+end
+
+local function captured_notifications()
+  return e2e.exec(child, "return _G.__eda_notify or {}")
+end
+
+T["open_in_browser"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+T["open_in_browser"]["keymap path opens branch URL for a committed file"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  wait_for_git_ready()
+  cursor_to("foo.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.com/foo/bar/blob/main/src/foo.lua")
+end
+
+T["open_in_browser"]["dispatch path opens branch URL"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  wait_for_git_ready()
+  cursor_to("foo.lua")
+  e2e.exec(
+    child,
+    [[
+    local eda = require("eda")
+    local exp = eda.get_current()
+    local action = require("eda.action")
+    action.dispatch("open_in_browser", {
+      store = exp.store,
+      buffer = exp.buffer,
+      window = exp.window,
+      scanner = exp.scanner,
+      config = require("eda.config").get(),
+      explorer = exp,
+    })
+  ]]
+  )
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.com/foo/bar/blob/main/src/foo.lua")
+end
+
+T["open_in_browser"]["directory node uses /tree/ in URL"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("src")
+  wait_for_git_ready()
+  cursor_to("src")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.com/foo/bar/tree/main/src")
+end
+
+T["open_in_browser"]["untracked file is blocked with notification"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  e2e.create_file(tmp .. "/untracked.lua", "x")
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("untracked.lua")
+  wait_for_git_ready()
+  cursor_to("untracked.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(
+    child,
+    [[
+      for _, n in ipairs(_G.__eda_notify or {}) do
+        if n.msg:find("untracked", 1, true) then return true end
+      end
+      return false
+    ]]
+  )
+  MiniTest.expect.equality(captured_url(), vim.NIL)
+end
+
+T["open_in_browser"]["detached HEAD falls back to SHA URL"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  sh({ "git", "-C", tmp, "checkout", "--quiet", sha })
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  wait_for_git_ready()
+  cursor_to("foo.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  local url = captured_url()
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/" .. sha .. "/src/foo.lua")
+end
+
+T["open_in_browser"]["no upstream falls back to SHA URL"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  -- Drop upstream tracking but keep refs/remotes/origin/main so SHA is on remote.
+  sh({ "git", "-C", tmp, "branch", "--unset-upstream" })
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  wait_for_git_ready()
+  cursor_to("foo.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.com/foo/bar/blob/" .. sha .. "/src/foo.lua")
+end
+
+T["open_in_browser"]["default branch fallback when origin/HEAD missing"] = function()
+  local sha = init_repo(tmp)
+  -- Set up remote + origin/main ref + upstream but DELETE origin/HEAD so we
+  -- exercise the origin/main probe fallback. Use config sha = "deadbeef" so
+  -- 'branch -r --contains' finds nothing → falls through to default_branch.
+  sh({ "git", "-C", tmp, "remote", "add", "origin", "git@github.com:foo/bar.git" })
+  sh({ "git", "-C", tmp, "update-ref", "refs/remotes/origin/main", sha })
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({
+      git = { enabled = true },
+      icon = { provider = "none" },
+      window = { kind = "split_left", width = 40 },
+      confirm = false,
+      header = false,
+      open_in_browser = { ref = "default_branch", url_builder = nil },
+    })
+  ]]
+  )
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  wait_for_git_ready()
+  cursor_to("foo.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.com/foo/bar/blob/main/src/foo.lua")
+end
+
+T["open_in_browser"]["URL path is relative to git_root, not eda root"] = function()
+  -- eda is opened at tmp/src (a subdirectory of the git repo at tmp) so the
+  -- URL must include 'src/' even though the eda explorer root has hidden it.
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha)
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  local sub_dir = vim.uv.fs_realpath(tmp .. "/src")
+  e2e.exec(child, string.format([[require("eda").open({ dir = %q })]], sub_dir))
+  e2e.wait_until(
+    child,
+    [[
+    vim.bo.filetype == "eda"
+    and vim.api.nvim_buf_line_count(0) > 0
+    and vim.api.nvim_buf_get_lines(0, 0, 1, false)[1] ~= ""
+  ]]
+  )
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+      local g = require("eda.git")
+      return g.get_status_ready(%q) == "ready"
+    ]],
+      sub_dir
+    )
+  )
+  cursor_to("foo.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.com/foo/bar/blob/main/src/foo.lua")
+end
+
+T["open_in_browser"]["GHE host is preserved in URL"] = function()
+  local sha = init_repo(tmp)
+  seed_origin(tmp, sha, "git@github.example.com:foo/bar.git")
+  setup_eda_with_git(child)
+  inject_ui_open_stub(child)
+  e2e.open_eda(child, tmp)
+  e2e.feed(child, "gE")
+  wait_for_file_in_buffer("foo.lua")
+  wait_for_git_ready()
+  cursor_to("foo.lua")
+  e2e.feed(child, "gO")
+  e2e.wait_until(child, "_G.__eda_open_url ~= nil")
+  MiniTest.expect.equality(captured_url(), "https://github.example.com/foo/bar/blob/main/src/foo.lua")
+end
+
+return T

--- a/tests/test_git_url.lua
+++ b/tests/test_git_url.lua
@@ -1,0 +1,481 @@
+local T = MiniTest.new_set()
+
+-- Lazily reload module each test to ensure stub state is fresh.
+local function load()
+  package.loaded["eda.git_url"] = nil
+  return require("eda.git_url")
+end
+
+--- Build a stub _exec that dispatches based on git args.
+--- routes: table<string, {stdout=string, code=integer}> keyed by args joined with " ".
+--- Unmatched args return {stdout="", code=1} (simulate git failure).
+--- The stub ignores git_root since tests don't need to assert on it.
+---@param routes table<string, table>
+---@return fun(git_root: string, args: string[]): table
+local function make_exec(routes)
+  return function(_git_root, args)
+    local key = table.concat(args, " ")
+    local result = routes[key]
+    if result then
+      return result
+    end
+    return { stdout = "", code = 1 }
+  end
+end
+
+-----------------------------------------------------------
+-- parse_remote: scheme coverage
+-----------------------------------------------------------
+T["parse_remote"] = MiniTest.new_set()
+
+local parse_cases = {
+  {
+    name = "ssh_shorthand_with_git_suffix",
+    url = "git@github.com:foo/bar.git",
+    expected = { host = "github.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "ssh_shorthand_without_git_suffix",
+    url = "git@github.com:foo/bar",
+    expected = { host = "github.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "https_with_git_suffix",
+    url = "https://github.com/foo/bar.git",
+    expected = { host = "github.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "https_ghe_without_git_suffix",
+    url = "https://github.example.com/foo/bar",
+    expected = { host = "github.example.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "ssh_scheme_with_port",
+    url = "ssh://git@github.com:22/foo/bar.git",
+    expected = { host = "github.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "ssh_scheme_no_port",
+    url = "ssh://git@github.com/foo/bar.git",
+    expected = { host = "github.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "git_scheme",
+    url = "git://github.com/foo/bar",
+    expected = { host = "github.com", owner = "foo", repo = "bar" },
+  },
+  {
+    name = "http_scheme",
+    url = "http://github.example.com/foo/bar.git",
+    expected = { host = "github.example.com", owner = "foo", repo = "bar" },
+  },
+}
+
+for _, case in ipairs(parse_cases) do
+  T["parse_remote"][case.name] = function()
+    local m = load()
+    MiniTest.expect.equality(m.parse_remote(case.url), case.expected)
+  end
+end
+
+T["parse_remote"]["unparseable_returns_nil"] = function()
+  local m = load()
+  MiniTest.expect.equality(m.parse_remote("gh:foo/bar"), nil)
+  MiniTest.expect.equality(m.parse_remote("not_a_url"), nil)
+  MiniTest.expect.equality(m.parse_remote(""), nil)
+end
+
+-----------------------------------------------------------
+-- build_github_url: URL composition + encoding
+-----------------------------------------------------------
+T["build_github_url"] = MiniTest.new_set()
+
+T["build_github_url"]["file_blob"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "main",
+    rel_path = "lua/eda/init.lua",
+    node_type = "file",
+  })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/lua/eda/init.lua")
+end
+
+T["build_github_url"]["dir_tree"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "main",
+    rel_path = "lua",
+    node_type = "directory",
+  })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/tree/main/lua")
+end
+
+T["build_github_url"]["root_tree"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "main",
+    rel_path = "",
+    node_type = "directory",
+  })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/tree/main/")
+end
+
+T["build_github_url"]["path_with_space_is_encoded"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "main",
+    rel_path = "docs/hello world.md",
+    node_type = "file",
+  })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/docs/hello%20world.md")
+end
+
+T["build_github_url"]["path_with_hash_is_encoded"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "main",
+    rel_path = "docs/issue#1.md",
+    node_type = "file",
+  })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/docs/issue%231.md")
+end
+
+T["build_github_url"]["path_with_japanese_is_encoded"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "main",
+    rel_path = "docs/日本語.md",
+    node_type = "file",
+  })
+  -- "日本語" = E6 97 A5 E6 9C AC E8 AA 9E in UTF-8
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/docs/%E6%97%A5%E6%9C%AC%E8%AA%9E.md")
+end
+
+T["build_github_url"]["branch_with_slash_preserved"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "feature/foo",
+    rel_path = "x.lua",
+    node_type = "file",
+  })
+  -- Slashes inside a branch name are part of the ref hierarchy and must remain literal.
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/feature/foo/x.lua")
+end
+
+T["build_github_url"]["branch_with_hash_is_encoded"] = function()
+  local m = load()
+  local url = m.build_github_url({
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    ref = "fix#1",
+    rel_path = "x.lua",
+    node_type = "file",
+  })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/fix%231/x.lua")
+end
+
+-----------------------------------------------------------
+-- resolve_ref: fallback chain with stubbed _exec
+-----------------------------------------------------------
+T["resolve_ref"] = MiniTest.new_set()
+
+T["resolve_ref"]["branch_with_upstream"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["rev-parse --abbrev-ref HEAD"] = { stdout = "feature/foo\n", code = 0 },
+    ["rev-parse --abbrev-ref feature/foo@{upstream}"] = { stdout = "origin/feature/foo\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "branch")
+  MiniTest.expect.equality(result, { ref = "feature/foo", ref_kind = "branch" })
+end
+
+T["resolve_ref"]["branch_without_upstream_falls_back_to_pushed_sha"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["rev-parse --abbrev-ref HEAD"] = { stdout = "feature/foo\n", code = 0 },
+    ["rev-parse --abbrev-ref feature/foo@{upstream}"] = { stdout = "", code = 128 },
+    ["rev-parse HEAD"] = { stdout = "abc123\n", code = 0 },
+    ["branch -r --contains abc123"] = { stdout = "  origin/main\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "branch")
+  MiniTest.expect.equality(result, { ref = "abc123", ref_kind = "sha" })
+end
+
+T["resolve_ref"]["sha_pushed"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["rev-parse HEAD"] = { stdout = "abc123\n", code = 0 },
+    ["branch -r --contains abc123"] = { stdout = "  origin/main\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "sha")
+  MiniTest.expect.equality(result, { ref = "abc123", ref_kind = "sha" })
+end
+
+T["resolve_ref"]["sha_unpushed_falls_back_to_default_branch"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["rev-parse HEAD"] = { stdout = "abc123\n", code = 0 },
+    ["branch -r --contains abc123"] = { stdout = "", code = 0 },
+    ["symbolic-ref --short refs/remotes/origin/HEAD"] = { stdout = "origin/main\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "sha")
+  MiniTest.expect.equality(result, { ref = "main", ref_kind = "default_branch" })
+end
+
+T["resolve_ref"]["default_branch_via_origin_HEAD"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["symbolic-ref --short refs/remotes/origin/HEAD"] = { stdout = "origin/main\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "default_branch")
+  MiniTest.expect.equality(result, { ref = "main", ref_kind = "default_branch" })
+end
+
+T["resolve_ref"]["default_branch_probes_origin_main_when_HEAD_missing"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["symbolic-ref --short refs/remotes/origin/HEAD"] = { stdout = "", code = 128 },
+    ["rev-parse --verify origin/main"] = { stdout = "abc123\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "default_branch")
+  MiniTest.expect.equality(result, { ref = "main", ref_kind = "default_branch" })
+end
+
+T["resolve_ref"]["default_branch_probes_origin_master_when_main_missing"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["symbolic-ref --short refs/remotes/origin/HEAD"] = { stdout = "", code = 128 },
+    ["rev-parse --verify origin/main"] = { stdout = "", code = 128 },
+    ["rev-parse --verify origin/master"] = { stdout = "abc123\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "default_branch")
+  MiniTest.expect.equality(result, { ref = "master", ref_kind = "default_branch" })
+end
+
+T["resolve_ref"]["all_fail_returns_nil"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["rev-parse --abbrev-ref HEAD"] = { stdout = "HEAD\n", code = 0 }, -- detached
+    ["rev-parse HEAD"] = { stdout = "abc123\n", code = 0 },
+    ["branch -r --contains abc123"] = { stdout = "", code = 0 },
+    ["symbolic-ref --short refs/remotes/origin/HEAD"] = { stdout = "", code = 128 },
+    ["rev-parse --verify origin/main"] = { stdout = "", code = 128 },
+    ["rev-parse --verify origin/master"] = { stdout = "", code = 128 },
+  })
+  local result = m.resolve_ref("/repo", "branch")
+  MiniTest.expect.equality(result, nil)
+end
+
+T["resolve_ref"]["detached_HEAD_falls_to_sha_path"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["rev-parse --abbrev-ref HEAD"] = { stdout = "HEAD\n", code = 0 },
+    ["rev-parse HEAD"] = { stdout = "abc123\n", code = 0 },
+    ["branch -r --contains abc123"] = { stdout = "  origin/main\n", code = 0 },
+  })
+  local result = m.resolve_ref("/repo", "branch")
+  MiniTest.expect.equality(result, { ref = "abc123", ref_kind = "sha" })
+end
+
+-----------------------------------------------------------
+-- resolve_remote_url
+-----------------------------------------------------------
+T["resolve_remote_url"] = MiniTest.new_set()
+
+T["resolve_remote_url"]["returns_origin_url"] = function()
+  local m = load()
+  m._exec = make_exec({
+    ["remote get-url origin"] = { stdout = "git@github.com:foo/bar.git\n", code = 0 },
+  })
+  MiniTest.expect.equality(m.resolve_remote_url("/repo"), "git@github.com:foo/bar.git")
+end
+
+T["resolve_remote_url"]["returns_nil_when_no_origin"] = function()
+  local m = load()
+  m._exec = make_exec({})
+  MiniTest.expect.equality(m.resolve_remote_url("/repo"), nil)
+end
+
+-----------------------------------------------------------
+-- build_url: url_builder override + pcall safety + ctx schema
+-----------------------------------------------------------
+T["build_url"] = MiniTest.new_set()
+
+local function sample_ctx()
+  return {
+    node = { type = "file", path = "/project/lua/init.lua" },
+    relative_path = "lua/init.lua",
+    ref = "main",
+    ref_kind = "branch",
+    remote_url = "git@github.com:foo/bar.git",
+    host = "github.com",
+    owner = "foo",
+    repo = "bar",
+    kind = "blob",
+  }
+end
+
+T["build_url"]["uses_builtin_when_builder_nil"] = function()
+  local m = load()
+  local url = m.build_url(sample_ctx(), { ref = "branch", url_builder = nil })
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/lua/init.lua")
+end
+
+T["build_url"]["uses_builder_return_when_string"] = function()
+  local m = load()
+  local config = {
+    ref = "branch",
+    url_builder = function(_)
+      return "https://custom.example.com/x"
+    end,
+  }
+  MiniTest.expect.equality(m.build_url(sample_ctx(), config), "https://custom.example.com/x")
+end
+
+T["build_url"]["falls_back_when_builder_returns_nil"] = function()
+  local m = load()
+  local config = {
+    ref = "branch",
+    url_builder = function(_)
+      return nil
+    end,
+  }
+  MiniTest.expect.equality(m.build_url(sample_ctx(), config), "https://github.com/foo/bar/blob/main/lua/init.lua")
+end
+
+T["build_url"]["falls_back_when_builder_raises"] = function()
+  local m = load()
+  local notify_msgs = {}
+  local original_notify = vim.notify
+  vim.notify = function(msg, _)
+    table.insert(notify_msgs, msg)
+  end
+  local config = {
+    ref = "branch",
+    url_builder = function(_)
+      error("boom")
+    end,
+  }
+  local ok, url = pcall(m.build_url, sample_ctx(), config)
+  vim.notify = original_notify
+  MiniTest.expect.equality(ok, true)
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/lua/init.lua")
+  MiniTest.expect.equality(#notify_msgs >= 1, true)
+end
+
+T["build_url"]["falls_back_when_builder_returns_non_string"] = function()
+  local m = load()
+  local notify_msgs = {}
+  local original_notify = vim.notify
+  vim.notify = function(msg, _)
+    table.insert(notify_msgs, msg)
+  end
+  local config = {
+    ref = "branch",
+    url_builder = function(_)
+      return 42
+    end,
+  }
+  local url = m.build_url(sample_ctx(), config)
+  vim.notify = original_notify
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/lua/init.lua")
+  MiniTest.expect.equality(#notify_msgs >= 1, true)
+end
+
+T["build_url"]["falls_back_when_builder_returns_empty_string"] = function()
+  local m = load()
+  local notify_msgs = {}
+  local original_notify = vim.notify
+  vim.notify = function(msg, _)
+    table.insert(notify_msgs, msg)
+  end
+  local config = {
+    ref = "branch",
+    url_builder = function(_)
+      return ""
+    end,
+  }
+  local url = m.build_url(sample_ctx(), config)
+  vim.notify = original_notify
+  MiniTest.expect.equality(url, "https://github.com/foo/bar/blob/main/lua/init.lua")
+  MiniTest.expect.equality(#notify_msgs >= 1, true)
+end
+
+T["build_url"]["ctx_table_schema_snapshot"] = function()
+  local m = load()
+  local captured = nil
+  local config = {
+    ref = "branch",
+    url_builder = function(c)
+      captured = c
+      return nil
+    end,
+  }
+  m.build_url(sample_ctx(), config)
+  MiniTest.expect.equality(type(captured), "table")
+  local keys = {}
+  for k in pairs(captured) do
+    table.insert(keys, k)
+  end
+  table.sort(keys)
+  MiniTest.expect.equality(keys, {
+    "host",
+    "kind",
+    "node",
+    "owner",
+    "ref",
+    "ref_kind",
+    "relative_path",
+    "remote_url",
+    "repo",
+  })
+end
+
+-----------------------------------------------------------
+-- MSG table existence
+-----------------------------------------------------------
+T["MSG"] = MiniTest.new_set()
+
+T["MSG"]["exposes_required_keys"] = function()
+  local m = load()
+  local required = {
+    "untracked",
+    "added",
+    "ignored",
+    "multi_target",
+    "no_remote",
+    "no_repo",
+    "loading",
+    "no_resolvable_ref",
+    "unparseable_remote",
+    "url_builder_error",
+    "timeout",
+  }
+  for _, key in ipairs(required) do
+    MiniTest.expect.equality(type(m.MSG[key]), "string")
+  end
+end
+
+return T


### PR DESCRIPTION
## Summary

Adds an `open_in_browser` action that opens the node under cursor (or a single marked / Visual-selected node) on the remote repository host (GitHub.com / GitHub Enterprise) via `vim.ui.open`. Pairs with the existing `go` / `system_open` as its network counterpart. Default mapping: `gO`.

Example URLs produced:

| Node | URL |
|---|---|
| File `lua/eda/init.lua` on `main` | `https://github.com/wadackel/eda.nvim/blob/main/lua/eda/init.lua` |
| Dir `lua/eda` | `https://github.com/wadackel/eda.nvim/tree/main/lua/eda` |
| Repo root | `https://github.com/wadackel/eda.nvim/tree/main/` |
| GHE host | `https://github.example.com/<owner>/<repo>/blob/<ref>/<path>` (host preserved from remote URL) |

### Target resolution

Reuses the existing `Visual > marks > cursor` resolver from `get_target_nodes`. Multiple-selection is intentionally rejected (`MSG.multi_target`) — opening many browser tabs in one keystroke is noise, not a feature.

### Git status gating (P1 Strict)

| status | behavior |
|---|---|
| `?` (untracked) / `A` (staged) / `!` (ignored) | block with notification — URL would 404 |
| `M` (modified) / `R` (renamed) / clean | open |
| `config.git.enabled = false` | bypass status check entirely |
| status not yet ready | notify `git status not ready, retry shortly` and return |
| not in a git repo | notify and return |

### Ref resolution + fallback chain

Config `open_in_browser.ref` selects the preferred ref form; each falls back when its preferred form is not on `origin`:

- `branch` (default) — use the current branch's remote tracking name. Detached HEAD or missing upstream → SHA path.
- `sha` — verify HEAD is on a remote via `git branch -r --contains`; if not → default branch path.
- `default_branch` — resolve via `git symbolic-ref --short refs/remotes/origin/HEAD`; if absent, probe `origin/main` then `origin/master`; otherwise hard fail with an actionable message.

All git calls are local (no `git ls-remote` / network IO).

### URL construction + encoding

`parse_remote` accepts `ssh://[user@]host[:port]/owner/repo(.git)?`, `git@host:owner/repo(.git)?`, `https?://[user@]host/owner/repo(.git)?`, `git://host/owner/repo(.git)?`. `.git` is stripped, port is dropped, host is preserved (GHE works without extra config). `host`, `owner`, `repo` come from the parsed remote.

Path segments and ref names are percent-encoded per-segment so spaces, `#`, `?`, and multi-byte UTF-8 characters (e.g. Japanese filenames) round-trip cleanly. `/` is preserved inside ref names so branches like `feature/foo` are not mangled.

### `url_builder` escape hatch

For GitLab / Bitbucket / custom hosts:

```lua
require("eda").setup({
  open_in_browser = {
    url_builder = function(ctx)
      -- ctx schema (stable contract, snapshot-tested):
      --   { node, relative_path, ref, ref_kind, remote_url, host, owner, repo, kind }
      -- relative_path is anchored at the git repository root (not eda root),
      -- so it matches the remote layout when eda is opened in a sub-directory.
      -- kind = "blob" for files, "tree" for directories.
      if ctx.host == "gitlab.com" then
        return string.format("https://gitlab.com/%s/%s/-/%s/%s/%s",
          ctx.owner, ctx.repo, ctx.kind, ctx.ref, ctx.relative_path)
      end
      return nil -- fall back to built-in GitHub composer
    end,
  },
})
```

The callback is `pcall`-guarded: errors, empty strings, and non-string returns all fall back to the built-in composer with a notification.

## Implementation notes

- **`lua/eda/git_url.lua` (new)** — `parse_remote` / `resolve_remote_url` / `resolve_ref` / `build_github_url` / `build_url` / `MSG` table. `M._exec(git_root, args)` is exposed as a table field so tests can inject a stub `_exec`. Synchronous `vim.system(...):wait()` with a 2s per-call timeout (SIGKILL = timeout → notify `MSG.timeout`); aggregate cost is ~200–400ms per invocation across at most ~5 git calls — acceptable for a user-initiated, non-loop action.
- **`lua/eda/action/builtin.lua`** — single-target enforcement, status gating, ref/URL composition, `vim.ui.open(url)`. `relative_path` is computed against the resolved `git_root` (not the eda explorer root) so opening eda in a subdirectory of the repo still produces a URL anchored at the remote tree root.
- **`lua/eda/git.lua`** — added `M.find_git_root(root)` public alias so the action can share the same cached git-root resolution as the rest of the plugin.
- **`lua/eda/config.lua`** — `defaults.open_in_browser = { ref = "branch", url_builder = nil }`, `mappings["gO"] = "open_in_browser"`, LDoc classes `eda.OpenInBrowserCtx` and `eda.OpenInBrowserConfig`. `gO` is buffer-local so it does not shadow Neovim's built-in `gO` (table of contents) outside `eda` buffers.

## Test plan

- [x] `nix develop --command just test` — 49 new unit cases.
  - `tests/test_git_url.lua` (36) covers remote URL parsing across all five scheme variants, build_github_url encoding (space / `#` / Japanese / `feature/foo` ref / `fix#1` ref), full ref resolution fallback chain with stubbed `_exec`, `url_builder` pcall safety (error / nil / non-string / empty string), and a snapshot test pinning the `ctx_table` key set.
  - `tests/action/test_open_in_browser.lua` (13) covers empty target, multi-mark rejection, all five git status branches (`?` / `A` / `!` / `M`/`R`/clean), `git.enabled = false` bypass, loading / no_repo states, and unparseable / unresolvable error paths.
- [x] `nix develop --command just test-e2e` — 9 new E2E cases driving a real git repo + child Neovim with stubbed `vim.ui.open`. Covers keymap path (`gO`), direct dispatch path, directory `/tree/` URL, untracked block, detached HEAD SHA fallback, no-upstream SHA fallback, `default_branch` `origin/main` probe, GHE host preservation, and eda-opened-in-subdirectory URL anchoring.
- [x] `nix develop --command just format-check` / `lint` / `typecheck` — all clean.
- [x] `nix develop --command just doc` — `doc/eda.nvim.txt` regenerated.
- [ ] Manual: press `gO` on a committed file in a real GitHub repository and confirm the correct URL opens.
- [ ] Manual: press `gO` on an untracked file and confirm the error notification appears with no browser launch.

## References

- n/a
