### PR TITLE
fix: preserve unsaved edits during automatic refresh

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -779,6 +779,12 @@ skipped during parsing. The computed operations are then validated for
 structural errors — missing rename targets, duplicate destinations — and
 rejected on failure.
 
+Automatic filesystem refreshes are deferred while the buffer has unsaved edits.
+After saving or discarding the edits, pending external changes are reconciled.
+A refresh already in progress cannot replace the snapshot used by a new edit.
+If a file operation fails because the filesystem changed, the edit remains
+unsaved and the error is reported.
+
 ## Mappings
 
 Default key mappings in the explorer buffer. Customize via the `mappings`

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -800,6 +800,12 @@ skipped during parsing. The computed operations are then validated for
 structural errors — missing rename targets, duplicate destinations — and
 rejected on failure.
 
+Automatic filesystem refreshes are deferred while the buffer has unsaved edits.
+After saving or discarding the edits, pending external changes are reconciled.
+A refresh already in progress cannot replace the snapshot used by a new edit.
+If a file operation fails because the filesystem changed, the edit remains
+unsaved and the error is reported.
+
 
 MAPPINGS                                          *eda.nvim-eda.nvim-mappings*
 

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -10,6 +10,7 @@ local git = require("eda.git")
 local Watcher = require("eda.watcher")
 local Preview = require("eda.preview")
 local FullName = require("eda.full_name")
+local Refresh = require("eda.refresh")
 
 -- Load builtin actions (registers them on require)
 require("eda.action.builtin")
@@ -31,6 +32,7 @@ local next_instance_id = 0
 ---@field watcher eda.Watcher
 ---@field preview eda.Preview
 ---@field full_name eda.FullName
+---@field refresh eda.Refresh
 ---@field _render_gen integer
 ---@field _last_painted_gen integer
 ---@field _incremental_hint? { toggled_node_id: integer }
@@ -539,6 +541,7 @@ function M.open(opts)
     _pending_dispatch = nil,
   }
 
+  explorer.refresh = Refresh.new(explorer)
   M._current = explorer
   table.insert(M._instances, explorer)
 
@@ -730,6 +733,7 @@ function M.open(opts)
   buffer.render = function(_self_buf, _s)
     mark_render_dirty()
     render_with_decorators()
+    explorer.refresh:flush()
   end
 
   -- Edit-preserving render: capture edits → full repaint → replay edits
@@ -1000,31 +1004,11 @@ function M.open(opts)
         end)
       end
 
-      -- Setup watcher on root directory
+      local gen = explorer.generation
       watcher:watch(root_path, function()
-        if not util.is_valid_buf(buffer.bufnr) then
-          watcher:unwatch_all()
-          return
+        if explorer.generation == gen and util.is_valid_buf(buffer.bufnr) then
+          explorer.refresh:request()
         end
-        scanner:rescan_preserving_state(store.root_id, function()
-          vim.schedule(function()
-            if not util.is_valid_buf(buffer.bufnr) then
-              return
-            end
-            mark_render_dirty()
-            schedule_render()
-            -- Refresh git status after external filesystem changes
-            if cfg.git.enabled then
-              git.status(root_path, function(_status)
-                if not util.is_valid_buf(buffer.bufnr) then
-                  return
-                end
-                mark_render_dirty()
-                schedule_render()
-              end)
-            end
-          end)
-        end)
       end)
     end)
   end
@@ -1201,6 +1185,7 @@ function M._change_root(explorer, new_path, opts)
 
   -- Increment generation to invalidate stale callbacks
   explorer.generation = explorer.generation + 1
+  explorer.refresh:reset()
 
   -- Reset the pre-render dispatch gate: after a root change, the new scan is
   -- in flight and `flat_lines` is empty until `on_scan_complete` below. Treat
@@ -1324,38 +1309,10 @@ function M._change_root(explorer, new_path, opts)
         end)
       end
 
-      -- Setup watcher on new root
       explorer.watcher:watch(new_path, function()
-        if explorer.generation ~= gen then
-          return
+        if explorer.generation == gen and util.is_valid_buf(explorer.buffer.bufnr) then
+          explorer.refresh:request()
         end
-        if not util.is_valid_buf(explorer.buffer.bufnr) then
-          explorer.watcher:unwatch_all()
-          return
-        end
-        explorer.scanner:rescan_preserving_state(explorer.store.root_id, function()
-          vim.schedule(function()
-            if explorer.generation ~= gen then
-              return
-            end
-            if not util.is_valid_buf(explorer.buffer.bufnr) then
-              return
-            end
-            explorer.buffer:render(explorer.store)
-            -- Refresh git status after external filesystem changes
-            if cfg.git.enabled then
-              git.status(new_path, function(_status)
-                if explorer.generation ~= gen then
-                  return
-                end
-                if not util.is_valid_buf(explorer.buffer.bufnr) then
-                  return
-                end
-                explorer.buffer:render(explorer.store)
-              end)
-            end
-          end)
-        end)
       end)
     end)
   end
@@ -1414,6 +1371,7 @@ function M.close()
   current.preview:close()
   current.full_name:destroy()
   pcall(vim.api.nvim_del_augroup_by_name, "eda_preview_" .. current.buffer.bufnr)
+  current.refresh:reset()
   current.watcher:unwatch_all()
   current.buffer:destroy()
   current.window:close()
@@ -1460,29 +1418,8 @@ end
 
 ---Refresh all active explorer instances.
 function M.refresh_all()
-  local cfg = config.get()
   for _, explorer in ipairs(M._instances) do
-    if util.is_valid_buf(explorer.buffer.bufnr) then
-      local gen = explorer.generation
-      explorer.scanner:rescan_preserving_state(explorer.store.root_id, function()
-        vim.schedule(function()
-          if util.is_valid_buf(explorer.buffer.bufnr) then
-            explorer.buffer:render(explorer.store)
-            -- Refresh git status after rescan
-            if cfg.git.enabled then
-              git.status(explorer.root_path, function(_status)
-                if explorer.generation ~= gen then
-                  return
-                end
-                if util.is_valid_buf(explorer.buffer.bufnr) then
-                  explorer.buffer:render(explorer.store)
-                end
-              end)
-            end
-          end
-        end)
-      end)
-    end
+    explorer.refresh:request()
   end
 end
 

--- a/lua/eda/refresh.lua
+++ b/lua/eda/refresh.lua
@@ -1,0 +1,110 @@
+local config = require("eda.config")
+local Store = require("eda.tree.store")
+local Scanner = require("eda.tree.scanner")
+local util = require("eda.util")
+local git = require("eda.git")
+
+---@class eda.Refresh
+---@field explorer eda.Explorer
+---@field pending boolean
+---@field running boolean
+---@field epoch integer
+local Refresh = {}
+Refresh.__index = Refresh
+
+---@param explorer eda.Explorer
+---@return eda.Refresh
+function Refresh.new(explorer)
+  local self = setmetatable({ explorer = explorer, pending = false, running = false, epoch = 0 }, Refresh)
+  vim.api.nvim_create_autocmd("BufModifiedSet", {
+    buffer = explorer.buffer.bufnr,
+    callback = function()
+      -- Flushing synchronously would see the temporary clean state before edit replay.
+      vim.schedule(function()
+        self:flush()
+      end)
+    end,
+  })
+  vim.api.nvim_create_autocmd("BufWipeout", {
+    buffer = explorer.buffer.bufnr,
+    callback = function()
+      self:reset()
+      explorer.watcher:unwatch_all()
+    end,
+  })
+  return self
+end
+
+function Refresh:reset()
+  self.epoch = self.epoch + 1
+  self.pending = false
+  self.running = false
+end
+
+function Refresh:request()
+  self.pending = true
+  self:flush()
+end
+
+function Refresh:flush()
+  local ex = self.explorer
+  local bufnr = ex.buffer.bufnr
+  if not self.pending or self.running or not util.is_valid_buf(bufnr) then
+    return
+  end
+  if vim.bo[bufnr].modified or not ex._initial_scan_complete or ex.scanner._active_fds > 0 then
+    return
+  end
+
+  self.pending = false
+  self.running = true
+  local epoch, generation, render_gen = self.epoch, ex.generation, ex._render_gen
+  local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+  local store = ex.store
+  local next_id, store_gen = store.next_id, store.generation
+  local candidate = Store.new()
+  candidate:set_root(ex.root_path)
+  candidate.next_id = next_id
+  local cfg = config.get()
+  local scanner = Scanner.new(candidate, cfg)
+
+  -- Guarding only the watcher event misses edits started during asynchronous I/O.
+  -- Applying directory results directly would invalidate the dirty snapshot's IDs.
+  scanner:rescan_preserving_state(candidate.root_id, function()
+    if self.epoch ~= epoch then
+      return
+    end
+    self.running = false
+    if ex.generation ~= generation or not util.is_valid_buf(bufnr) then
+      return
+    end
+    if
+      vim.bo[bufnr].modified
+      or vim.api.nvim_buf_get_changedtick(bufnr) ~= changedtick
+      or ex._render_gen ~= render_gen
+      or store.next_id ~= next_id
+      or store.generation ~= store_gen
+      or ex.scanner._active_fds > 0
+    then
+      self.pending = true
+      self:flush()
+      return
+    end
+
+    store.nodes = candidate.nodes
+    store.path_index = candidate.path_index
+    store.next_id = candidate.next_id
+    store:next_generation()
+    ex.buffer:render(store)
+    if cfg.git.enabled then
+      git.status(ex.root_path, function()
+        if self.epoch == epoch and ex.generation == generation and util.is_valid_buf(bufnr) then
+          ex.buffer:render(store)
+        end
+      end)
+    end
+    self:flush()
+  end, store)
+end
+
+return Refresh

--- a/lua/eda/refresh.lua
+++ b/lua/eda/refresh.lua
@@ -16,20 +16,28 @@ Refresh.__index = Refresh
 ---@return eda.Refresh
 function Refresh.new(explorer)
   local self = setmetatable({ explorer = explorer, pending = false, running = false, epoch = 0 }, Refresh)
-  vim.api.nvim_create_autocmd("BufModifiedSet", {
-    buffer = explorer.buffer.bufnr,
-    callback = function()
+  local function flush_later()
+    if self.pending then
       -- Flushing synchronously would see the temporary clean state before edit replay.
       vim.schedule(function()
         self:flush()
       end)
-    end,
+    end
+  end
+  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+    buffer = explorer.buffer.bufnr,
+    callback = flush_later,
+  })
+  local option_event = vim.api.nvim_create_autocmd("OptionSet", {
+    pattern = "modified",
+    callback = flush_later,
   })
   vim.api.nvim_create_autocmd("BufWipeout", {
     buffer = explorer.buffer.bufnr,
     callback = function()
       self:reset()
       explorer.watcher:unwatch_all()
+      vim.api.nvim_del_autocmd(option_event)
     end,
   })
   return self

--- a/lua/eda/tree/scanner.lua
+++ b/lua/eda/tree/scanner.lua
@@ -418,11 +418,14 @@ end
 
 ---@param root_id integer
 ---@param callback fun()
-function Scanner:rescan_preserving_state(root_id, callback)
+---@param state_store? eda.Store
+function Scanner:rescan_preserving_state(root_id, callback, state_store)
+  local state_root_id = state_store and state_store.root_id or root_id
+  state_store = state_store or self.store
   local open_by_path = {}
   local marked_by_path = {}
-  for _, node in pairs(self.store.nodes) do
-    if node.id ~= root_id then
+  for _, node in pairs(state_store.nodes) do
+    if node.id ~= state_root_id then
       if Node.is_dir(node) and node.open then
         open_by_path[node.path] = true
       end

--- a/tests/e2e/test_refresh.lua
+++ b/tests/e2e/test_refresh.lua
@@ -90,4 +90,361 @@ T["refresh"]["reflects externally deleted file after Ctrl-L"] = function()
   )
 end
 
+local function intercept_watcher()
+  e2e.exec(
+    child,
+    [[
+    _G.watcher_callbacks = {}
+    local Watcher = require("eda.watcher")
+    local watch = Watcher.watch
+    Watcher.watch = function(self, path, callback)
+      _G.watcher_callbacks[path] = callback
+      watch(self, path, function(...)
+        _G.watcher_events = (_G.watcher_events or 0) + 1
+        callback(...)
+      end)
+    end
+  ]]
+  )
+end
+
+local function delete_pending_line()
+  e2e.exec(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    _G.pending_id = ex.store:get_by_path(ex.root_path .. "/remove.txt").id
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for i, line in ipairs(lines) do
+      if line == "remove.txt" then
+        vim.api.nvim_win_set_cursor(0, { i, 0 })
+        vim.cmd.normal({ "dd", bang = true })
+        break
+      end
+    end
+  ]]
+  )
+  MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified"), true)
+end
+
+for _, event in ipairs({ "create", "rename", "delete" }) do
+  T["refresh"]["preserves pending deletion during external " .. event] = function()
+    e2e.create_file(tmp .. "/remove.txt", "remove me")
+    intercept_watcher()
+    e2e.open_eda(child, tmp)
+    delete_pending_line()
+    if event == "create" then
+      e2e.create_file(tmp .. "/external.txt", "external")
+    elseif event == "rename" then
+      assert(vim.uv.fs_rename(tmp .. "/existing.txt", tmp .. "/external.txt"))
+    else
+      assert(vim.uv.fs_unlink(tmp .. "/existing.txt"))
+    end
+    e2e.wait_until(child, "(_G.watcher_events or 0) > 0")
+    e2e.wait_until(
+      child,
+      [[
+      local ex = require("eda").get_current()
+      return ex.scanner._active_fds == 0
+    ]]
+    )
+    MiniTest.expect.equality(
+      e2e.exec(
+        child,
+        [[
+      local ex = require("eda").get_current()
+      return ex.store:get(_G.pending_id) ~= nil and vim.bo.modified
+    ]]
+      ),
+      true
+    )
+    e2e.feed(child, ":w<CR>")
+    e2e.wait_until(
+      child,
+      [[
+      local ex = require("eda").get_current()
+      return not vim.bo.modified and not vim.uv.fs_stat(ex.root_path .. "/remove.txt")
+    ]]
+    )
+    e2e.wait_until(
+      child,
+      string.format(
+        [[
+      local ex = require("eda").get_current()
+      local external = ex.store:get_by_path(ex.root_path .. "/external.txt")
+      local existing = ex.store:get_by_path(ex.root_path .. "/existing.txt")
+      return %s
+    ]],
+        event == "create" and "external ~= nil and existing ~= nil"
+          or event == "rename" and "external ~= nil and existing == nil"
+          or "external == nil and existing == nil"
+      )
+    )
+  end
+end
+
+local function hold_background_scan()
+  e2e.exec(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    ex.watcher:unwatch_all()
+    local Scanner = require("eda.tree.scanner")
+    local rescan = Scanner.rescan_preserving_state
+    Scanner.rescan_preserving_state = function(self, id, callback, state_store)
+      return rescan(self, id, function()
+        callback()
+        _G.finished_scans = (_G.finished_scans or 0) + 1
+      end, state_store)
+    end
+    local readdir = vim.uv.fs_readdir
+    vim.uv.fs_readdir = function(dir, callback)
+      return readdir(dir, function(err, entries)
+        if not entries and not _G.release_scan then
+          _G.release_scan = function()
+            vim.uv.fs_readdir = readdir
+            callback(err, entries)
+          end
+        else
+          callback(err, entries)
+        end
+      end)
+    end
+    _G.watcher_callbacks[ex.root_path]()
+  ]]
+  )
+  e2e.wait_until(child, "_G.release_scan ~= nil")
+end
+
+T["refresh"]["defers a scan that completes after editing begins"] = function()
+  e2e.create_file(tmp .. "/remove.txt", "remove me")
+  intercept_watcher()
+  e2e.open_eda(child, tmp)
+  hold_background_scan()
+  delete_pending_line()
+  e2e.exec(child, "_G.release_scan()")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return ex.scanner._active_fds == 0 and (not ex.refresh or not ex.refresh.running)
+  ]]
+  )
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = require("eda").get_current()
+    return ex.store:get(_G.pending_id) ~= nil and vim.bo.modified
+  ]]
+    ),
+    true
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and not vim.uv.fs_stat(ex.root_path .. "/remove.txt")
+  ]]
+  )
+end
+
+T["refresh"]["reconciles a deferred event after undo discards edits"] = function()
+  e2e.create_file(tmp .. "/remove.txt", "remove me")
+  intercept_watcher()
+  e2e.open_eda(child, tmp)
+  delete_pending_line()
+  e2e.create_file(tmp .. "/external.txt", "external")
+  e2e.wait_until(child, "(_G.watcher_events or 0) > 0")
+  e2e.feed(child, "u")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and ex.store:get_by_path(ex.root_path .. "/external.txt") ~= nil
+      and not ex.refresh.pending and not ex.refresh.running
+  ]]
+  )
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/remove.txt"), { "remove me" })
+end
+
+T["refresh"]["retains the edit when its source is deleted externally"] = function()
+  e2e.create_file(tmp .. "/remove.txt", "remove me")
+  intercept_watcher()
+  e2e.open_eda(child, tmp)
+  e2e.exec(
+    child,
+    [[
+    for i, line in ipairs(vim.api.nvim_buf_get_lines(0, 0, -1, false)) do
+      if line == "remove.txt" then
+        vim.api.nvim_win_set_cursor(0, { i, 0 })
+        break
+      end
+    end
+  ]]
+  )
+  e2e.feed(child, "cc")
+  e2e.feed_insert(child, "renamed.txt")
+  assert(vim.uv.fs_unlink(tmp .. "/remove.txt"))
+  e2e.wait_until(child, "(_G.watcher_events or 0) > 0")
+  e2e.exec(
+    child,
+    [[
+    _G.write_finished = false
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "EdaMutationPost",
+      once = true,
+      callback = function(args) _G.write_finished = args.data.results.error ~= nil end,
+    })
+  ]]
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "_G.write_finished")
+  MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified"), true)
+end
+
+T["refresh"]["refresh_all preserves edits in an explorer"] = function()
+  e2e.create_file(tmp .. "/remove.txt", "remove me")
+  e2e.open_eda(child, tmp)
+  delete_pending_line()
+  e2e.exec(child, "require('eda').refresh_all()")
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = require("eda").get_current()
+    return ex.refresh.pending and ex.store:get(_G.pending_id) ~= nil
+  ]]
+    ),
+    true
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and not vim.uv.fs_stat(ex.root_path .. "/remove.txt")
+  ]]
+  )
+end
+
+T["refresh"]["coalesces watcher events raised during a save"] = function()
+  e2e.create_file(tmp .. "/remove.txt", "remove me")
+  intercept_watcher()
+  e2e.open_eda(child, tmp)
+  delete_pending_line()
+  e2e.exec(
+    child,
+    [[
+    local Fs = require("eda.fs")
+    local execute = Fs.execute_operations
+    Fs.execute_operations = function(ops, opts, callback)
+      _G.finish_write = function() execute(ops, opts, callback) end
+    end
+  ]]
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "_G.finish_write ~= nil")
+  e2e.create_file(tmp .. "/external.txt", "external")
+  e2e.wait_until(child, "(_G.watcher_events or 0) > 0")
+  e2e.exec(child, "_G.finish_write()")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and not ex.refresh.pending and not ex.refresh.running
+      and ex.store:get_by_path(ex.root_path .. "/external.txt") ~= nil
+      and not vim.uv.fs_stat(ex.root_path .. "/remove.txt")
+  ]]
+  )
+end
+
+T["refresh"]["ignores a background scan completed after close"] = function()
+  intercept_watcher()
+  e2e.open_eda(child, tmp)
+  hold_background_scan()
+  e2e.exec(
+    child,
+    [[
+    _G.closed_explorer = require("eda").get_current()
+    _G.closed_nodes = _G.closed_explorer.store.nodes
+    require("eda").close()
+    _G.release_scan()
+  ]]
+  )
+  e2e.wait_until(child, "(_G.finished_scans or 0) > 0")
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    return require("eda").get_current() == nil and _G.closed_explorer.store.nodes == _G.closed_nodes
+  ]]
+    ),
+    true
+  )
+end
+
+T["refresh"]["ignores old root callbacks and installs a guarded new root watcher"] = function()
+  e2e.create_file(tmp .. "/nested/keep.txt", "keep")
+  e2e.create_file(tmp .. "/nested/remove.txt", "remove me")
+  intercept_watcher()
+  e2e.open_eda(child, tmp)
+  hold_background_scan()
+  e2e.exec(
+    child,
+    [[
+    local eda = require("eda")
+    local ex = eda.get_current()
+    _G.old_root = ex.root_path
+    eda._change_root(ex, ex.root_path .. "/nested")
+  ]]
+  )
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return ex._initial_scan_complete and _G.watcher_callbacks[ex.root_path] ~= nil
+  ]]
+  )
+  e2e.exec(
+    child,
+    [[
+    _G.release_scan()
+    _G.watcher_callbacks[_G.old_root]()
+  ]]
+  )
+  e2e.wait_until(child, "(_G.finished_scans or 0) > 0")
+  delete_pending_line()
+  e2e.create_file(tmp .. "/nested/external.txt", "external")
+  e2e.wait_until(child, "(_G.watcher_events or 0) > 0")
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and not ex.refresh.pending and not ex.refresh.running
+      and ex.store:get_by_path(ex.root_path .. "/external.txt") ~= nil
+      and not vim.uv.fs_stat(ex.root_path .. "/remove.txt")
+  ]]
+  )
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/existing.txt"), { "exists" })
+end
+
+T["refresh"]["releases watchers when the explorer buffer is wiped"] = function()
+  e2e.open_eda(child, tmp)
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = require("eda").get_current()
+    local watched = next(ex.watcher._handles) ~= nil
+    vim.api.nvim_buf_delete(ex.buffer.bufnr, { force = true })
+    return watched and next(ex.watcher._handles) == nil
+  ]]
+    ),
+    true
+  )
+end
+
 return T

--- a/tests/e2e/test_refresh.lua
+++ b/tests/e2e/test_refresh.lua
@@ -253,6 +253,16 @@ end
 T["refresh"]["reconciles a deferred event after undo discards edits"] = function()
   e2e.create_file(tmp .. "/remove.txt", "remove me")
   intercept_watcher()
+  e2e.exec(
+    child,
+    [[
+    local create_autocmd = vim.api.nvim_create_autocmd
+    vim.api.nvim_create_autocmd = function(event, opts)
+      assert(event ~= "BufModifiedSet", "BufModifiedSet is unavailable")
+      return create_autocmd(event, opts)
+    end
+  ]]
+  )
   e2e.open_eda(child, tmp)
   delete_pending_line()
   e2e.create_file(tmp .. "/external.txt", "external")

--- a/tests/e2e/test_split_state.lua
+++ b/tests/e2e/test_split_state.lua
@@ -41,7 +41,14 @@ local function dispatch_split(nvim)
     action.dispatch("split", ctx)
   ]]
   )
-  e2e.wait_until(nvim, "#require('eda').get_all() >= 2", 10000)
+  e2e.wait_until(
+    nvim,
+    [[
+    local instances = require("eda").get_all()
+    return #instances >= 2 and instances[#instances]._initial_scan_complete
+  ]],
+    10000
+  )
 end
 
 T["split state"]["expand directory in one pane does not affect other"] = function()


### PR DESCRIPTION
## Summary

A filesystem watcher could replace node IDs while an explorer buffer still contained unsaved edits. Saving that buffer could silently drop a pending deletion. Automatic refreshes now wait while edits are pending and scan into a separate candidate store, applying results only when the buffer and explorer state still match. Pending changes are reconciled after saving or discarding edits; root changes and buffer destruction invalidate old work.

The same protection applies to `refresh_all()`. The live store object stays stable for existing consumers, and explicit edit-preserving navigation retains its current behavior. Vim help documents the refresh behavior.

Validation: 773 unit tests and 178 E2E tests pass, including external create/rename/delete events, editing during a scan, notifications during save, undo, missing-source conflicts, old-root completions, and buffer cleanup. Formatting, lint, type checks, and generated vimdoc pass. Self-review also corrected a split test that waited for instance allocation before its initial scan completed.

## References

Closes #59
