### PR TITLE
fix: dispose watcher and preview debounce timers

### DIFF
--- a/lua/eda/preview.lua
+++ b/lua/eda/preview.lua
@@ -11,7 +11,7 @@ local util = require("eda.util")
 ---@field scanner eda.Scanner?
 ---@field decorator_chain eda.DecoratorChain?
 ---@field painter eda.Painter?
----@field _debounced fun(node: eda.TreeNode)?
+---@field _debounced eda.Debounce?
 ---@field _pending_target integer|string|nil  Node id (dir mode) or path string (file mode)
 ---@field _current_target integer|string|nil  Node id (dir mode) or path string (file mode)
 local Preview = {}
@@ -298,6 +298,10 @@ end
 
 ---Close the preview window.
 function Preview:close()
+  if self._debounced then
+    self._debounced.dispose()
+    self._debounced = nil
+  end
   if self.bufnr and vim.api.nvim_buf_is_valid(self.bufnr) then
     image.detach(self.bufnr)
   end
@@ -416,7 +420,7 @@ function Preview:update(node)
     end)
   end
 
-  self._debounced(node)
+  self._debounced.call(node)
 end
 
 return Preview

--- a/lua/eda/util.lua
+++ b/lua/eda/util.lua
@@ -2,23 +2,50 @@ local M = {}
 
 local is_mac = vim.uv.os_uname().sysname == "Darwin"
 
----Debounce a function call.
+---@class eda.Debounce
+---@field call fun(...: any)
+---@field cancel fun()
+---@field dispose fun()
+
 ---@param ms integer Delay in milliseconds
 ---@param fn fun(...: any) Function to debounce
----@return fun(...: any) debounced Debounced function
+---@return eda.Debounce
 function M.debounce(ms, fn)
   local timer = assert(vim.uv.new_timer(), "failed to create timer")
-  return function(...)
-    local args = { ... }
-    timer:stop()
-    timer:start(ms, 0, function()
+  local disposed, generation = false, 0
+  local function cancel()
+    generation = generation + 1
+    if not disposed then
       timer:stop()
+    end
+  end
+  local function dispose()
+    if disposed then
+      return
+    end
+    cancel()
+    disposed = true
+    timer:close()
+  end
+  local function call(...)
+    if disposed then
+      return
+    end
+    cancel()
+    local token = generation
+    local args = { ... }
+    local count = select("#", ...)
+    timer:start(ms, 0, function()
       vim.schedule(function()
-        ---@diagnostic disable-next-line: deprecated
-        fn(unpack(args))
+        -- Stopping the timer cannot retract a callback already queued with vim.schedule.
+        if not disposed and generation == token then
+          ---@diagnostic disable-next-line: deprecated
+          fn(unpack(args, 1, count))
+        end
       end)
     end)
   end
+  return { call = call, cancel = cancel, dispose = dispose }
 end
 
 ---Check if a buffer is valid.

--- a/lua/eda/watcher.lua
+++ b/lua/eda/watcher.lua
@@ -2,7 +2,7 @@ local util = require("eda.util")
 
 ---@class eda.Watcher
 ---@field _handles table<string, uv.uv_fs_event_t>
----@field _debounced table<string, fun()>
+---@field _debounced table<string, eda.Debounce>
 ---@field pending_operations table<string, boolean>
 local Watcher = {}
 Watcher.__index = Watcher
@@ -40,38 +40,40 @@ function Watcher:watch(path, callback)
   end)
 
   self._debounced[path] = debounced
+  self._handles[path] = handle
 
-  handle:start(path, {}, function(err, filename, events)
+  local ok = handle:start(path, {}, function(err, filename, events)
     if err then
       return
     end
-    vim.schedule(function()
-      debounced(filename, events)
-    end)
+    debounced.call(filename, events)
   end)
 
-  self._handles[path] = handle
+  if not ok then
+    self:unwatch(path)
+  end
 end
 
 ---Stop watching a specific path.
 ---@param path string
 function Watcher:unwatch(path)
+  local debounced = self._debounced[path]
+  if debounced then
+    debounced.dispose()
+    self._debounced[path] = nil
+  end
   local handle = self._handles[path]
   if handle then
     handle:stop()
     handle:close()
     self._handles[path] = nil
-    self._debounced[path] = nil
   end
 end
 
 ---Stop all watchers.
 function Watcher:unwatch_all()
-  for path, handle in pairs(self._handles) do
-    handle:stop()
-    handle:close()
-    self._handles[path] = nil
-    self._debounced[path] = nil
+  for path in pairs(self._handles) do
+    self:unwatch(path)
   end
 end
 

--- a/tests/test_debounce_lifecycle.lua
+++ b/tests/test_debounce_lifecycle.lua
@@ -1,0 +1,223 @@
+local util = require("eda.util")
+local Watcher = require("eda.watcher")
+local Preview = require("eda.preview")
+local helpers = require("helpers")
+local T = MiniTest.new_set()
+
+local function with_timers(test)
+  local original_timer, original_schedule = vim.uv.new_timer, vim.schedule
+  local timers, queued = {}, {}
+  vim.uv.new_timer = function()
+    local timer = { closes = 0, starts = 0, closing = false }
+    function timer:start(_, _, callback)
+      self.starts = self.starts + 1
+      self.fire = callback
+    end
+    function timer:stop() end
+    function timer:close()
+      self.closes = self.closes + 1
+      self.closing = true
+    end
+    function timer:is_closing()
+      return self.closing
+    end
+    timers[#timers + 1] = timer
+    return timer
+  end
+  vim.schedule = function(callback)
+    queued[#queued + 1] = callback
+  end
+  local function flush()
+    local pending = queued
+    queued = {}
+    for _, callback in ipairs(pending) do
+      callback()
+    end
+  end
+  local ok, err = pcall(test, timers, flush)
+  vim.uv.new_timer, vim.schedule = original_timer, original_schedule
+  assert(ok, err)
+end
+
+T["cancel and dispose are idempotent before the first call"] = function()
+  with_timers(function(timers, flush)
+    local d = util.debounce(50, function()
+      error("unexpected callback")
+    end)
+    d.cancel()
+    d.cancel()
+    d.dispose()
+    d.dispose()
+    d.cancel()
+    d.call("late")
+    flush()
+    MiniTest.expect.equality(timers[1].closes, 1)
+    MiniTest.expect.equality(timers[1].starts, 0)
+  end)
+end
+
+T["cancel invalidates queued work and permits later scheduling with nil arguments"] = function()
+  with_timers(function(timers, flush)
+    local calls = {}
+    local d = util.debounce(50, function(...)
+      calls[#calls + 1] = { n = select("#", ...), ... }
+    end)
+    d.call("old")
+    timers[1].fire()
+    d.cancel()
+    d.cancel()
+    flush()
+    MiniTest.expect.equality(#calls, 0)
+    d.call("new", nil, 3, nil)
+    timers[1].fire()
+    flush()
+    MiniTest.expect.equality(calls, { { n = 4, [1] = "new", [3] = 3 } })
+    d.dispose()
+  end)
+end
+
+T["rescheduling invalidates an already-fired callback"] = function()
+  with_timers(function(timers, flush)
+    local calls = {}
+    local d = util.debounce(50, function(value)
+      calls[#calls + 1] = value
+    end)
+    d.call("old")
+    timers[1].fire()
+    d.call("new")
+    flush()
+    MiniTest.expect.equality(#calls, 0)
+    timers[1].fire()
+    flush()
+    MiniTest.expect.equality(calls, { "new" })
+    d.dispose()
+  end)
+end
+
+for _, fired in ipairs({ false, true }) do
+  T["dispose invalidates pending work after timer fired=" .. tostring(fired)] = function()
+    with_timers(function(timers, flush)
+      local d = util.debounce(50, function()
+        error("unexpected callback")
+      end)
+      d.call()
+      if fired then
+        timers[1].fire()
+      end
+      d.dispose()
+      d.dispose()
+      if not fired then
+        timers[1].fire()
+      end
+      flush()
+      MiniTest.expect.equality(timers[1].closes, 1)
+    end)
+  end
+end
+
+T["preview close disposes its timer and cancels queued display"] = function()
+  with_timers(function(timers, flush)
+    local preview = Preview.new({ enabled = true, debounce = 50 })
+    preview.show = function()
+      error("closed preview was reopened")
+    end
+    preview:update({ type = "file", path = "/tmp/preview" })
+    timers[1].fire()
+    preview:close()
+    preview:close()
+    flush()
+    MiniTest.expect.equality(timers[1].closes, 1)
+    MiniTest.expect.equality(preview._debounced, nil)
+    preview:update({ type = "file", path = "/tmp/next" })
+    MiniTest.expect.equality(#timers, 2)
+    preview:close()
+  end)
+end
+
+T["100 watch and unwatch cycles return live handles to baseline"] = function()
+  local before, owned = {}, {}
+  vim.uv.walk(function(handle)
+    before[handle] = true
+  end)
+  local tmp = helpers.create_temp_dir()
+  local watcher = Watcher.new()
+  local ok, err = pcall(function()
+    for _ = 1, 100 do
+      watcher:watch(tmp, function()
+        error("stale watcher")
+      end)
+      watcher:unwatch_all()
+    end
+    collectgarbage("collect")
+    vim.uv.walk(function(handle)
+      if not before[handle] then
+        owned[handle] = true
+      end
+    end)
+    local live = 0
+    helpers.wait_for(1000, function()
+      live = 0
+      vim.uv.walk(function(handle)
+        if owned[handle] then
+          live = live + 1
+        end
+      end)
+      return live == 0
+    end)
+    MiniTest.expect.equality(live, 0)
+  end)
+  watcher:unwatch_all()
+  vim.uv.walk(function(handle)
+    if owned[handle] and not handle:is_closing() then
+      handle:close()
+    end
+  end)
+  helpers.remove_temp_dir(tmp)
+  assert(ok, err)
+end
+
+for _, fail_start in ipairs({ false, true }) do
+  T["watcher cleanup invalidates queued events with start failure=" .. tostring(fail_start)] = function()
+    with_timers(function(timers, flush)
+      local original = vim.uv.new_fs_event
+      local handle = { closes = 0 }
+      function handle:start(_, _, callback)
+        self.event = callback
+        if fail_start then
+          return nil, "ENOENT"
+        end
+        return 0
+      end
+      function handle:stop() end
+      function handle:close()
+        self.closes = self.closes + 1
+      end
+      vim.uv.new_fs_event = function()
+        return handle
+      end
+      local watcher = Watcher.new()
+      local ok, err = pcall(function()
+        watcher:watch("/root", function()
+          error("stale event")
+        end)
+        if not fail_start then
+          handle.event(nil, "entry", {})
+          flush()
+          timers[1].fire()
+          watcher:unwatch("/root")
+          handle.event(nil, "late", {})
+          flush()
+        end
+        MiniTest.expect.equality(next(watcher._handles), nil)
+        MiniTest.expect.equality(next(watcher._debounced), nil)
+        MiniTest.expect.equality(handle.closes, 1)
+        MiniTest.expect.equality(timers[1].closes, 1)
+      end)
+      watcher:unwatch_all()
+      vim.uv.new_fs_event = original
+      assert(ok, err)
+    end)
+  end
+end
+
+return T

--- a/tests/test_util.lua
+++ b/tests/test_util.lua
@@ -9,12 +9,13 @@ T["debounce"]["delays function call"] = function()
   local debounced = util.debounce(50, function()
     called = true
   end)
-  debounced()
+  debounced.call()
   MiniTest.expect.equality(called, false)
   vim.wait(200, function()
     return called
   end, 10)
   MiniTest.expect.equality(called, true)
+  debounced.dispose()
 end
 
 T["debounce"]["only fires last call"] = function()
@@ -22,13 +23,14 @@ T["debounce"]["only fires last call"] = function()
   local debounced = util.debounce(50, function()
     count = count + 1
   end)
-  debounced()
-  debounced()
-  debounced()
+  debounced.call()
+  debounced.call()
+  debounced.call()
   vim.wait(200, function()
     return count > 0
   end, 10)
   MiniTest.expect.equality(count, 1)
+  debounced.dispose()
 end
 
 T["is_valid_buf"] = MiniTest.new_set()


### PR DESCRIPTION
## Summary

Repeated watch/unwatch cycles leaked one debounce timer per directory, and queued callbacks could run after unwatch or preview close. Give the internal debounce helper explicit `call`, `cancel`, and `dispose` methods. Generation checks invalidate callbacks already queued on Neovim's main loop; disposal closes the timer and later calls are harmless.

Watchers dispose their debounce on unwatch and failed startup. Preview close disposes its lazy debounce, and a later update creates a fresh one. Update the existing delay/coalescing tests to use and release the controller.

Validation: format, lint, type checks, unit and E2E suites. Nine regression cases exercise cancellation/disposal before scheduling, after timer firing, queued callback invalidation, nil arguments, preview close/reopen, failed watcher startup, and 100 real watch/unwatch cycles returning libuv handles to baseline after close callbacks finish. Self-reviewed ownership, cleanup call sites, and the complete diff.

## References

Closes #62.
