### PR TITLE
fix: reject occupied file creation destinations

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -761,7 +761,10 @@ Collapsed subtrees are excluded from the diff, so files hidden under a
 collapsed directory are safe.
 
 **Create** — Add a new line with a name. Append `/` to create a directory
-instead of a file.
+instead of a file. Existing destinations, including symbolic links, are
+rejected without replacing their contents. If another process creates the
+destination before the operation executes, creation fails and the edit remains
+unsaved.
 
 **Move** — Change the indentation of a line to move it under a different
 parent directory.

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -782,7 +782,10 @@ Collapsed subtrees are excluded from the diff, so files hidden under a
 collapsed directory are safe.
 
 **Create** — Add a new line with a name. Append `/` to create a directory
-instead of a file.
+instead of a file. Existing destinations, including symbolic links, are
+rejected without replacing their contents. If another process creates the
+destination before the operation executes, creation fails and the edit remains
+unsaved.
 
 **Move** — Change the indentation of a line to move it under a different
 parent directory.

--- a/lua/eda/fs.lua
+++ b/lua/eda/fs.lua
@@ -5,40 +5,36 @@ local M = {}
 ---@param is_dir boolean
 ---@param cb fun(err?: string)
 function M.create(path, is_dir, cb)
-  if is_dir then
-    vim.uv.fs_mkdir(path, 493, function(err) -- 0755
-      if err then
-        -- Try mkdir -p equivalent
-        vim.schedule(function()
-          local ok = vim.fn.mkdir(path, "p")
-          cb(ok == 0 and ("Failed to create directory: " .. path) or nil)
-        end)
-      else
-        vim.schedule(function()
-          cb()
-        end)
-      end
-    end)
-  else
-    -- Ensure parent directory exists
+  vim.schedule(function()
     local parent = vim.fn.fnamemodify(path, ":h")
-    vim.schedule(function()
-      vim.fn.mkdir(parent, "p")
-      vim.uv.fs_open(path, "w", 420, function(err, fd) -- 0644
+    local ok, parent_err = pcall(vim.fn.mkdir, parent, "p")
+    if not ok then
+      cb("Failed to create parent directory: " .. tostring(parent_err))
+      return
+    end
+    if is_dir then
+      vim.uv.fs_mkdir(path, 493, function(err)
+        vim.schedule(function()
+          cb(err and ("Failed to create directory: " .. err) or nil)
+        end)
+      end)
+    else
+      -- A preflight check cannot prevent another writer from creating the path before open.
+      vim.uv.fs_open(path, "wx", 420, function(err, fd)
         if err then
           vim.schedule(function()
             cb("Failed to create file: " .. err)
           end)
           return
         end
-        vim.uv.fs_close(fd, function()
+        vim.uv.fs_close(fd, function(close_err)
           vim.schedule(function()
-            cb()
+            cb(close_err and ("Failed to close created file: " .. close_err) or nil)
           end)
         end)
       end)
-    end)
-  end
+    end
+  end)
 end
 
 ---Delete a file or directory recursively.

--- a/lua/eda/tree/diff.lua
+++ b/lua/eda/tree/diff.lua
@@ -1,3 +1,5 @@
+local util = require("eda.util")
+
 local M = {}
 
 ---@class eda.Operation
@@ -101,6 +103,8 @@ function M.validate(operations, _store)
       elseif op.src == op.dst then
         table.insert(errors, "Move operation has same src and dst: " .. op.src)
       end
+    elseif op.type == "create" and vim.uv.fs_lstat(op.path) then
+      table.insert(errors, "Create destination already exists: " .. op.path)
     end
   end
 
@@ -114,10 +118,11 @@ function M.validate(operations, _store)
       dst = op.path
     end
     if dst then
-      if dst_paths[dst] then
+      local key = util.nfc_normalize(vim.fs.normalize(dst))
+      if dst_paths[key] then
         table.insert(errors, "Duplicate destination path: " .. dst)
       end
-      dst_paths[dst] = true
+      dst_paths[key] = true
     end
   end
 

--- a/tests/e2e/test_buffer_edit.lua
+++ b/tests/e2e/test_buffer_edit.lua
@@ -176,4 +176,30 @@ T["buffer edit"]["deletes a directory via dd with confirm dialog"] = function()
   MiniTest.expect.equality(vim.fn.isdirectory(dir_path), 0)
 end
 
+T["buffer edit"]["duplicate filename is rejected without truncating content"] = function()
+  e2e.exec(
+    child,
+    [[
+    local cfg = require("eda.config")
+    cfg.get().confirm = cfg._normalize_confirm(true)
+    vim.notify = function(message) vim.g.create_error = message end
+    vim.g.completed_creates = 0
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "EdaMutationPost",
+      callback = function(ev) vim.g.completed_creates = #ev.data.results.completed end,
+    })
+  ]]
+  )
+  e2e.open_eda(child, tmp)
+  e2e.exec(child, "vim.api.nvim_win_set_cursor(0, {1, 0})")
+  e2e.feed(child, "o")
+  e2e.feed_insert(child, "hello.txt")
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "vim.g.create_error ~= nil")
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/hello.txt"), { "hello" })
+  MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified"), true)
+  MiniTest.expect.equality(e2e.exec(child, "return vim.g.completed_creates"), 0)
+  MiniTest.expect.equality(e2e.exec(child, 'return vim.g.create_error:find("already exists", 1, true) ~= nil'), true)
+end
+
 return T

--- a/tests/test_fs.lua
+++ b/tests/test_fs.lua
@@ -3,6 +3,97 @@ local helpers = require("helpers")
 
 local T = MiniTest.new_set()
 
+local function create_and_wait(path, is_dir)
+  local done, result = false, nil
+  Fs.create(path, is_dir, function(err)
+    result = err
+    done = true
+  end)
+  helpers.wait_for(3000, function()
+    return done
+  end)
+  return result
+end
+
+T["create rejects an existing file without changing its contents"] = function()
+  local dir = helpers.create_temp_dir()
+  local path = dir .. "/keep.txt"
+  helpers.create_file(path, "keep this content")
+  MiniTest.expect.equality(type(create_and_wait(path, false)), "string")
+  MiniTest.expect.equality(vim.fn.readfile(path), { "keep this content" })
+  helpers.remove_temp_dir(dir)
+end
+
+T["create rejects an existing directory"] = function()
+  local dir = helpers.create_temp_dir()
+  MiniTest.expect.equality(type(create_and_wait(dir, true)), "string")
+  MiniTest.expect.equality(vim.fn.isdirectory(dir), 1)
+  helpers.remove_temp_dir(dir)
+end
+
+T["create rejects valid and broken symlink destinations"] = function()
+  local dir = helpers.create_temp_dir()
+  local target = dir .. "/target.txt"
+  helpers.create_file(target, "keep target")
+  for _, source in ipairs({ target, dir .. "/missing.txt" }) do
+    local path = dir .. "/link-" .. vim.fn.fnamemodify(source, ":t")
+    assert(vim.uv.fs_symlink(source, path))
+    MiniTest.expect.equality(type(create_and_wait(path, false)), "string")
+    MiniTest.expect.equality(vim.uv.fs_readlink(path), source)
+  end
+  MiniTest.expect.equality(vim.fn.readfile(target), { "keep target" })
+  MiniTest.expect.equality(vim.uv.fs_stat(dir .. "/missing.txt"), nil)
+  helpers.remove_temp_dir(dir)
+end
+
+T["create protects a file appearing after preflight"] = function()
+  local dir = helpers.create_temp_dir()
+  local path = dir .. "/race.txt"
+  local operations = { { type = "create", path = path, entry_type = "file" } }
+  local store = require("eda.tree.store").new()
+  store:set_root(dir)
+  MiniTest.expect.equality(require("eda.tree.diff").validate(operations, store).valid, true)
+  helpers.create_file(path, "external writer")
+  local result
+  Fs.execute_operations(operations, { delete_to_trash = false }, function(value)
+    result = value
+  end)
+  helpers.wait_for(3000, function()
+    return result ~= nil
+  end)
+  MiniTest.expect.equality(#result.completed, 0)
+  MiniTest.expect.equality(type(result.error), "string")
+  MiniTest.expect.equality(vim.fn.readfile(path), { "external writer" })
+  helpers.remove_temp_dir(dir)
+end
+
+T["create makes missing parents for exclusive files and directories"] = function()
+  local dir = helpers.create_temp_dir()
+  MiniTest.expect.equality(create_and_wait(dir .. "/a/b/file.txt", false), nil)
+  MiniTest.expect.equality(create_and_wait(dir .. "/c/d/nested", true), nil)
+  MiniTest.expect.equality(vim.fn.filereadable(dir .. "/a/b/file.txt"), 1)
+  MiniTest.expect.equality(vim.fn.isdirectory(dir .. "/c/d/nested"), 1)
+  helpers.remove_temp_dir(dir)
+end
+
+T["create preserves filesystem resolution through symlink parents"] = function()
+  local dir = helpers.create_temp_dir()
+  helpers.create_dir(dir .. "/real/nested")
+  assert(vim.uv.fs_symlink(dir .. "/real/nested", dir .. "/link"))
+  MiniTest.expect.equality(create_and_wait(dir .. "/link/../file.txt", false), nil)
+  MiniTest.expect.equality(vim.fn.filereadable(dir .. "/real/file.txt"), 1)
+  MiniTest.expect.equality(vim.fn.filereadable(dir .. "/file.txt"), 0)
+  helpers.remove_temp_dir(dir)
+end
+
+T["create reports parent errors through its callback"] = function()
+  local dir = helpers.create_temp_dir()
+  helpers.create_file(dir .. "/parent", "not a directory")
+  MiniTest.expect.equality(type(create_and_wait(dir .. "/parent/file.txt", false)), "string")
+  MiniTest.expect.equality(vim.fn.readfile(dir .. "/parent"), { "not a directory" })
+  helpers.remove_temp_dir(dir)
+end
+
 T["execute_operations module loads"] = function()
   MiniTest.expect.equality(type(Fs.create), "function")
   MiniTest.expect.equality(type(Fs.delete), "function")

--- a/tests/tree/test_diff.lua
+++ b/tests/tree/test_diff.lua
@@ -368,4 +368,29 @@ T["validate rejects duplicate destination from move and create"] = function()
   MiniTest.expect.equality(result.errors[1], "Duplicate destination path: /project/target.lua")
 end
 
+T["validate rejects occupied CREATE paths including aliases and broken links"] = function()
+  local helpers = require("helpers")
+  local dir = helpers.create_temp_dir()
+  local store = Store.new()
+  store:set_root(dir)
+  helpers.create_file(dir .. "/keep.txt", "keep")
+  assert(vim.uv.fs_symlink(dir .. "/missing.txt", dir .. "/broken"))
+  for _, path in ipairs({ dir .. "/keep.txt", dir .. "/./keep.txt", dir .. "/broken", dir }) do
+    local result = Diff.validate({ { type = "create", path = path, entry_type = "file" } }, store)
+    MiniTest.expect.equality(result.valid, false)
+    MiniTest.expect.equality(result.errors[1], "Create destination already exists: " .. path)
+  end
+  helpers.remove_temp_dir(dir)
+end
+
+T["validate rejects equivalent destination spellings"] = function()
+  local store = Store.new()
+  store:set_root("/project")
+  local result = Diff.validate({
+    { type = "create", path = "/project/new.txt", entry_type = "file" },
+    { type = "create", path = "/project/./new.txt", entry_type = "file" },
+  }, store)
+  MiniTest.expect.equality(result.valid, false)
+end
+
 return T


### PR DESCRIPTION
## Summary

Adding a second explorer line with an existing filename now fails validation instead of emptying the existing file. File creation also uses exclusive open, so a destination created by another process after validation is preserved; existing directories and symlinks are rejected as occupied targets.

Parent-directory failures reach the operation callback, and creation retains native filesystem resolution through symlink parents. The help reference documents conflict behavior.

Validation: 773 unit tests and 167 E2E tests pass, along with format-check, lint, typecheck, and regenerated vimdoc. Regressions cover existing contents, valid/broken symlinks, equivalent destination spellings, external creation after preflight, nested parents, and symlink-parent path resolution. Self-review checked callback settlement, descriptor closure, and preservation of dirty-buffer state.

## References

Closes #56.
