### PR TITLE
fix(dir_size): use monotonic clock for cache TTL

### DIFF
--- a/lua/eda/buffer/dir_size.lua
+++ b/lua/eda/buffer/dir_size.lua
@@ -14,7 +14,7 @@ local M = {}
 
 ---@class eda.DirSizeEntry
 ---@field bytes integer
----@field computed_at_ms integer
+---@field computed_at_ms number
 
 local _defaults = { cache_ttl_ms = 30000 }
 local _config = vim.deepcopy(_defaults)
@@ -59,7 +59,7 @@ function M._start_walk(path)
       return
     end
     if not root_errored then
-      _cache[path] = { bytes = state.bytes, computed_at_ms = vim.uv.now() }
+      _cache[path] = { bytes = state.bytes, computed_at_ms = vim.uv.hrtime() / 1e6 }
     end
     _active[path] = nil
   end
@@ -135,7 +135,7 @@ end
 ---@return { state: "cached"|"computing", bytes: integer? }
 function M.ensure(path)
   local c = _cache[path]
-  if c and (vim.uv.now() - c.computed_at_ms) < _config.cache_ttl_ms then
+  if c and (vim.uv.hrtime() / 1e6 - c.computed_at_ms) < _config.cache_ttl_ms then
     return { state = "cached", bytes = c.bytes }
   end
   if _active[path] then


### PR DESCRIPTION
## Summary

Fix a deterministic CI test failure in `tests/buffer/test_dir_size.lua | ensure re-launches walk after TTL expiry`. The root cause is that `vim.uv.now()` returns the libuv event-loop's cached timestamp, which does not advance while the thread is blocked by `vim.uv.sleep()`. The dir_size cache used `vim.uv.now()` for both writing `computed_at_ms` and checking TTL expiry, so the test's `vim.uv.sleep(60)` did not push the cached time past the 20ms TTL window, and `ensure()` incorrectly returned the still-fresh cache.

Switch both call sites to `vim.uv.hrtime() / 1e6` (monotonic clock, advances independently of the event loop). Verified locally with the same sleep scenario:

- Before: `vim.uv.now()` delta during `vim.uv.sleep(80)` = `0ms`
- After: `vim.uv.hrtime()` delta during `vim.uv.sleep(80)` = `80.13ms`

This matches the patterns already used elsewhere in the codebase (`tests/e2e/helpers.lua` uses `vim.uv.hrtime()` for the same reason).

### Changes

- `lua/eda/buffer/dir_size.lua`
  - `_start_walk` (cache write): `vim.uv.now()` → `vim.uv.hrtime() / 1e6`
  - `ensure` (TTL check): `vim.uv.now()` → `vim.uv.hrtime() / 1e6`
  - `@field computed_at_ms integer` → `number` (the value is now a float)

No test changes — the existing `test_dir_size.lua` cases now all pass.

## References

- n/a
