### PR TITLE
fix(image): allow tmux passthrough from hidden panes so images are removed

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -482,7 +482,7 @@ detection do not apply to directory previews.
 
 Image files (`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`) are rendered in the
 preview pane using the Kitty graphics protocol on terminals that support it
-(kitty, Ghostty, WezTerm). Inside tmux, eda sets `allow-passthrough` to `on`
+(kitty, Ghostty, WezTerm). Inside tmux, eda sets `allow-passthrough` to `all`
 for the pane on the first image preview (the setting stays with the pane) and
 accounts for pane and status line offsets. Formats other
 than PNG, and PNGs larger than 2048px on a side, require ImageMagick (`magick`)
@@ -497,8 +497,10 @@ Known limitations of image preview:
 - Images are placed by cursor position, above everything Neovim draws. Only the
   confirm and help dialogs hide the image while open; other floats,
   notifications, or popups overlapping the preview area are covered by it.
-- Inside tmux, an image stays on screen when you switch to another pane unless
-  tmux has `focus-events on`, which lets eda hide it on `FocusLost`.
+- Inside tmux, an image stays on screen when you switch to another pane or
+  window unless tmux has `focus-events on`, which lets eda hide it on
+  `FocusLost`. The pane's `allow-passthrough all` is what lets that removal
+  through once the pane is no longer visible.
 - Support is detected by asking the terminal directly: eda sends the Kitty
   graphics capability query (and an XTVERSION query as a fast path for kitty,
   Ghostty, and WezTerm) and waits up to one second for an answer, so any

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -499,7 +499,7 @@ do not apply to directory previews.
 
 Image files (`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`) are rendered in the
 preview pane using the Kitty graphics protocol on terminals that support it
-(kitty, Ghostty, WezTerm). Inside tmux, eda sets `allow-passthrough` to `on`
+(kitty, Ghostty, WezTerm). Inside tmux, eda sets `allow-passthrough` to `all`
 for the pane on the first image preview (the setting stays with the pane) and
 accounts for pane and status line offsets. Formats other than PNG, and PNGs
 larger than 2048px on a side, require ImageMagick (`magick`) and are converted
@@ -514,8 +514,10 @@ Known limitations of image preview:
 - Images are placed by cursor position, above everything Neovim draws. Only the
     confirm and help dialogs hide the image while open; other floats,
     notifications, or popups overlapping the preview area are covered by it.
-- Inside tmux, an image stays on screen when you switch to another pane unless
-    tmux has `focus-events on`, which lets eda hide it on `FocusLost`.
+- Inside tmux, an image stays on screen when you switch to another pane or
+    window unless tmux has `focus-events on`, which lets eda hide it on
+    `FocusLost`. The pane’s `allow-passthrough all` is what lets that removal
+    through once the pane is no longer visible.
 - Support is detected by asking the terminal directly: eda sends the Kitty
     graphics capability query (and an XTVERSION query as a fast path for kitty,
     Ghostty, and WezTerm) and waits up to one second for an answer, so any

--- a/lua/eda/image/terminal.lua
+++ b/lua/eda/image/terminal.lua
@@ -75,8 +75,11 @@ function M.ensure_passthrough()
     return
   end
   passthrough_enabled = true
-  -- `on` (visible panes only) is enough: images are only drawn while the pane is shown
-  pcall(vim.fn.system, { "tmux", "set", "-p", "allow-passthrough", "on" })
+  -- `on` drops passthrough from panes that are not visible, so the `a=d` sent on
+  -- FocusLost after a window switch never reaches the terminal and the image
+  -- lingers. `all` cannot paint over another window: placements stop once the
+  -- pane has lost focus.
+  pcall(vim.fn.system, { "tmux", "set", "-p", "allow-passthrough", "all" })
 end
 
 ---@class eda.image.Terminal

--- a/tests/image/test_terminal.lua
+++ b/tests/image/test_terminal.lua
@@ -201,7 +201,7 @@ T["detect"]["enables tmux passthrough before querying the terminal"] = function(
   vim.api.nvim_list_uis, vim.fn.system, terminal.is_tmux, terminal.writer =
     saved.uis, saved.system, saved.is_tmux, saved.writer
   terminal._reset()
-  MiniTest.expect.equality(order[1], "tmux set -p allow-passthrough on")
+  MiniTest.expect.equality(order[1], "tmux set -p allow-passthrough all")
   MiniTest.expect.equality(order[2] ~= nil and order[2]:find("\27[>q", 1, true) ~= nil, true)
 end
 


### PR DESCRIPTION
## Summary

Inside tmux, an image left on screen after switching to another window stayed there. eda sends the Kitty delete command on `FocusLost`, but the pane was set to `allow-passthrough on`, and tmux only forwards passthrough sequences from a pane while it is visible, so the removal never reached the terminal.

The pane is now set to `allow-passthrough all`, which lets sequences through from a pane that is no longer visible. This cannot paint an image over another window: once the pane has lost focus, placements are held back until focus returns, so the only sequence that goes out from a hidden pane is the delete.

- `image/terminal.lua`: `ensure_passthrough` sets `all` instead of `on`
- `doc/eda.md` / `doc/eda.nvim.txt`: state the value and why the removal on `FocusLost` depends on it
- `tests/image/test_terminal.lua`: expectation updated

Reported from a limenty (Android terminal) test session, where switching tmux windows left the preview image behind.

## References

- Follow-up to #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AQBByubvoaNpDtkqRxney
