### PR TITLE
fix: reserve unique batch paste destinations

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -902,7 +902,13 @@ success (partial failures keep the marks for the failed/unattempted entries).
 - **paste** — Paste from the register into the directory under the cursor
   (or the parent of a file under the cursor; falls back to the explorer
   root). Appends `_copy` suffix on name collision and falls back to `_2`,
-  `_3`... counters.
+  `_3`... counters. Destinations are reserved in register order before any
+  operation starts, including when several sources have the same name.
+  Existing files, directories, and broken symlinks occupy their names.
+  Paste stops at the first error and keeps only failed and unattempted
+  entries in the register for retry. A newer register is preserved if it
+  changes while paste is running. A failed copy may leave a partial
+  destination; a failed cut may leave both source and destination.
 - **duplicate** — Duplicate each target node into its parent directory with
   the same `_copy` collision-resolution as `paste`. No prompt; works on
   files and directories.

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -980,7 +980,13 @@ success (partial failures keep the marks for the failed/unattempted entries).
 - **paste** — Paste from the register into the directory under the cursor
     (or the parent of a file under the cursor; falls back to the explorer
     root). Appends `_copy` suffix on name collision and falls back to `_2`,
-    `_3`… counters.
+    `_3`… counters. Destinations are reserved in register order before any
+    operation starts, including when several sources have the same name.
+    Existing files, directories, and broken symlinks occupy their names.
+    Paste stops at the first error and keeps only failed and unattempted
+    entries in the register for retry. A newer register is preserved if it
+    changes while paste is running. A failed copy may leave a partial
+    destination; a failed cut may leave both source and destination.
 - **duplicate** — Duplicate each target node into its parent directory with
     the same `_copy` collision-resolution as `paste`. No prompt; works on
     files and directories.

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -767,11 +767,22 @@ end
 --- appends `_copy` (dotfile/no-extension aware) and falls back to `_2`, `_3`... counter.
 ---@param dir string  Target directory (without trailing slash).
 ---@param name string  Candidate filename.
+---@param reserved? table<string, boolean>
 ---@return string  Absolute destination path that does not currently exist.
-local function resolve_unique_dst(dir, name)
+local function resolve_unique_dst(dir, name, reserved)
+  local util = require("eda.util")
+  local function occupied(path)
+    return (reserved and reserved[util.nfc_normalize(path)]) or vim.uv.fs_lstat(path) ~= nil
+  end
+  local function reserve(path)
+    if reserved then
+      reserved[util.nfc_normalize(path)] = true
+    end
+    return path
+  end
   local dst = dir .. "/" .. name
-  if not vim.uv.fs_stat(dst) then
-    return dst
+  if not occupied(dst) then
+    return reserve(dst)
   end
   local copy_name = generate_copy_name(name)
   dst = dir .. "/" .. copy_name
@@ -779,7 +790,7 @@ local function resolve_unique_dst(dir, name)
   local orig_base = orig_ext ~= "" and name:sub(1, -(#orig_ext + 2)) or name
   local is_dotfile = orig_base == "" or orig_base == "."
   local counter = 2
-  while vim.uv.fs_stat(dst) do
+  while occupied(dst) do
     if is_dotfile or orig_ext == "" then
       dst = dir .. "/" .. copy_name .. "_" .. counter
     else
@@ -788,7 +799,7 @@ local function resolve_unique_dst(dir, name)
     end
     counter = counter + 1
   end
-  return dst
+  return reserve(dst)
 end
 
 M._resolve_unique_dst = resolve_unique_dst
@@ -1236,12 +1247,18 @@ action.register("quickfix", function(ctx)
   end
 end, { desc = "Create quickfix from target nodes (Visual > marks > cursor)" })
 
+local active_pastes = {}
+
 action.register("paste", function(ctx)
   local register = require("eda.register")
   local Fs = require("eda.fs")
   local reg = register.get()
   if not reg then
     vim.notify("Register is empty")
+    return
+  end
+  if active_pastes[reg] then
+    vim.notify("Paste is already running", vim.log.levels.WARN)
     return
   end
   -- Determine target directory
@@ -1254,43 +1271,60 @@ action.register("paste", function(ctx)
   else
     target_dir = ctx.explorer.root_path
   end
-  -- Check for self-paste (directory into itself)
+  local real_target = vim.uv.fs_realpath(target_dir) or target_dir
   for _, src_path in ipairs(reg.paths) do
-    if target_dir == src_path or target_dir:sub(1, #src_path + 1) == src_path .. "/" then
+    local real_source = vim.uv.fs_realpath(src_path) or src_path
+    if real_target == real_source or real_target:sub(1, #real_source + 1) == real_source .. "/" then
       vim.notify("Cannot paste into itself: " .. vim.fn.fnamemodify(src_path, ":t"), vim.log.levels.ERROR)
       return
     end
   end
-  -- Execute operations
-  local remaining = #reg.paths
-  local errors = {}
+
+  local planned, reserved = {}, {}
   for _, src_path in ipairs(reg.paths) do
-    local name = vim.fn.fnamemodify(src_path, ":t")
-    local dst = resolve_unique_dst(target_dir, name)
-    local function on_done(err)
+    planned[#planned + 1] = {
+      src = src_path,
+      dst = resolve_unique_dst(target_dir, vim.fn.fnamemodify(src_path, ":t"), reserved),
+    }
+  end
+  active_pastes[reg] = true
+  local index = 0
+  local function finish(err)
+    active_pastes[reg] = nil
+    if register.get() == reg then
       if err then
-        table.insert(errors, err)
-      end
-      remaining = remaining - 1
-      if remaining == 0 then
-        if #errors == 0 then
-          register.clear()
+        local pending = {}
+        for i = index, #planned do
+          pending[#pending + 1] = planned[i].src
         end
-        vim.schedule(function()
-          if #errors > 0 then
-            vim.notify(table.concat(errors, "\n"), vim.log.levels.ERROR)
-          end
-          -- Refresh all instances
-          get_eda().refresh_all()
-        end)
+        register.set(pending, reg.operation)
+      else
+        register.clear()
       end
+    end
+    if err then
+      vim.notify(err, vim.log.levels.ERROR)
+    end
+    get_eda().refresh_all()
+  end
+  local function next_entry(err)
+    if err then
+      finish(err)
+      return
+    end
+    index = index + 1
+    local entry = planned[index]
+    if not entry then
+      finish()
+      return
     end
     if reg.operation == "cut" then
-      Fs.move(src_path, dst, on_done)
+      Fs.move(entry.src, entry.dst, next_entry, { no_replace = true })
     else
-      Fs.copy(src_path, dst, on_done)
+      Fs.copy(entry.src, entry.dst, next_entry, { no_replace = true })
     end
   end
+  next_entry()
 end, { desc = "Paste from register" })
 
 action.register("help", function(ctx)

--- a/lua/eda/fs.lua
+++ b/lua/eda/fs.lua
@@ -55,7 +55,12 @@ end
 ---@param src string
 ---@param dst string
 ---@param cb fun(err?: string)
-function M.move(src, dst, cb)
+---@param opts? { no_replace?: boolean }
+function M.move(src, dst, cb, opts)
+  if opts and opts.no_replace then
+    require("eda.fs.exclusive").move(src, dst, cb)
+    return
+  end
   -- Ensure destination parent exists before renaming
   vim.schedule(function()
     local parent = vim.fn.fnamemodify(dst, ":h")
@@ -80,7 +85,12 @@ end
 ---@param src string
 ---@param dst string
 ---@param cb fun(err?: string)
-function M.copy(src, dst, cb)
+---@param opts? { no_replace?: boolean }
+function M.copy(src, dst, cb, opts)
+  if opts and opts.no_replace then
+    require("eda.fs.exclusive").copy(src, dst, cb)
+    return
+  end
   vim.schedule(function()
     local parent = vim.fn.fnamemodify(dst, ":h")
     vim.fn.mkdir(parent, "p")

--- a/lua/eda/fs/exclusive.lua
+++ b/lua/eda/fs/exclusive.lua
@@ -1,0 +1,125 @@
+local uv = vim.uv
+local M = {}
+
+local function copy_entry(src, dst, callback)
+  uv.fs_lstat(src, function(err, stat)
+    if err or not stat then
+      callback(err or ("Cannot stat source: " .. src))
+    elseif stat.type == "link" then
+      uv.fs_readlink(src, function(link_err, target)
+        if link_err then
+          callback(link_err)
+        else
+          uv.fs_symlink(target, dst, callback)
+        end
+      end)
+    elseif stat.type == "directory" then
+      uv.fs_mkdir(dst, 448, function(mkdir_err)
+        if mkdir_err then
+          callback(mkdir_err)
+          return
+        end
+        uv.fs_scandir(src, function(scan_err, request)
+          if scan_err then
+            callback(scan_err)
+            return
+          end
+          local names = {}
+          while true do
+            local name = uv.fs_scandir_next(request)
+            if not name then
+              break
+            end
+            names[#names + 1] = name
+          end
+          local index = 0
+          local function next_entry(copy_err)
+            if copy_err then
+              callback(copy_err)
+              return
+            end
+            index = index + 1
+            local name = names[index]
+            if name then
+              copy_entry(src .. "/" .. name, dst .. "/" .. name, next_entry)
+            else
+              uv.fs_chmod(dst, stat.mode % 4096, callback)
+            end
+          end
+          next_entry()
+        end)
+      end)
+    elseif stat.type == "file" then
+      uv.fs_copyfile(src, dst, { excl = true }, callback)
+    else
+      callback("Unsupported source type: " .. stat.type)
+    end
+  end)
+end
+
+local function move_entry(src, dst, callback)
+  uv.fs_lstat(src, function(err, stat)
+    if err or not stat then
+      callback(err or ("Cannot stat source: " .. src))
+      return
+    end
+    if stat.type == "directory" then
+      uv.fs_lstat(dst, function(dst_err, existing)
+        if existing then
+          callback("Destination already exists: " .. dst)
+        elseif dst_err and not dst_err:match("^ENOENT") then
+          callback(dst_err)
+        else
+          uv.fs_rename(src, dst, callback)
+        end
+      end)
+      return
+    end
+    local function unlink_source(copy_err)
+      if copy_err then
+        callback(copy_err)
+      else
+        uv.fs_unlink(src, callback)
+      end
+    end
+    if stat.type == "link" then
+      copy_entry(src, dst, unlink_source)
+    else
+      -- A destination check followed by rename can overwrite a concurrent writer's file.
+      uv.fs_link(src, dst, function(link_err)
+        if link_err and link_err:match("^EXDEV") then
+          copy_entry(src, dst, unlink_source)
+        else
+          unlink_source(link_err)
+        end
+      end)
+    end
+  end)
+end
+
+local function run(operation, src, dst, callback)
+  vim.schedule(function()
+    local ok, err = pcall(vim.fn.mkdir, vim.fn.fnamemodify(dst, ":h"), "p")
+    if not ok then
+      callback(tostring(err))
+      return
+    end
+    operation(src, dst, vim.schedule_wrap(callback))
+  end)
+end
+
+---@param src string
+---@param dst string
+---@param callback fun(err?: string)
+function M.copy(src, dst, callback)
+  run(copy_entry, src, dst, callback)
+end
+
+---@param src string
+---@param dst string
+---@param callback fun(err?: string)
+function M.move(src, dst, callback)
+  run(move_entry, src, dst, callback)
+end
+
+return M

--- a/tests/e2e/test_batch_paste.lua
+++ b/tests/e2e/test_batch_paste.lua
@@ -1,0 +1,219 @@
+local e2e = require("e2e.helpers")
+local child, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      e2e.setup_eda(child)
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_file(tmp .. "/a/file.txt", "A")
+      e2e.create_file(tmp .. "/b/file.txt", "B")
+      e2e.create_file(tmp .. "/dest/keep", "KEEP")
+      e2e.exec(
+        child,
+        [[
+        local notify = vim.notify
+        vim.notify = function(message, level)
+          if level == vim.log.levels.ERROR then _G.paste_error = message end
+          if level == vim.log.levels.WARN then _G.paste_warning = message end
+          notify(message, level)
+        end
+      ]]
+      )
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function seed(operation, extra)
+  e2e.open_eda(child, tmp .. "/dest")
+  e2e.exec(child, [[vim.fn.search("keep", "w")]])
+  e2e.exec(
+    child,
+    string.format(
+      [[
+    require("eda.register").set({ %q, %q%s }, %q)
+  ]],
+      tmp .. "/a/file.txt",
+      tmp .. "/b/file.txt",
+      extra and ", " .. string.format("%q", extra) or "",
+      operation
+    )
+  )
+end
+
+for _, operation in ipairs({ "copy", "cut" }) do
+  T[operation .. " preserves both same-named source contents"] = function()
+    seed(operation)
+    e2e.feed(child, "gp")
+    e2e.wait_until(child, [[require("eda.register").get() == nil]])
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file.txt"), { "A" })
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file_copy.txt"), { "B" })
+    MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/a/file.txt"), operation == "copy" and 1 or 0)
+    MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/b/file.txt"), operation == "copy" and 1 or 0)
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/keep"), { "KEEP" })
+  end
+end
+
+T["reserves suffixes around files directories and broken symlinks"] = function()
+  for _, name in ipairs({ "file.txt", "file_copy.txt", "file_copy_2.txt" }) do
+    e2e.create_file(tmp .. "/dest/" .. name, name)
+  end
+  e2e.create_file(tmp .. "/dest/file_copy_3.txt/inside", "inside")
+  assert(vim.uv.fs_symlink(tmp .. "/missing", tmp .. "/dest/file_copy_4.txt"))
+  seed("copy")
+  e2e.feed(child, "gp")
+  e2e.wait_until(child, [[require("eda.register").get() == nil]])
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file_copy_5.txt"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file_copy_6.txt"), { "B" })
+  for _, name in ipairs({ "file.txt", "file_copy.txt", "file_copy_2.txt" }) do
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/" .. name), { name })
+  end
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file_copy_3.txt/inside"), { "inside" })
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/dest/file_copy_4.txt").type, "link")
+end
+
+T["retries only failed and unattempted cut entries"] = function()
+  e2e.create_file(tmp .. "/c/file.txt", "C")
+  seed("cut", tmp .. "/c/file.txt")
+  e2e.exec(
+    child,
+    [[
+    local Fs = require("eda.fs")
+    local move = Fs.move
+    _G.moves = 0
+    Fs.move = function(src, dst, callback, opts)
+      _G.moves = _G.moves + 1
+      if _G.moves == 2 then callback("injected failure")
+      else move(src, dst, callback, opts) end
+    end
+  ]]
+  )
+  e2e.feed(child, "gp")
+  e2e.wait_until(child, "_G.paste_error ~= nil")
+  MiniTest.expect.equality(
+    e2e.exec(child, [[return require("eda.register").get().paths]]),
+    { tmp .. "/b/file.txt", tmp .. "/c/file.txt" }
+  )
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/c/file.txt"), { "C" })
+  e2e.feed(child, "gp")
+  e2e.wait_until(child, [[require("eda.register").get() == nil]])
+  MiniTest.expect.equality(e2e.exec(child, "return _G.moves"), 4)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file.txt"), { "A" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file_copy.txt"), { "B" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file_copy_2.txt"), { "C" })
+end
+
+for _, operation in ipairs({ "copy", "cut" }) do
+  T[operation .. " rejects a destination occupied after planning"] = function()
+    seed(operation)
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      local Fs = require("eda.fs")
+      local original = Fs[%q]
+      Fs[%q] = function(src, dst, callback, opts)
+        Fs[%q] = original
+        vim.fn.writefile({ "external" }, dst)
+        original(src, dst, callback, opts)
+      end
+    ]],
+        operation == "cut" and "move" or "copy",
+        operation == "cut" and "move" or "copy",
+        operation == "cut" and "move" or "copy"
+      )
+    )
+    e2e.feed(child, "gp")
+    e2e.wait_until(child, "_G.paste_error ~= nil")
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/file.txt"), { "external" })
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/a/file.txt"), { "A" })
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/b/file.txt"), { "B" })
+    MiniTest.expect.equality(e2e.exec(child, [[return #require("eda.register").get().paths]]), 2)
+  end
+end
+
+T["keeps a replacement register and ignores a repeated pending paste"] = function()
+  seed("copy")
+  e2e.exec(
+    child,
+    [[
+    local Fs = require("eda.fs")
+    local original = Fs.copy
+    _G.copies = 0
+    _G.completed = 0
+    Fs.copy = function(src, dst, callback, opts)
+      _G.copies = _G.copies + 1
+      local complete = function(err)
+        callback(err)
+        _G.completed = _G.completed + 1
+      end
+      if _G.copies == 1 then
+        _G.finish_copy = function() original(src, dst, complete, opts) end
+      else
+        original(src, dst, complete, opts)
+      end
+    end
+  ]]
+  )
+  e2e.feed(child, "gp")
+  e2e.wait_until(child, "_G.finish_copy ~= nil")
+  e2e.feed(child, "gp")
+  e2e.wait_until(child, "_G.paste_warning ~= nil")
+  e2e.exec(
+    child,
+    [[
+    require("eda.register").set({ "/replacement" }, "cut")
+    _G.finish_copy()
+  ]]
+  )
+  e2e.wait_until(child, "_G.completed == 2")
+  MiniTest.expect.equality(e2e.exec(child, "return _G.copies"), 2)
+  MiniTest.expect.equality(e2e.exec(child, [[return require("eda.register").get().paths]]), { "/replacement" })
+end
+
+for _, operation in ipairs({ "copy", "cut" }) do
+  T[operation .. " preserves same-named directories and symlinks"] = function()
+    e2e.create_file(tmp .. "/a/tree/nested", "A")
+    e2e.create_file(tmp .. "/b/tree/nested", "B")
+    assert(vim.uv.fs_symlink("file.txt", tmp .. "/a/link"))
+    assert(vim.uv.fs_symlink("missing", tmp .. "/b/link"))
+    seed(operation)
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      require("eda.register").set({ %q, %q, %q, %q }, %q)
+    ]],
+        tmp .. "/a/tree",
+        tmp .. "/b/tree",
+        tmp .. "/a/link",
+        tmp .. "/b/link",
+        operation
+      )
+    )
+    e2e.feed(child, "gp")
+    e2e.wait_until(child, [[require("eda.register").get() == nil]])
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/tree/nested"), { "A" })
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/tree_copy/nested"), { "B" })
+    MiniTest.expect.equality(vim.uv.fs_readlink(tmp .. "/dest/link"), "file.txt")
+    MiniTest.expect.equality(vim.uv.fs_readlink(tmp .. "/dest/link_copy"), "missing")
+    MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/a/tree") ~= nil, operation == "copy")
+    MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/b/link") ~= nil, operation == "copy")
+  end
+end
+
+T["rejects copying a directory into a symlink alias of itself"] = function()
+  assert(vim.uv.fs_symlink(tmp .. "/dest", tmp .. "/alias"))
+  seed("copy")
+  e2e.exec(child, string.format([[require("eda.register").set({ %q }, "copy")]], tmp .. "/alias"))
+  e2e.feed(child, "gp")
+  e2e.wait_until(child, "_G.paste_error ~= nil")
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/dest/alias"), nil)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/keep"), { "KEEP" })
+end
+
+return T

--- a/tests/fs/test_exclusive.lua
+++ b/tests/fs/test_exclusive.lua
@@ -1,0 +1,115 @@
+local Fs = require("eda.fs")
+local helpers = require("helpers")
+local tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmp = helpers.create_temp_dir()
+    end,
+    post_case = function()
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function transfer(operation, src, dst)
+  local finished, result, fast = false, nil, nil
+  Fs[operation](src, dst, function(err)
+    result, fast, finished = err, vim.in_fast_event(), true
+  end, { no_replace = true })
+  helpers.wait_for(5000, function()
+    return finished
+  end)
+  MiniTest.expect.equality(finished, true)
+  MiniTest.expect.equality(fast, false)
+  return result
+end
+
+for _, operation in ipairs({ "copy", "move" }) do
+  T[operation .. " preserves existing files directories and broken links"] = function()
+    helpers.create_file(tmp .. "/source", "SOURCE")
+    helpers.create_file(tmp .. "/file", "KEEP")
+    helpers.create_file(tmp .. "/dir/inside", "INSIDE")
+    assert(vim.uv.fs_symlink(tmp .. "/missing", tmp .. "/link"))
+    for _, name in ipairs({ "file", "dir", "link" }) do
+      MiniTest.expect.equality(type(transfer(operation, tmp .. "/source", tmp .. "/" .. name)), "string")
+      MiniTest.expect.equality(vim.fn.readfile(tmp .. "/source"), { "SOURCE" })
+    end
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/file"), { "KEEP" })
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dir/inside"), { "INSIDE" })
+    MiniTest.expect.equality(vim.uv.fs_readlink(tmp .. "/link"), tmp .. "/missing")
+  end
+
+  T[operation .. " preserves the text of symlinks"] = function()
+    helpers.create_file(tmp .. "/source", "SOURCE")
+    assert(vim.uv.fs_symlink("source", tmp .. "/link"))
+    MiniTest.expect.equality(transfer(operation, tmp .. "/link", tmp .. "/nested/link"), nil)
+    MiniTest.expect.equality(vim.uv.fs_readlink(tmp .. "/nested/link"), "source")
+    MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/link") ~= nil, operation == "copy")
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/source"), { "SOURCE" })
+  end
+end
+
+T["copy preserves nested files hidden entries and directory permissions"] = function()
+  helpers.create_file(tmp .. "/src/nested/file", "FILE")
+  helpers.create_file(tmp .. "/src/.hidden", "HIDDEN")
+  assert(vim.uv.fs_symlink("nested/file", tmp .. "/src/link"))
+  MiniTest.expect.equality(transfer("copy", tmp .. "/src", tmp .. "/dst"), nil)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dst/nested/file"), { "FILE" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dst/.hidden"), { "HIDDEN" })
+  MiniTest.expect.equality(vim.uv.fs_readlink(tmp .. "/dst/link"), "nested/file")
+  MiniTest.expect.equality(vim.uv.fs_stat(tmp .. "/dst").mode, vim.uv.fs_stat(tmp .. "/src").mode)
+end
+
+T["move refuses an existing empty directory"] = function()
+  helpers.create_file(tmp .. "/src/file", "FILE")
+  assert(vim.uv.fs_mkdir(tmp .. "/dst", 493))
+  MiniTest.expect.equality(type(transfer("move", tmp .. "/src", tmp .. "/dst")), "string")
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/src/file"), { "FILE" })
+  MiniTest.expect.equality(vim.uv.fs_stat(tmp .. "/dst/file"), nil)
+end
+
+T["cross-device move copies exclusively before removing its source"] = function()
+  helpers.create_file(tmp .. "/source", "SOURCE")
+  local link = vim.uv.fs_link
+  vim.uv.fs_link = function(_, _, callback)
+    callback("EXDEV: injected cross-device link")
+  end
+  local ok, err = pcall(transfer, "move", tmp .. "/source", tmp .. "/dest")
+  vim.uv.fs_link = link
+  assert(ok, err)
+  MiniTest.expect.equality(err, nil)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest"), { "SOURCE" })
+  MiniTest.expect.equality(vim.uv.fs_stat(tmp .. "/source"), nil)
+end
+
+T["cross-device fallback does not overwrite a destination"] = function()
+  helpers.create_file(tmp .. "/source", "SOURCE")
+  helpers.create_file(tmp .. "/dest", "KEEP")
+  local link = vim.uv.fs_link
+  vim.uv.fs_link = function(_, _, callback)
+    callback("EXDEV: injected cross-device link")
+  end
+  local ok, err = pcall(transfer, "move", tmp .. "/source", tmp .. "/dest")
+  vim.uv.fs_link = link
+  assert(ok, err)
+  MiniTest.expect.equality(type(err), "string")
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest"), { "KEEP" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/source"), { "SOURCE" })
+end
+
+T["unlink failure retains both source and destination"] = function()
+  helpers.create_file(tmp .. "/source", "SOURCE")
+  local unlink = vim.uv.fs_unlink
+  vim.uv.fs_unlink = function(_, callback)
+    callback("EACCES: injected unlink failure")
+  end
+  local ok, err = pcall(transfer, "move", tmp .. "/source", tmp .. "/dest")
+  vim.uv.fs_unlink = unlink
+  assert(ok, err)
+  MiniTest.expect.equality(type(err), "string")
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest"), { "SOURCE" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/source"), { "SOURCE" })
+end
+
+return T


### PR DESCRIPTION
## Summary

Pasting `a/file.txt` and `b/file.txt` into one directory could choose the same destination and lose one file's contents, including both original paths during a cut. Reserve all destinations in register order using the existing `_copy` and numeric suffix policy, then execute sequentially. Stop on failure and retain only failed and unattempted register entries; preserve a newer register and reject repeated paste while the same batch is pending.

Add exclusive filesystem operations for paste so files and symlinks created after planning are not overwritten. Recursive copies preserve symlink text and directory permissions. File moves use an exclusive hard link with a cross-device copy fallback. Directory moves check again before native rename; libuv does not provide an atomic no-replace directory rename, so a concurrently created empty directory remains a platform limitation. Failed operations can leave a partial destination, as documented in the updated help.

Validation: formatting, lint, type checks, unit tests and the full E2E suite; ten new paste E2E cases also pass on Neovim nightly. Tests assert actual source/destination contents, occupied suffixes and broken links, deterministic assignment, partial failure and retry, register replacement, repeated input, and execution-time collisions. Filesystem tests cover real wrappers, cross-device fallback and failed source removal. Self-reviewed the complete diff and generated documentation.

## References

Closes #58.
