### PR TITLE
fix: parse Git status with NUL-delimited paths

### DIFF
--- a/lua/eda/git.lua
+++ b/lua/eda/git.lua
@@ -39,25 +39,20 @@ local function parent_dir(path)
   return path:match("^(.*)/[^/]*$") or path
 end
 
----Parse git status --porcelain output into a path→status map.
----Optionally collects directly reported changed file paths into `reported_out`
----(before propagation, excluding ignored entries). Used for jump/filter features.
 ---@param output string
 ---@param root string Git root directory
 ---@param reported_out? table<string, true>  Optional set to populate with reported changed paths
 ---@return table<string, string>
 local function parse_status(output, root, reported_out)
   local result = {}
-  for line in output:gmatch("[^\n]+") do
-    -- Format: XY path (or XY path -> new_path for renames)
-    local status_code = line:sub(1, 2)
-    local path = line:sub(4)
+  local records = output:gmatch("([^%z]+)%z")
+  for record in records do
+    local status_code = record:sub(1, 2)
+    local path = record:sub(4)
 
-    -- Handle renames: "R  old -> new"
-    -- Use plain=true because `-` is a Lua pattern quantifier otherwise.
-    local arrow = path:find(" -> ", 1, true)
-    if arrow then
-      path = path:sub(arrow + 4)
+    -- Arrows and newlines are literal pathname bytes; -z puts rename/copy sources in the next field.
+    if status_code:find("[RC]") then
+      records()
     end
 
     -- Determine the effective status
@@ -134,8 +129,8 @@ function M.status(root, cb)
   cache[git_root] = { ready = "loading" }
 
   vim.system(
-    { "git", "-C", git_root, "status", "--porcelain", "-uall", "--ignored=matching" },
-    { text = true },
+    { "git", "-C", git_root, "status", "--porcelain=v1", "-z", "-uall", "--ignored=matching" },
+    {},
     function(result)
       vim.schedule(function()
         if result.code ~= 0 then

--- a/tests/git/test_pathnames.lua
+++ b/tests/git/test_pathnames.lua
@@ -1,0 +1,105 @@
+local git = require("eda.git")
+local helpers = require("helpers")
+local T = MiniTest.new_set()
+
+T["NUL records preserve every pathname byte"] = function()
+  local names = {
+    "normal.txt",
+    "space name",
+    "日本語.txt",
+    'quote"name',
+    "a -> b",
+    "line\nname",
+    "cr\r\nname",
+    "tab\tname",
+    "back\\slash",
+  }
+  local records, expected, reported = {}, {}, {}
+  for _, name in ipairs(names) do
+    records[#records + 1] = "?? " .. name .. "\0"
+    expected["/root/" .. name] = "?"
+  end
+  MiniTest.expect.equality(git._parse_status(table.concat(records), "/root", reported), expected)
+  for _, name in ipairs(names) do
+    MiniTest.expect.equality(reported["/root/" .. name], true)
+  end
+end
+
+T["rename and copy consume destination then source fields"] = function()
+  for _, code in ipairs({ "R ", " R", "C ", " C", "RM" }) do
+    local reported = {}
+    local output = code .. ' new/line\n -> name\0old/quote"name\0?? after\0!! ignored dir/\0'
+    local result = git._parse_status(output, "/root", reported)
+    local effective = code:sub(2, 2) ~= " " and code:sub(2, 2) or code:sub(1, 1)
+    MiniTest.expect.equality(result, {
+      ["/root/new/line\n -> name"] = effective,
+      ["/root/new"] = effective,
+      ["/root/after"] = "?",
+      ["/root/ignored dir"] = "!",
+    })
+    MiniTest.expect.equality(reported, { ["/root/new/line\n -> name"] = true, ["/root/after"] = true })
+  end
+end
+
+for _, quote_path in ipairs({ "true", "false" }) do
+  T["real Git status preserves unusual names with core.quotePath=" .. quote_path] = function()
+    local tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+    local function command(...)
+      local args = { "git", "-C", tmp }
+      vim.list_extend(args, { ... })
+      local result = vim.system(args, { text = true }):wait()
+      assert(result.code == 0, result.stderr)
+    end
+    local ok, err = pcall(function()
+      command("init")
+      command("config", "user.email", "test@test.com")
+      command("config", "user.name", "Test")
+      command("config", "core.quotePath", quote_path)
+      command("config", "status.renames", "true")
+      local src, dst = 'old "日本語" -> name', 'new "日本語" -> line\r\nname'
+      helpers.create_file(tmp .. "/" .. src, "ORIGINAL")
+      helpers.create_file(tmp .. "/.gitignore", "ignored/")
+      command("add", ".")
+      command("commit", "--no-gpg-sign", "-m", "fixture")
+      command("mv", "--", src, dst)
+      local names = {
+        "space name",
+        "日本語.txt",
+        'quote"name',
+        "a -> b",
+        "line\nname",
+        "cr\r\nname",
+        "tab\tname",
+        "back\\slash",
+      }
+      for _, name in ipairs(names) do
+        helpers.create_file(tmp .. "/" .. name, name)
+      end
+      helpers.create_file(tmp .. "/ignored/inside", "IGNORED")
+      local ready, statuses = false, nil
+      git.status(tmp, function(value)
+        ready, statuses = true, value
+      end)
+      helpers.wait_for(5000, function()
+        return ready
+      end)
+      MiniTest.expect.equality(ready, true)
+      for _, name in ipairs(names) do
+        MiniTest.expect.equality(statuses[tmp .. "/" .. name], "?")
+      end
+      MiniTest.expect.equality(statuses[tmp .. "/" .. dst], "R")
+      MiniTest.expect.equality(statuses[tmp .. "/" .. src], nil)
+      MiniTest.expect.equality(statuses[tmp .. "/ignored"], "!")
+      MiniTest.expect.equality(git.is_gitignored(statuses, tmp .. "/ignored/inside"), true)
+      local reported = git.get_reported_changes(tmp)
+      MiniTest.expect.equality(reported[tmp .. "/" .. dst], true)
+      MiniTest.expect.equality(reported[tmp .. "/ignored"], nil)
+      MiniTest.expect.equality(git.get_cached(tmp), statuses)
+    end)
+    git.invalidate(tmp)
+    helpers.remove_temp_dir(tmp)
+    assert(ok, err)
+  end
+end
+
+return T

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -125,42 +125,42 @@ T["git porcelain status format for renamed files"] = function()
 end
 
 T["parse_status: ignored + untracked mixed dir gets untracked status"] = function()
-  local result = git._parse_status("!! dir/ignored.txt\n?? dir/new.txt", "/root")
+  local result = git._parse_status("!! dir/ignored.txt\0?? dir/new.txt\0", "/root")
   MiniTest.expect.equality(result["/root/dir"], "?")
   MiniTest.expect.equality(result["/root/dir/ignored.txt"], "!")
   MiniTest.expect.equality(result["/root/dir/new.txt"], "?")
 end
 
 T["parse_status: ignored + modified mixed dir gets modified status"] = function()
-  local result = git._parse_status("!! dir/.env\n M dir/main.lua", "/root")
+  local result = git._parse_status("!! dir/.env\0 M dir/main.lua\0", "/root")
   MiniTest.expect.equality(result["/root/dir"], "M")
 end
 
 T["parse_status: multiple statuses dir gets highest priority"] = function()
-  local result = git._parse_status("?? dir/new.txt\n M dir/changed.lua\nUU dir/conflict.lua", "/root")
+  local result = git._parse_status("?? dir/new.txt\0 M dir/changed.lua\0UU dir/conflict.lua\0", "/root")
   MiniTest.expect.equality(result["/root/dir"], "U")
 end
 
 T["parse_status: deep nesting propagates to all ancestors"] = function()
-  local result = git._parse_status(" M a/b/c/file.lua", "/root")
+  local result = git._parse_status(" M a/b/c/file.lua\0", "/root")
   MiniTest.expect.equality(result["/root/a/b/c"], "M")
   MiniTest.expect.equality(result["/root/a/b"], "M")
   MiniTest.expect.equality(result["/root/a"], "M")
 end
 
 T["parse_status: explicit ignored dir after child does not downgrade"] = function()
-  local result = git._parse_status("?? vendor/used.txt\n!! vendor/", "/root")
+  local result = git._parse_status("?? vendor/used.txt\0!! vendor/\0", "/root")
   MiniTest.expect.equality(result["/root/vendor"], "?")
 end
 
 T["parse_status: ignored file does not propagate to parent"] = function()
-  local result = git._parse_status("!! dir/secret.txt", "/root")
+  local result = git._parse_status("!! dir/secret.txt\0", "/root")
   MiniTest.expect.equality(result["/root/dir/secret.txt"], "!")
   MiniTest.expect.equality(result["/root/dir"], nil)
 end
 
 T["parse_status: ignored deep nesting does not propagate to ancestors"] = function()
-  local result = git._parse_status("!! a/b/c/ignored.log", "/root")
+  local result = git._parse_status("!! a/b/c/ignored.log\0", "/root")
   MiniTest.expect.equality(result["/root/a/b/c/ignored.log"], "!")
   MiniTest.expect.equality(result["/root/a/b/c"], nil)
   MiniTest.expect.equality(result["/root/a/b"], nil)
@@ -234,7 +234,7 @@ end
 
 T["parse_status with reported_out collects direct changed file paths"] = function()
   local reported = {}
-  git._parse_status(" M a/b/file.lua\n?? new.txt", "/root", reported)
+  git._parse_status(" M a/b/file.lua\0?? new.txt\0", "/root", reported)
   MiniTest.expect.equality(reported["/root/a/b/file.lua"], true)
   MiniTest.expect.equality(reported["/root/new.txt"], true)
   -- dir propagation should NOT appear in reported set
@@ -244,21 +244,21 @@ end
 
 T["parse_status with reported_out excludes ignored entries"] = function()
   local reported = {}
-  git._parse_status("!! dir/secret.txt\n M dir/code.lua", "/root", reported)
+  git._parse_status("!! dir/secret.txt\0 M dir/code.lua\0", "/root", reported)
   MiniTest.expect.equality(reported["/root/dir/secret.txt"], nil)
   MiniTest.expect.equality(reported["/root/dir/code.lua"], true)
 end
 
 T["parse_status with reported_out excludes ignored directory entries (--ignored=matching)"] = function()
   local reported = {}
-  git._parse_status("!! node_modules/\n?? new.txt", "/root", reported)
+  git._parse_status("!! node_modules/\0?? new.txt\0", "/root", reported)
   MiniTest.expect.equality(reported["/root/node_modules"], nil)
   MiniTest.expect.equality(reported["/root/new.txt"], true)
 end
 
 T["parse_status with reported_out stores renamed file's new path"] = function()
   local reported = {}
-  git._parse_status("R  old.txt -> new.txt", "/root", reported)
+  git._parse_status("R  new.txt\0old.txt\0", "/root", reported)
   MiniTest.expect.equality(reported["/root/new.txt"], true)
   MiniTest.expect.equality(reported["/root/old.txt"], nil)
 end


### PR DESCRIPTION
## Summary

Git indicators and change navigation could miss files named `space name`, `日本語.txt`, `quote"name`, or `a -> b` because the parser treated quoted or arrow-containing output as literal paths or renames. Request porcelain v1 with `-z` and parse NUL-delimited fields. Rename and copy records use the destination followed by a separate source field; literal arrows and newlines remain part of filenames.

Keep stdout in raw mode so CRLF inside a filename is not normalized. Preserve status precedence, parent propagation, ignored-directory handling, and the directly reported change set. Convert internal parser fixtures to the NUL format.

Validation: formatting, lint, type checks, unit and E2E tests. New synthetic cases cover pathname bytes and rename/copy field boundaries; real temporary Git repositories exercise `git.status`, cache results, ignored directories, and unusual renames with `core.quotePath` both enabled and disabled. Self-reviewed the complete diff, including the raw-output requirement and existing navigation/filter behavior.

## References

Closes #61.
