### PR TITLE
fix: validate buffer mutation batches and preserve partial writes

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -770,9 +770,20 @@ unsaved.
 parent directory.
 
 When you write the buffer (`:w`), eda.nvim computes a diff between the current
-buffer state and the last rendered snapshot. Operations are grouped and
-executed in order: creates (parents before children), deletes (children before
-parents), and moves.
+buffer state and the last rendered snapshot. Independent moves execute first,
+followed by deletes (children before parents) and creates (parents before
+children). Renaming an expanded directory also moves its unchanged descendants;
+those descendants are not moved a second time. Moving children out of a deleted
+directory happens before deleting that directory.
+
+Batches with overlapping paths, including name swaps, moving into a destination
+scheduled for deletion, or editing descendants while renaming their parent, are
+rejected before any filesystem operation. Save those changes separately.
+
+The buffer is temporarily unmodifiable while its filesystem operations run.
+If execution stops partway through, completed operations become the new baseline
+and pending edits remain unsaved. Correct the error and write again to retry only
+the remaining operations.
 
 Invalidated extmarks (e.g., from external formatters mangling lines) are
 skipped during parsing. The computed operations are then validated for

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -791,9 +791,20 @@ unsaved.
 parent directory.
 
 When you write the buffer (`:w`), eda.nvim computes a diff between the current
-buffer state and the last rendered snapshot. Operations are grouped and
-executed in order: creates (parents before children), deletes (children before
-parents), and moves.
+buffer state and the last rendered snapshot. Independent moves execute first,
+followed by deletes (children before parents) and creates (parents before
+children). Renaming an expanded directory also moves its unchanged descendants;
+those descendants are not moved a second time. Moving children out of a deleted
+directory happens before deleting that directory.
+
+Batches with overlapping paths, including name swaps, moving into a destination
+scheduled for deletion, or editing descendants while renaming their parent, are
+rejected before any filesystem operation. Save those changes separately.
+
+The buffer is temporarily unmodifiable while its filesystem operations run. If
+execution stops partway through, completed operations become the new baseline
+and pending edits remain unsaved. Correct the error and write again to retry
+only the remaining operations.
 
 Invalidated extmarks (e.g., from external formatters mangling lines) are
 skipped during parsing. The computed operations are then validated for

--- a/lua/eda/buffer/edit_preserve.lua
+++ b/lua/eda/buffer/edit_preserve.lua
@@ -14,6 +14,7 @@ local M = {}
 ---@field prev_node_id integer? nearest extmark-bearing line above (primary anchor)
 ---@field parent_path string from parser (fallback anchor)
 ---@field indent integer depth level (fallback anchor)
+---@field follows_create? boolean
 
 ---Check whether a capture contains any edits.
 ---@param capture eda.EditCapture
@@ -61,7 +62,7 @@ function M.capture(bufnr, painter, store, root_path, indent_width)
       if node_id then
         local idx = index_by_node_id[node_id]
         if idx then
-          local row = header_lines + idx - 1
+          local row = parsed[idx].line_nr or header_lines + idx - 1
           local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
           if line then
             moves[node_id] = line
@@ -79,7 +80,7 @@ function M.capture(bufnr, painter, store, root_path, indent_width)
   -- Collect CREATE entries: parsed lines without node_id
   for i, pl in ipairs(parsed) do
     if not pl.node_id and pl.name ~= "" then
-      local row = header_lines + i - 1
+      local row = pl.line_nr or header_lines + i - 1
       local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
       if line then
         -- Find prev_node_id: scan upward for nearest extmark-bearing line
@@ -96,6 +97,7 @@ function M.capture(bufnr, painter, store, root_path, indent_width)
           prev_node_id = prev_node_id,
           parent_path = pl.parent_path,
           indent = pl.indent,
+          follows_create = i > 1 and parsed[i - 1].node_id == nil,
         })
       end
     end
@@ -134,6 +136,12 @@ function M.replay(bufnr, painter, capture, store)
     local pos = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns_id, node_id, {})
     if pos and pos[1] then
       vim.api.nvim_buf_set_lines(bufnr, pos[1], pos[1] + 1, false, { text })
+      -- An invalidated ID would turn the pending rename into a delete and create on save.
+      vim.api.nvim_buf_set_extmark(bufnr, ns_id, pos[1], 0, {
+        id = node_id,
+        right_gravity = true,
+        invalidate = true,
+      })
     end
   end
 
@@ -156,11 +164,12 @@ function M.replay(bufnr, painter, capture, store)
   -- Track insertion offsets per anchor to preserve ordering of consecutive CREATEs
   -- sharing the same prev_node_id (e.g., `o foo`, `o bar` both anchor to file_a)
   local anchor_offsets = {}
+  local previous_create_row
   for _, cr in ipairs(capture.creates) do
-    local insert_row = nil
+    local insert_row = cr.follows_create and previous_create_row and previous_create_row + 1 or nil
 
     -- Primary anchor: prev_node_id
-    if cr.prev_node_id then
+    if not insert_row and cr.prev_node_id then
       local anchor_id = cr.prev_node_id --[[@as integer]]
       local pos = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns_id, anchor_id, {})
       local anchor_row = pos and pos[1]
@@ -214,6 +223,10 @@ function M.replay(bufnr, painter, capture, store)
     if not insert_row and cr.parent_path then
       local parent_node = store:get_by_path(cr.parent_path)
       if parent_node then
+        if parent_node.id == store.root_id then
+          -- Looking up a root ID mark would drop unanchored creates when the header is hidden.
+          insert_row = painter.header_lines or 0
+        end
         local pos = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns_id, parent_node.id, {})
         if pos and pos[1] then
           -- Insert after parent's last visible child
@@ -251,6 +264,7 @@ function M.replay(bufnr, painter, capture, store)
     if insert_row then
       vim.api.nvim_buf_set_lines(bufnr, insert_row, insert_row, false, { cr.text })
     end
+    previous_create_row = insert_row
   end
 
   -- Restore undo levels

--- a/lua/eda/buffer/parser.lua
+++ b/lua/eda/buffer/parser.lua
@@ -7,6 +7,7 @@ local M = {}
 ---@field is_dir boolean Whether the entry is a directory (trailing /)
 ---@field parent_path string?
 ---@field full_path string?
+---@field line_nr integer?
 
 ---Parse a single buffer line.
 ---@param bufnr integer
@@ -115,6 +116,7 @@ function M.parse_lines(bufnr, ns_id, indent_width, root_path, header_lines)
     local full_path = parent_path .. "/" .. name
 
     table.insert(result, {
+      line_nr = line_nr,
       indent = indent,
       node_id = mark_by_row[line_nr],
       name = name,

--- a/lua/eda/buffer/reconcile.lua
+++ b/lua/eda/buffer/reconcile.lua
@@ -1,0 +1,94 @@
+local util = require("eda.util")
+
+local M = {}
+
+local function contains(parent, path)
+  return parent == path or path:sub(1, #parent + 1) == parent .. "/"
+end
+
+---@param buffer eda.Buffer
+---@param store eda.Store
+---@param completed eda.Operation[]
+---@param parsed eda.ParsedLine[]
+function M.apply(buffer, store, completed, parsed)
+  local snapshot = buffer.painter:get_snapshot()
+  local root = assert(store:get(store.root_id))
+  local entries_by_path = {}
+  for _, entry in ipairs(parsed) do
+    entries_by_path[entry.full_path] = entry
+  end
+
+  local function remove(path)
+    for id, entry in pairs(snapshot.entries) do
+      if contains(path, entry.path) then
+        snapshot.entries[id] = nil
+      end
+    end
+    local node = store:get_by_path(path)
+    if node then
+      store:remove(node.id)
+    end
+  end
+
+  for _, op in ipairs(completed) do
+    if op.type == "delete" then
+      remove(op.path)
+    elseif op.type == "move" then
+      remove(op.dst)
+      local node = store:get_by_path(op.src)
+      local parsed_entry = entries_by_path[op.dst]
+      if node then
+        local old_parent = store:get(node.parent_id)
+        local parent = store:get_by_path(parsed_entry.parent_path) or root
+        if old_parent and old_parent.id ~= parent.id then
+          for i, id in ipairs(old_parent.children_ids or {}) do
+            if id == node.id then
+              table.remove(old_parent.children_ids, i)
+              break
+            end
+          end
+          parent.children_ids = parent.children_ids or {}
+          table.insert(parent.children_ids, node.id)
+          node.parent_id = parent.id
+        end
+        node.name = parsed_entry.name
+        for _, child in pairs(store.nodes) do
+          if contains(op.src, child.path) then
+            store.path_index[util.nfc_normalize(child.path)] = nil
+            child.path = op.dst .. child.path:sub(#op.src + 1)
+            store.path_index[util.nfc_normalize(child.path)] = child.id
+          end
+        end
+      end
+      for _, entry in pairs(snapshot.entries) do
+        if contains(op.src, entry.path) then
+          entry.path = op.dst .. entry.path:sub(#op.src + 1)
+        end
+      end
+    elseif op.type == "create" then
+      local entry = entries_by_path[op.path]
+      local parent = store:get_by_path(entry.parent_path) or root
+      local id = store:add({
+        name = entry.name,
+        path = op.path,
+        parent_id = parent.id,
+        type = entry.is_dir and "directory" or "file",
+        open = entry.is_dir,
+        children_state = "loaded",
+      })
+      snapshot.entries[id] = { line = entry.line_nr, path = op.path }
+      vim.api.nvim_buf_set_extmark(buffer.bufnr, buffer.painter.ns_ids, entry.line_nr, 0, {
+        id = id,
+        right_gravity = true,
+        invalidate = true,
+      })
+    end
+  end
+  for _, node in pairs(store.nodes) do
+    node._sorted_children_ids = nil
+    node._sorted_children = nil
+  end
+  store:next_generation()
+end
+
+return M

--- a/lua/eda/fs.lua
+++ b/lua/eda/fs.lua
@@ -59,7 +59,11 @@ function M.move(src, dst, cb)
   -- Ensure destination parent exists before renaming
   vim.schedule(function()
     local parent = vim.fn.fnamemodify(dst, ":h")
-    vim.fn.mkdir(parent, "p")
+    local ok, parent_err = pcall(vim.fn.mkdir, parent, "p")
+    if not ok then
+      cb("Failed to create destination parent: " .. tostring(parent_err))
+      return
+    end
     vim.uv.fs_rename(src, dst, function(err)
       vim.schedule(function()
         if err then

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -42,6 +42,7 @@ local next_instance_id = 0
 ---@field _no_repo_notified? boolean
 ---@field _initial_scan_complete boolean
 ---@field _pending_dispatch? { name: string, ctx: eda.ActionContext }
+---@field _writing? boolean
 
 ---@type eda.Explorer?
 M._current = nil
@@ -784,6 +785,10 @@ function M.open(opts)
   -- `get_cursor_node` would resolve to nil. Park the dispatch in a single
   -- slot and drain it in `on_initial_scan_complete` below; latest-write wins.
   buffer:set_mappings(cfg.mappings, function(action_name)
+    if explorer._writing then
+      vim.notify("eda: file operations are still running", vim.log.levels.WARN)
+      return
+    end
     local ctx = make_ctx(explorer)
     if not explorer._initial_scan_complete then
       explorer._pending_dispatch = { name = action_name, ctx = ctx }
@@ -1056,6 +1061,10 @@ end
 ---Handle :w in the eda buffer.
 ---@param explorer eda.Explorer
 function M._handle_write(explorer)
+  if explorer._writing then
+    vim.notify("eda: file operations are still running", vim.log.levels.WARN)
+    return
+  end
   local Parser = require("eda.buffer.parser")
   local Diff = require("eda.tree.diff")
   local Fs = require("eda.fs")
@@ -1090,44 +1099,72 @@ function M._handle_write(explorer)
   -- Check if confirmation is needed
   local needs_confirm = M._should_confirm(cfg.confirm, operations)
 
+  local write_tick = vim.api.nvim_buf_get_changedtick(buffer.bufnr)
+  local generation = explorer.generation
   local function execute()
-    fire_event("EdaMutationPre", { operations = operations })
+    if not util.is_valid_buf(buffer.bufnr) or explorer.generation ~= generation then
+      return
+    end
+    if vim.api.nvim_buf_get_changedtick(buffer.bufnr) ~= write_tick or explorer._writing then
+      vim.notify("eda: buffer changed before confirmation; save again", vim.log.levels.WARN)
+      return
+    end
+    local modifiable = vim.bo[buffer.bufnr].modifiable
+    explorer._writing = true
+    vim.bo[buffer.bufnr].modifiable = false
+    local function release()
+      explorer._writing = false
+      if util.is_valid_buf(buffer.bufnr) then
+        vim.bo[buffer.bufnr].modifiable = modifiable
+      end
+    end
+
+    local pre_ok, pre_err = pcall(fire_event, "EdaMutationPre", { operations = operations })
+    if not pre_ok then
+      release()
+      vim.notify("eda: mutation hook failed: " .. tostring(pre_err), vim.log.levels.ERROR)
+      return
+    end
     Fs.execute_operations(operations, { delete_to_trash = cfg.delete_to_trash }, function(result)
       vim.schedule(function()
-        if not util.is_valid_buf(buffer.bufnr) then
+        if not util.is_valid_buf(buffer.bufnr) or explorer.generation ~= generation then
+          release()
           return
         end
-        fire_event("EdaMutationPost", { operations = operations, results = result })
-        if result.error and #result.completed == 0 then
-          -- No operations succeeded; keep buffer dirty
+        local post_ok, post_err = pcall(fire_event, "EdaMutationPost", { operations = operations, results = result })
+        if not post_ok then
+          vim.notify("eda: mutation hook failed: " .. tostring(post_err), vim.log.levels.ERROR)
+        end
+        if not util.is_valid_buf(buffer.bufnr) or explorer.generation ~= generation then
+          release()
           return
         end
-        -- Re-scan and re-render (even on partial failure, reflect successful operations)
+        if result.error then
+          release()
+          if #result.completed > 0 then
+            -- Rescanning would discard the IDs needed to distinguish completed and pending edits.
+            require("eda.buffer.reconcile").apply(buffer, store, result.completed, parsed)
+            explorer._render_preserving_edits()
+            vim.notify("Applied " .. #result.completed .. " operation(s), error: " .. result.error, vim.log.levels.WARN)
+          end
+          return
+        end
         explorer.scanner:rescan_preserving_state(store.root_id, function()
           vim.schedule(function()
-            if not util.is_valid_buf(buffer.bufnr) then
+            if not util.is_valid_buf(buffer.bufnr) or explorer.generation ~= generation then
+              release()
               return
             end
-            if result.error then
-              -- Partial failure: rescan completed but keep buffer dirty, report error
-              buffer:render(store)
-              vim.notify(
-                "Applied " .. #result.completed .. " operation(s), error: " .. result.error,
-                vim.log.levels.WARN
-              )
-            else
-              vim.bo[buffer.bufnr].modified = false
-              buffer:render(store)
-              vim.notify("Applied " .. #result.completed .. " operation(s)")
-              -- Refresh git status after successful file operations
-              if cfg.git.enabled then
-                git.status(explorer.root_path, function(_status)
-                  if not util.is_valid_buf(buffer.bufnr) then
-                    return
-                  end
+            vim.bo[buffer.bufnr].modified = false
+            buffer:render(store)
+            release()
+            vim.notify("Applied " .. #result.completed .. " operation(s)")
+            if cfg.git.enabled then
+              git.status(explorer.root_path, function(_status)
+                if util.is_valid_buf(buffer.bufnr) and explorer.generation == generation then
                   buffer:render(store)
-                end)
-              end
+                end
+              end)
             end
           end)
         end)

--- a/lua/eda/tree/diff.lua
+++ b/lua/eda/tree/diff.lua
@@ -53,6 +53,7 @@ function M.compute(parsed_lines, snapshot, store)
           path = pl.full_path,
           src = snap_entry.path,
           dst = pl.full_path,
+          entry_type = pl.is_dir and "directory" or "file",
         })
       end
     else
@@ -65,7 +66,29 @@ function M.compute(parsed_lines, snapshot, store)
     end
   end
 
-  -- Order: MOVE → DELETE (children before parents) → CREATE (parents before children)
+  local moves_by_src = {}
+  for _, op in ipairs(moves) do
+    if op.entry_type == "directory" then
+      moves_by_src[op.src] = op
+    end
+  end
+  moves = vim.tbl_filter(function(op)
+    local parent = vim.fn.fnamemodify(op.src, ":h")
+    while parent ~= op.src do
+      local ancestor = moves_by_src[parent]
+      if ancestor then
+        -- Moving the ancestor already relocates unchanged descendants on disk.
+        return op.dst ~= ancestor.dst .. op.src:sub(#parent + 1)
+      end
+      local next_parent = vim.fn.fnamemodify(parent, ":h")
+      if next_parent == parent then
+        break
+      end
+      parent = next_parent
+    end
+    return true
+  end, moves)
+
   -- Sort deletes: longer paths first (children before parents)
   table.sort(deletes, function(a, b)
     return #a.path > #b.path
@@ -89,6 +112,38 @@ function M.compute(parsed_lines, snapshot, store)
   return operations
 end
 
+local function contains(parent, path)
+  return parent == path or (parent == "/" and path:sub(1, 1) == "/") or path:sub(1, #parent + 1) == parent .. "/"
+end
+
+local function overlaps(a, b)
+  return a and b and (contains(a, b) or contains(b, a))
+end
+
+local function path_key(path, parents)
+  if not path then
+    return nil
+  end
+  local tail = vim.fn.fnamemodify(path, ":t")
+  local parent = vim.fn.fnamemodify(path, ":h")
+  while true do
+    local resolved = parents[parent]
+    if resolved == nil then
+      resolved = vim.uv.fs_realpath(parent) or false
+      parents[parent] = resolved
+    end
+    if resolved then
+      return util.nfc_normalize(vim.fs.normalize(resolved .. "/" .. tail))
+    end
+    local next_parent = vim.fn.fnamemodify(parent, ":h")
+    if next_parent == parent then
+      return util.nfc_normalize(vim.fs.normalize(path))
+    end
+    tail = vim.fn.fnamemodify(parent, ":t") .. "/" .. tail
+    parent = next_parent
+  end
+end
+
 ---Validate operations before execution.
 ---@param operations eda.Operation[]
 ---@param _store eda.Store
@@ -108,22 +163,87 @@ function M.validate(operations, _store)
     end
   end
 
-  -- Check for duplicate destination paths
-  local dst_paths = {}
-  for _, op in ipairs(operations) do
-    local dst
-    if op.type == "move" then
-      dst = op.dst
-    elseif op.type == "create" then
-      dst = op.path
+  if #errors > 0 then
+    return { valid = false, errors = errors }
+  end
+
+  local paths, destinations, parents, sources = {}, {}, {}, {}
+  for i, op in ipairs(operations) do
+    local src = path_key(op.type == "delete" and op.path or op.src, parents)
+    local dst = path_key(op.type == "create" and op.path or op.dst, parents)
+    paths[i] = { src = src, dst = dst }
+    if src then
+      if sources[src] then
+        errors[#errors + 1] = "Source scheduled more than once: " .. (op.src or op.path)
+      end
+      sources[src] = true
     end
     if dst then
-      local key = util.nfc_normalize(vim.fs.normalize(dst))
-      if dst_paths[key] then
-        table.insert(errors, "Duplicate destination path: " .. dst)
+      if destinations[dst] then
+        errors[#errors + 1] = "Duplicate destination path: " .. (op.dst or op.path)
       end
-      dst_paths[key] = true
+      destinations[dst] = true
     end
+    if op.type == "move" and overlaps(src, dst) then
+      errors[#errors + 1] = "Move source and destination overlap: " .. op.path
+    end
+  end
+  if #errors > 0 then
+    return { valid = false, errors = errors }
+  end
+  local function check_pair(i, j)
+    local a, b = operations[i], operations[j]
+    local ap, bp = paths[i], paths[j]
+    local conflict = overlaps(ap.dst, bp.src) or overlaps(bp.dst, ap.src)
+    if overlaps(ap.src, bp.src) and not (a.type == "delete" and b.type == "delete") then
+      local extracting = a.type == "move" and b.type == "delete" and ap.src ~= bp.src and contains(bp.src, ap.src)
+        or b.type == "move" and a.type == "delete" and ap.src ~= bp.src and contains(ap.src, bp.src)
+      conflict = conflict or not extracting
+    end
+    if overlaps(ap.dst, bp.dst) then
+      local creating_children = a.type == "create"
+        and b.type == "create"
+        and ap.dst ~= bp.dst
+        and (
+          (contains(ap.dst, bp.dst) and a.entry_type == "directory")
+          or (contains(bp.dst, ap.dst) and b.entry_type == "directory")
+        )
+      conflict = conflict or not creating_children
+    end
+    if conflict then
+      errors[#errors + 1] = "Overlapping operations must be saved separately: " .. a.path .. " and " .. b.path
+    end
+  end
+
+  local ordered = {}
+  for i, path in ipairs(paths) do
+    if path.src then
+      ordered[#ordered + 1] = { path = path.src, index = i }
+    end
+    if path.dst then
+      ordered[#ordered + 1] = { path = path.dst, index = i }
+    end
+  end
+  -- A sibling such as src-extra must not sort between src and src/file.
+  table.sort(ordered, function(a, b)
+    return a.path .. "/" < b.path .. "/"
+  end)
+  local ancestors, checked = {}, {}
+  for _, entry in ipairs(ordered) do
+    while #ancestors > 0 and not contains(ancestors[#ancestors].path, entry.path) do
+      table.remove(ancestors)
+    end
+    for _, ancestor in ipairs(ancestors) do
+      if ancestor.index ~= entry.index then
+        local i, j = math.min(ancestor.index, entry.index), math.max(ancestor.index, entry.index)
+        local key = i .. ":" .. j
+        if not checked[key] then
+          checked[key] = true
+          check_pair(i, j)
+        end
+      end
+    end
+    ancestors[#ancestors + 1] = entry
   end
 
   return {

--- a/tests/e2e/test_partial_write.lua
+++ b/tests/e2e/test_partial_write.lua
@@ -1,0 +1,275 @@
+local e2e = require("e2e.helpers")
+local child, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      e2e.setup_eda(child)
+      e2e.exec(child, [[require("eda.config").get().delete_to_trash = false]])
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_file(tmp .. "/a", "A")
+      e2e.create_file(tmp .. "/b", "B")
+      e2e.create_file(tmp .. "/keep", "KEEP")
+      e2e.open_eda(child, tmp)
+      e2e.exec(
+        child,
+        [[
+        _G.results = {}
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "EdaMutationPost",
+          callback = function(args) table.insert(_G.results, args.data.results) end,
+        })
+      ]]
+      )
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function cursor_on(name)
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+    for i, line in ipairs(vim.api.nvim_buf_get_lines(0, 0, -1, false)) do
+      if line == %q then vim.api.nvim_win_set_cursor(0, { i, 0 }); return true end
+    end
+    return false
+  ]],
+      name
+    )
+  )
+end
+
+local function rename(from, to)
+  cursor_on(from)
+  e2e.feed(child, "cc")
+  e2e.feed_insert(child, to)
+end
+
+local function fail_second(operation)
+  e2e.exec(
+    child,
+    string.format(
+      [[
+    local Fs = require("eda.fs")
+    local original = Fs[%q]
+    _G.calls = 0
+    Fs[%q] = function(...)
+      _G.calls = _G.calls + 1
+      local args = { ... }
+      if _G.calls == 2 then
+        vim.schedule(function() args[#args]("injected failure") end)
+      else
+        original(unpack(args))
+      end
+    end
+  ]],
+      operation,
+      operation
+    )
+  )
+end
+
+local function partial_then_retry()
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "#_G.results == 1 and vim.bo.modifiable")
+  MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified"), true)
+  MiniTest.expect.equality(e2e.exec(child, "return #_G.results[1].completed"), 1)
+  MiniTest.expect.equality(e2e.exec(child, "return _G.results[1].error"), "injected failure")
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "#_G.results == 2 and not vim.bo.modified")
+  MiniTest.expect.equality(e2e.exec(child, "return #_G.results[2].completed"), 1)
+  MiniTest.expect.equality(e2e.exec(child, "return _G.calls"), 3)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/keep"), { "KEEP" })
+end
+
+T["retries only the pending move after a partial failure"] = function()
+  rename("a", "new_a")
+  rename("b", "new_b")
+  fail_second("move")
+  partial_then_retry()
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_b"), { "B" })
+end
+
+T["assigns completed creates IDs before retrying pending creates"] = function()
+  e2e.feed(child, "Go")
+  e2e.feed_insert(child, "created_a\ncreated_b")
+  fail_second("create")
+  partial_then_retry()
+  MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/created_a"), 1)
+  MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/created_b"), 1)
+end
+
+T["does not delete a replacement for an already completed deletion"] = function()
+  cursor_on("a")
+  e2e.feed(child, "dd")
+  cursor_on("b")
+  e2e.feed(child, "dd")
+  fail_second("delete")
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "#_G.results == 1 and vim.bo.modifiable")
+  local completed = e2e.exec(child, "return _G.results[1].completed[1].path")
+  e2e.create_file(completed, "replacement")
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "#_G.results == 2 and not vim.bo.modified")
+  MiniTest.expect.equality(e2e.exec(child, "return _G.calls"), 3)
+  MiniTest.expect.equality(vim.fn.readfile(completed), { "replacement" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/keep"), { "KEEP" })
+end
+
+T["rejects another write while execution is still pending"] = function()
+  rename("a", "new_a")
+  e2e.exec(
+    child,
+    [[
+    local Fs = require("eda.fs")
+    local execute = Fs.execute_operations
+    _G.execute_calls = 0
+    Fs.execute_operations = function(ops, opts, callback)
+      _G.execute_calls = _G.execute_calls + 1
+      _G.release_write = function() execute(ops, opts, callback) end
+    end
+  ]]
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "_G.release_write ~= nil")
+  MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modifiable"), false)
+  e2e.exec(child, [[require("eda")._handle_write(require("eda").get_current())]])
+  MiniTest.expect.equality(e2e.exec(child, "return _G.execute_calls"), 1)
+  e2e.exec(child, "_G.release_write()")
+  e2e.wait_until(child, "not vim.bo.modified and vim.bo.modifiable")
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_a"), { "A" })
+end
+
+for _, event in ipairs({ "EdaMutationPre", "EdaMutationPost" }) do
+  T["does not leave the buffer locked after an error in " .. event] = function()
+    rename("a", "new_a")
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      vim.api.nvim_create_autocmd("User", {
+        pattern = %q,
+        once = true,
+        callback = function() error("injected hook failure") end,
+      })
+    ]],
+        event
+      )
+    )
+    e2e.feed(child, ":w<CR>")
+    e2e.wait_until(child, "#_G.results == 1 and not vim.bo.modified and vim.bo.modifiable")
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_a"), { "A" })
+  end
+end
+
+T["retains relocated descendants when a later independent move fails"] = function()
+  e2e.create_file(tmp .. "/src/inside", "inside")
+  e2e.exec(child, [[require("eda").refresh_all()]])
+  cursor_on("src/")
+  e2e.feed(child, "<CR>")
+  cursor_on("  inside")
+  rename("src/", "lib/")
+  rename("b", "new_b")
+  fail_second("move")
+  partial_then_retry()
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/lib/inside"), { "inside" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_b"), { "B" })
+end
+
+T["rejects a confirmation for buffer text that has changed"] = function()
+  rename("a", "new_a")
+  e2e.exec(
+    child,
+    [[
+    require("eda.config").get().confirm = { move = true }
+    require("eda.buffer.confirm").show = function(_, _, execute) _G.confirm_write = execute end
+  ]]
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, "_G.confirm_write ~= nil")
+  rename("b", "new_b")
+  e2e.exec(child, "_G.confirm_write()")
+  MiniTest.expect.equality(e2e.exec(child, "return #_G.results"), 0)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/b"), { "B" })
+  MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified and vim.bo.modifiable"), true)
+end
+
+for _, entries in ipairs({ "created", "created_dir/\n  inside" }) do
+  T["retains pending creates before the first line: " .. entries] = function()
+    rename("a", "new_a")
+    e2e.feed(child, "ggO")
+    e2e.feed_insert(child, entries)
+    e2e.exec(
+      child,
+      [[
+    local Fs = require("eda.fs")
+    local create = Fs.create
+    Fs.create = function(_, _, callback)
+      Fs.create = create
+      callback("injected failure")
+    end
+  ]]
+    )
+    e2e.feed(child, ":w<CR>")
+    e2e.wait_until(child, "#_G.results == 1 and vim.bo.modifiable")
+    MiniTest.expect.equality(
+      e2e.exec(
+        child,
+        string.format(
+          [[
+    return vim.tbl_contains(vim.api.nvim_buf_get_lines(0, 0, -1, false), %q)
+  ]],
+          entries:match("[^\n]+")
+        )
+      ),
+      true
+    )
+    e2e.feed(child, ":w<CR>")
+    e2e.wait_until(child, "#_G.results == 2 and not vim.bo.modified")
+    MiniTest.expect.equality(
+      vim.fn.filereadable(tmp .. (entries == "created" and "/created" or "/created_dir/inside")),
+      1
+    )
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_a"), { "A" })
+  end
+end
+
+T["does not reconcile a partial result after a post hook closes the explorer"] = function()
+  rename("a", "new_a")
+  rename("b", "new_b")
+  fail_second("move")
+  e2e.exec(
+    child,
+    [[
+    _G.closed_explorer = require("eda").get_current()
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "EdaMutationPost",
+      once = true,
+      callback = function() require("eda").close() end,
+    })
+  ]]
+  )
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(child, [[#_G.results == 1 and require("eda").get_current() == nil]])
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = _G.closed_explorer
+    return not ex._writing and ex.store:get_by_path(ex.root_path .. "/a") ~= nil
+  ]]
+    ),
+    true
+  )
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/new_a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/b"), { "B" })
+end
+
+return T

--- a/tests/test_fs.lua
+++ b/tests/test_fs.lua
@@ -343,4 +343,21 @@ T["Fs.copy copies directory recursively"] = function()
   helpers.remove_temp_dir(tmpdir)
 end
 
+T["Fs.move reports parent creation failure without removing the source"] = function()
+  local dir = helpers.create_temp_dir()
+  helpers.create_file(dir .. "/source", "source")
+  helpers.create_file(dir .. "/blocked", "blocker")
+  local result
+  Fs.move(dir .. "/source", dir .. "/blocked/target", function(err)
+    result = err or false
+  end)
+  helpers.wait_for(5000, function()
+    return result ~= nil
+  end)
+  MiniTest.expect.equality(type(result), "string")
+  MiniTest.expect.equality(vim.fn.readfile(dir .. "/source"), { "source" })
+  MiniTest.expect.equality(vim.fn.readfile(dir .. "/blocked"), { "blocker" })
+  helpers.remove_temp_dir(dir)
+end
+
 return T

--- a/tests/tree/test_mutation_batches.lua
+++ b/tests/tree/test_mutation_batches.lua
@@ -1,0 +1,145 @@
+local Diff = require("eda.tree.diff")
+local Store = require("eda.tree.store")
+local Fs = require("eda.fs")
+local helpers = require("helpers")
+
+local tmp
+
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmp = helpers.create_temp_dir()
+    end,
+    post_case = function()
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function batch(files, changes)
+  local store = Store.new()
+  local root = store:set_root(tmp)
+  local snapshot, parsed = { entries = {} }, {}
+  for i, file in ipairs(files) do
+    local name, contents = file[1], file[2]
+    local path = tmp .. "/" .. name
+    if contents == false then
+      vim.fn.mkdir(path, "p")
+    else
+      helpers.create_file(path, contents)
+    end
+    local parent = store:get_by_path(vim.fn.fnamemodify(path, ":h"))
+    local id = store:add({
+      name = name,
+      path = path,
+      parent_id = parent and parent.id or root,
+      type = contents == false and "directory" or "file",
+    })
+    snapshot.entries[id] = { line = i - 1, path = path }
+    if changes[name] ~= false then
+      parsed[#parsed + 1] =
+        { node_id = id, full_path = tmp .. "/" .. (changes[name] or name), is_dir = contents == false }
+    end
+  end
+  return Diff.compute(parsed, snapshot, store), store
+end
+
+local function run_if_valid(ops, store)
+  local validation = Diff.validate(ops, store)
+  if not validation.valid then
+    return validation
+  end
+  local result
+  Fs.execute_operations(ops, { delete_to_trash = false }, function(value)
+    result = value
+  end)
+  helpers.wait_for(5000, function()
+    return result ~= nil
+  end)
+  MiniTest.expect.equality(result.error, nil)
+  return validation
+end
+
+T["rejects a swap before either source changes"] = function()
+  local ops, store = batch({ { "a", "A" }, { "b", "B" } }, { a = "b", b = "a" })
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, false)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/b"), { "B" })
+end
+
+T["rejects a moved destination also scheduled for deletion"] = function()
+  local ops, store = batch({ { "a", "A" }, { "b", "B" } }, { a = "b", b = false })
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, false)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/b"), { "B" })
+end
+
+T["renames an expanded directory without redundant descendant moves"] = function()
+  local ops, store = batch(
+    { { "src", false }, { "src/a", "A" }, { "src/deep", false }, { "src/deep/b", "B" } },
+    { src = "lib", ["src/a"] = "lib/a", ["src/deep"] = "lib/deep", ["src/deep/b"] = "lib/deep/b" }
+  )
+  MiniTest.expect.equality(#ops, 1)
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, true)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/lib/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/lib/deep/b"), { "B" })
+  MiniTest.expect.equality(vim.uv.fs_stat(tmp .. "/src"), nil)
+end
+
+T["rejects explicit descendant edits alongside a parent move"] = function()
+  local ops, store = batch({ { "src", false }, { "src/a", "A" } }, { src = "lib", ["src/a"] = "lib/renamed" })
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, false)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/src/a"), { "A" })
+  MiniTest.expect.equality(vim.uv.fs_stat(tmp .. "/lib"), nil)
+end
+
+T["extracts a child before deleting its directory"] = function()
+  local ops, store = batch({ { "src", false }, { "src/a", "A" } }, { src = false, ["src/a"] = "a" })
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, true)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/a"), { "A" })
+  MiniTest.expect.equality(vim.uv.fs_stat(tmp .. "/src"), nil)
+end
+
+T["keeps sibling path prefixes independent"] = function()
+  local ops, store = batch(
+    { { "src", false }, { "src/a", "A" }, { "src-extra", "B" } },
+    { src = "lib", ["src/a"] = "lib/a", ["src-extra"] = "other" }
+  )
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, true)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/lib/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/other"), { "B" })
+end
+
+T["detects ancestor conflicts even with intervening sibling prefixes"] = function()
+  local ops, store = batch(
+    { { "src", false }, { "src/a", "A" }, { "src-extra", "B" } },
+    { src = "lib", ["src/a"] = false, ["src-extra"] = "other" }
+  )
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, false)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/src/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/src-extra"), { "B" })
+end
+
+T["detects move dependencies through symlinked parents"] = function()
+  local ops, store = batch(
+    { { "real", false }, { "real/a", "A" }, { "real/b", "B" } },
+    { ["real/a"] = "alias/b", ["real/b"] = "real/c" }
+  )
+  assert(vim.uv.fs_symlink(tmp .. "/real", tmp .. "/alias"))
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, false)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/real/a"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/real/b"), { "B" })
+end
+
+T["creates parent directories before independent children"] = function()
+  local store = Store.new()
+  store:set_root(tmp)
+  local ops = Diff.compute({
+    { name = "new", full_path = tmp .. "/new", is_dir = true },
+    { name = "file", full_path = tmp .. "/new/file", is_dir = false },
+  }, { entries = {} }, store)
+  MiniTest.expect.equality(run_if_valid(ops, store).valid, true)
+  MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/new/file"), 1)
+end
+
+return T


### PR DESCRIPTION
## Summary

A buffer write could overwrite a source needed by another move, delete newly moved content, or move descendants twice after renaming an expanded directory. Preflight now rejects overlapping batches, including swaps and move/delete destination conflicts, before any filesystem mutation. Unchanged descendant moves are folded into their parent move, while child extraction before parent deletion remains supported.

Partial failures update the live snapshot only for completed operations, allowing the next save to retry pending edits without repeating successful moves, creates, or deletes. The buffer is temporarily unmodifiable during execution, and stale confirmations are rejected. Edit replay preserves rename IDs and leading or nested create lines so recovery cannot turn a rename into empty-file creation or silently drop pending work.

Validation: the full suite passed with 783 unit and 188 E2E cases, plus formatting, lint, type checks, and generated vimdoc. The final close-during-hook regression passes in the 11-case partial-write suite on Neovim nightly. Tests assert original and resulting contents, alias conflicts, sibling-prefix boundaries, partial retries, hook errors, and write lifetime. Self-review also checked the full diff and measured validation of 10,000 independent deletion entries at approximately 66 ms locally (excluding mutations).

## References

Closes #57
