### PR TITLE
fix: preserve files when system trash is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Explore as a tree, edit as a buffer — a file explorer for Neovim that combines
 - A terminal that implements the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/) (optional, for image preview; verified with kitty, Ghostty, and WezTerm, detected through the protocol's own capability query so other implementations work too)
 - [ImageMagick](https://imagemagick.org/) `magick` (optional, for previewing image formats other than PNG and for downscaling large PNGs)
 
+Deletion uses system trash by default: Finder through `osascript` on macOS,
+or [trash-cli](https://github.com/andreafrancia/trash-cli)'s `trash-put` on other
+platforms. If the backend is missing or fails, eda reports an error and never
+falls back to permanent deletion. Run `:checkhealth eda` to check availability,
+or explicitly set `delete_to_trash = false` to permanently delete files.
+
 ## Installation
 
 <details>
@@ -195,7 +201,6 @@ require("eda").setup({
     },
   },
 
-  -- Use trash instead of permanent delete
   delete_to_trash = true,
   -- Follow symbolic links when scanning
   follow_symlinks = true,

--- a/doc/eda.md
+++ b/doc/eda.md
@@ -326,6 +326,10 @@ Granular table fields:
 `boolean` (default: `true`)
 
 Send deleted files to the system trash instead of permanently removing them.
+macOS uses Finder through `osascript`; other platforms require `trash-put`
+from `trash-cli`. Missing backends or backend failures return an error without
+falling back to permanent deletion. Run `:checkhealth eda` to check backend
+availability. Set this option to `false` to explicitly enable permanent deletion.
 
 ### follow_symlinks
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -348,6 +348,11 @@ DELETE_TO_TRASH ~
 `boolean` (default: `true`)
 
 Send deleted files to the system trash instead of permanently removing them.
+macOS uses Finder through `osascript`; other platforms require `trash-put` from
+`trash-cli`. Missing backends or backend failures return an error without
+falling back to permanent deletion. Run `:checkhealth eda` to check backend
+availability. Set this option to `false` to explicitly enable permanent
+deletion.
 
 
 FOLLOW_SYMLINKS ~

--- a/lua/eda/fs.lua
+++ b/lua/eda/fs.lua
@@ -108,7 +108,17 @@ function M.copy(src, dst, cb, opts)
   end)
 end
 
----Move a file/directory to system trash (macOS).
+---@return string? backend
+---@return string? error
+function M.trash_backend()
+  local backend = vim.uv.os_uname().sysname == "Darwin" and "osascript" or "trash-put"
+  if vim.fn.executable(backend) == 1 then
+    return backend
+  end
+  local remedy = backend == "trash-put" and "Install trash-cli (trash-put)" or "Make osascript available"
+  return nil, "System trash unavailable: " .. remedy .. "; set delete_to_trash=false only for permanent deletion"
+end
+
 ---@param path string
 ---@param cb fun(err?: string)
 function M.trash(path, cb)
@@ -116,24 +126,38 @@ function M.trash(path, cb)
     cb("Path contains unsupported control characters: " .. path)
     return
   end
-  local sysname = vim.uv.os_uname().sysname
-  if sysname == "Darwin" then
-    vim.system({
-      "osascript",
+  local backend, backend_err = M.trash_backend()
+  if not backend then
+    cb(backend_err)
+    return
+  end
+  local command
+  if backend == "osascript" then
+    command = {
+      backend,
       "-e",
-      string.format('tell app "Finder" to delete POSIX file "%s"', path:gsub("\\", "\\\\"):gsub('"', '\\"')),
-    }, {}, function(result)
-      vim.schedule(function()
-        if result.code ~= 0 then
-          cb("Failed to trash: " .. (result.stderr or ""))
-        else
-          cb()
-        end
-      end)
-    end)
+      'on run argv\ntell application "Finder" to delete POSIX file (item 1 of argv)\nend run',
+      "--",
+      path,
+    }
   else
-    -- Fallback: use trash-cli or just delete
-    M.delete(path, cb)
+    command = { backend, "--", path }
+  end
+  local ok, err = pcall(
+    vim.system,
+    command,
+    { text = true },
+    vim.schedule_wrap(function(result)
+      if result.code ~= 0 then
+        local detail = result.stderr ~= "" and result.stderr or ("exit code " .. result.code)
+        cb("Failed to trash with " .. backend .. ": " .. detail)
+      else
+        cb()
+      end
+    end)
+  )
+  if not ok then
+    cb("Failed to start " .. backend .. ": " .. tostring(err))
   end
 end
 

--- a/lua/eda/health.lua
+++ b/lua/eda/health.lua
@@ -17,8 +17,18 @@ function M.check()
     vim.health.warn("git not found (git integration will be disabled)")
   end
 
-  -- Icon provider
   local cfg = require("eda.config").get()
+  if cfg.delete_to_trash then
+    local backend, err = require("eda.fs").trash_backend()
+    if backend then
+      vim.health.ok("System trash: " .. backend)
+    else
+      vim.health.warn(err or "System trash unavailable")
+    end
+  else
+    vim.health.info("Permanent deletion is enabled (delete_to_trash=false)")
+  end
+
   local icon_provider = cfg.icon and cfg.icon.provider or "mini_icons"
   if icon_provider == "none" then
     vim.health.ok("Icon provider disabled")

--- a/tests/e2e/helpers.lua
+++ b/tests/e2e/helpers.lua
@@ -106,6 +106,7 @@ function M.setup_eda(child)
       icon = { provider = "none" },
       window = { kind = "split_left", width = 40 },
       confirm = false,
+      delete_to_trash = false,
       header = false,
     })
   ]]

--- a/tests/e2e/test_buffer_edit.lua
+++ b/tests/e2e/test_buffer_edit.lua
@@ -117,6 +117,7 @@ T["buffer edit"]["deletes a directory via dd with confirm dialog"] = function()
       icon = { provider = "none" },
       window = { kind = "split_left", width = 40 },
       confirm = true,
+      delete_to_trash = false,
       header = false,
     })
   ]]

--- a/tests/e2e/test_marks.lua
+++ b/tests/e2e/test_marks.lua
@@ -232,6 +232,7 @@ T["marks"]["delete action deletes hidden marked file"] = function()
       confirm = false,
       header = false,
       show_hidden = true,
+      delete_to_trash = false,
     })
   ]]
   )
@@ -284,6 +285,7 @@ T["marks"]["delete action skips dialog when confirm.delete is false"] = function
       icon = { provider = "none" },
       window = { kind = "split_left", width = 40 },
       confirm = { delete = false, move = false, create = false },
+      delete_to_trash = false,
       header = false,
     })
   ]]

--- a/tests/fs/test_trash.lua
+++ b/tests/fs/test_trash.lua
@@ -1,0 +1,158 @@
+local Fs = require("eda.fs")
+local helpers = require("helpers")
+local tmp, original, calls, platform, available, result
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmp = helpers.create_temp_dir()
+      original = {
+        uname = vim.uv.os_uname,
+        executable = vim.fn.executable,
+        system = vim.system,
+        health = vim.health,
+        trash = require("eda.config").get().delete_to_trash,
+      }
+      calls, platform, available = {}, "Linux", {}
+      result = { code = 0, stderr = "" }
+      vim.uv.os_uname = function()
+        return { sysname = platform }
+      end
+      vim.fn.executable = function(name)
+        return available[name] and 1 or 0
+      end
+      vim.system = function(command, _, callback)
+        calls[#calls + 1] = command
+        callback(result)
+        return {}
+      end
+    end,
+    post_case = function()
+      vim.uv.os_uname = original.uname
+      vim.fn.executable = original.executable
+      vim.system = original.system
+      vim.health = original.health
+      require("eda.config").get().delete_to_trash = original.trash
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function trash(path)
+  local done, err, fast = false, nil, nil
+  Fs.trash(path, function(value)
+    done, err, fast = true, value, vim.in_fast_event()
+  end)
+  helpers.wait_for(5000, function()
+    return done
+  end)
+  MiniTest.expect.equality(done, true)
+  MiniTest.expect.equality(fast, false)
+  return err
+end
+
+for _, system in ipairs({ "Darwin", "Linux" }) do
+  T[system .. " preserves files when the trash backend is absent"] = function()
+    platform = system
+    helpers.create_file(tmp .. "/keep", "KEEP")
+    MiniTest.expect.equality(type(trash(tmp .. "/keep")), "string")
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/keep"), { "KEEP" })
+    MiniTest.expect.equality(#calls, 0)
+  end
+
+  T[system .. " passes the path as a separate backend argument"] = function()
+    platform = system
+    local backend = system == "Darwin" and "osascript" or "trash-put"
+    available[backend] = true
+    local path = tmp .. '/a "quoted" \\ path'
+    helpers.create_file(path, "KEEP")
+    MiniTest.expect.equality(trash(path), nil)
+    MiniTest.expect.equality(#calls, 1)
+    MiniTest.expect.equality(calls[1][1], backend)
+    MiniTest.expect.equality(calls[1][#calls[1]], path)
+    MiniTest.expect.equality(calls[1][#calls[1] - 1], "--")
+    if system == "Darwin" then
+      MiniTest.expect.equality(calls[1][3]:find(path, 1, true), nil)
+    end
+  end
+
+  T[system .. " reports backend failure without permanent fallback"] = function()
+    platform = system
+    available[system == "Darwin" and "osascript" or "trash-put"] = true
+    result = { code = 1, stderr = "permission denied" }
+    helpers.create_file(tmp .. "/keep", "KEEP")
+    MiniTest.expect.equality(trash(tmp .. "/keep"):find("permission denied", 1, true) ~= nil, true)
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/keep"), { "KEEP" })
+    MiniTest.expect.equality(#calls, 1)
+  end
+end
+
+T["spawn failure is returned and preserves the source"] = function()
+  available["trash-put"] = true
+  vim.system = function()
+    error("ENOENT: executable disappeared")
+  end
+  helpers.create_file(tmp .. "/keep", "KEEP")
+  MiniTest.expect.equality(trash(tmp .. "/keep"):find("ENOENT", 1, true) ~= nil, true)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/keep"), { "KEEP" })
+end
+
+T["option-like paths are passed after the option terminator"] = function()
+  available["trash-put"] = true
+  MiniTest.expect.equality(trash("--version"), nil)
+  MiniTest.expect.equality(calls[1], { "trash-put", "--", "--version" })
+end
+
+T["explicit permanent deletion works without a trash backend"] = function()
+  helpers.create_file(tmp .. "/delete", "DELETE")
+  local completed
+  Fs.execute_operations({ { type = "delete", path = tmp .. "/delete" } }, { delete_to_trash = false }, function(value)
+    completed = value
+  end)
+  helpers.wait_for(5000, function()
+    return completed ~= nil
+  end)
+  MiniTest.expect.equality(completed.error, nil)
+  MiniTest.expect.equality(#completed.completed, 1)
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/delete"), nil)
+  MiniTest.expect.equality(#calls, 0)
+end
+
+T["a missing backend fails the mutation result and leaves later operations unattempted"] = function()
+  helpers.create_file(tmp .. "/keep", "KEEP")
+  local completed
+  local operations = {
+    { type = "delete", path = tmp .. "/keep" },
+    { type = "create", path = tmp .. "/later", entry_type = "file" },
+  }
+  Fs.execute_operations(operations, { delete_to_trash = true }, function(value)
+    completed = value
+  end)
+  MiniTest.expect.equality(completed.failed, operations[1])
+  MiniTest.expect.equality(type(completed.error), "string")
+  MiniTest.expect.equality(#completed.completed, 0)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/keep"), { "KEEP" })
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmp .. "/later"), nil)
+end
+
+T["health reports missing available and explicitly disabled trash"] = function()
+  local messages = {}
+  vim.health = {}
+  for _, level in ipairs({ "start", "ok", "warn", "error", "info" }) do
+    vim.health[level] = function(message)
+      messages[#messages + 1] = level .. ":" .. message
+    end
+  end
+  local function check()
+    messages = {}
+    require("eda.health").check()
+    return table.concat(messages, "\n")
+  end
+  require("eda.config").get().delete_to_trash = true
+  MiniTest.expect.equality(check():find("warn:System trash unavailable", 1, true) ~= nil, true)
+  available["trash-put"] = true
+  MiniTest.expect.equality(check():find("ok:System trash: trash-put", 1, true) ~= nil, true)
+  require("eda.config").get().delete_to_trash = false
+  MiniTest.expect.equality(check():find("info:Permanent deletion is enabled", 1, true) ~= nil, true)
+end
+
+return T


### PR DESCRIPTION
## Summary

With the default `delete_to_trash=true`, non-macOS systems silently deleted files permanently. Use Finder through `osascript` on macOS and `trash-put` from trash-cli elsewhere. If the backend is unavailable, cannot start, or fails, report an error without falling back to permanent deletion. Explicit `delete_to_trash=false` continues to delete permanently.

Pass paths as separate process arguments and share backend discovery with `:checkhealth eda`. Update README and generated help with the platform requirements. Generic deletion E2E fixtures explicitly opt into permanent deletion so they do not depend on desktop trash tools.

Validation: format, lint, type checks, unit and E2E tests. Eleven new unit cases stub GUI/trash programs and assert source contents, safe argument boundaries, failure propagation, unattempted operations, explicit permanent deletion, and health messages. Reviewed the full diff and deletion fixtures; checked AppleScript argv with a harmless local round-trip and trash-cli's option-terminator handling against its source.

## References

Closes #60.
