### PR TITLE
fix: invalidate stale preview requests across lifecycles

### DIFF
--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -1242,6 +1242,11 @@ function M._change_root(explorer, new_path, opts)
   explorer.store = new_store
   explorer.scanner = new_scanner
   explorer.root_path = new_path
+  explorer.preview:attach(explorer.window, {
+    store = new_store,
+    scanner = new_scanner,
+    decorator_chain = explorer.decorator_chain,
+  })
 
   -- Update buffer name for uniqueness
   local buf_name = "eda://" .. new_path

--- a/lua/eda/preview.lua
+++ b/lua/eda/preview.lua
@@ -12,10 +12,19 @@ local util = require("eda.util")
 ---@field decorator_chain eda.DecoratorChain?
 ---@field painter eda.Painter?
 ---@field _debounced eda.Debounce?
+---@field _request_id integer
 ---@field _pending_target integer|string|nil  Node id (dir mode) or path string (file mode)
 ---@field _current_target integer|string|nil  Node id (dir mode) or path string (file mode)
 local Preview = {}
 Preview.__index = Preview
+
+-- bufhidden=wipe cannot free a buffer when presentation was cancelled before its first window opened.
+---@param bufnr integer?
+local function wipe_hidden_buffer(bufnr)
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) and #vim.fn.win_findbuf(bufnr) == 0 then
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end
+end
 
 ---Create a new preview manager.
 ---@param config eda.PreviewConfig
@@ -31,6 +40,7 @@ function Preview.new(config)
     decorator_chain = nil,
     painter = nil,
     _debounced = nil,
+    _request_id = 0,
     _pending_target = nil,
     _current_target = nil,
   }, Preview)
@@ -41,12 +51,29 @@ end
 ---@param window eda.Window
 ---@param deps? { store: eda.Store, scanner: eda.Scanner, decorator_chain: eda.DecoratorChain }
 function Preview:attach(window, deps)
+  self:close()
   self.window = window
-  if deps then
-    self.store = deps.store
-    self.scanner = deps.scanner
-    self.decorator_chain = deps.decorator_chain
+  self.store = deps and deps.store or nil
+  self.scanner = deps and deps.scanner or nil
+  self.decorator_chain = deps and deps.decorator_chain or nil
+end
+
+---@param target integer|string?
+---@return integer
+function Preview:_begin_request(target)
+  self._request_id = self._request_id + 1
+  self._pending_target = target
+  if self._debounced then
+    self._debounced.cancel()
   end
+  return self._request_id
+end
+
+---@param target integer|string
+---@param request_id integer
+---@return boolean
+function Preview:_is_current(target, request_id)
+  return self.config.enabled and self._pending_target == target and self._request_id == request_id
 end
 
 ---Check if a file is binary (contains NUL byte in first 512 bytes).
@@ -99,12 +126,15 @@ end
 ---@param path string
 function Preview:show(path)
   if not self.config.enabled then
+    self:close()
     return
   end
 
   if not self.window or not util.is_valid_win(self.window.winid) then
     return
   end
+
+  local request_id = self:_begin_request(path)
 
   -- Check file size
   local stat = vim.uv.fs_stat(path)
@@ -115,7 +145,7 @@ function Preview:show(path)
   -- Images bypass max_file_size and binary detection; they carry their own limit
   local image_cfg = self.config.image
   if type(image_cfg) == "table" and image_cfg.enabled and image.is_image(path) then
-    self:_show_image(path, stat)
+    self:_show_image(path, stat, request_id)
     return
   end
   local max_size = self.config.max_file_size
@@ -131,9 +161,6 @@ function Preview:show(path)
     return
   end
 
-  -- Mark this path as pending for async guard
-  self._pending_target = path
-
   -- Read file content asynchronously
   vim.uv.fs_open(path, "r", 438, function(err, fd)
     if err or not fd then
@@ -145,7 +172,7 @@ function Preview:show(path)
         return
       end
       vim.schedule(function()
-        self:_present(path, {
+        self:_present(path, request_id, {
           fill = function(bufnr)
             local lines = vim.split(data, "\n", { plain = true })
             if #lines > 0 and lines[#lines] == "" then
@@ -167,12 +194,11 @@ end
 ---backend can size its placement against the visible preview window.
 ---@param path string
 ---@param stat uv.fs_stat.result
-function Preview:_show_image(path, stat)
-  self._pending_target = path
-
+---@param request_id integer
+function Preview:_show_image(path, stat, request_id)
   local limit = self.config.image.max_file_size
   if stat.size > limit then
-    self:_present(path, {
+    self:_present(path, request_id, {
       fill = function(bufnr)
         vim.bo[bufnr].filetype = ""
         image.describe(bufnr, path, string.format("Image exceeds preview.image.max_file_size (%d bytes).", limit))
@@ -181,14 +207,14 @@ function Preview:_show_image(path, stat)
     return
   end
 
-  self:_present(path, {
+  self:_present(path, request_id, {
     fill = function(bufnr)
       vim.bo[bufnr].filetype = ""
       image.loading(bufnr, path)
     end,
     after = function(bufnr, winid)
       image.render(bufnr, winid, path, function()
-        return self._pending_target == path and self.bufnr == bufnr and self.winid == winid
+        return self:_is_current(path, request_id) and self.bufnr == bufnr and self.winid == winid
       end, { transmission = self.config.image.transmission })
     end,
   })
@@ -198,13 +224,11 @@ end
 ---@field fill fun(bufnr: integer) writes the buffer content for the target
 ---@field after? fun(bufnr: integer, winid: integer) runs once the preview window is visible
 
----Shared presentation for every target kind. Callers set `_pending_target`
----synchronously before any asynchronous work; a caller whose target went stale in
----the meantime is dropped here.
 ---@param target integer|string
+---@param request_id integer
 ---@param opts eda.PreviewPresentOpts
-function Preview:_present(target, opts)
-  if self._pending_target ~= target then
+function Preview:_present(target, request_id, opts)
+  if not self:_is_current(target, request_id) then
     return
   end
   if not self.window or not util.is_valid_win(self.window.winid) then
@@ -220,7 +244,13 @@ function Preview:_present(target, opts)
 
   self:_ensure_buffer()
   self.painter:reset()
-  opts.fill(self.bufnr)
+  local bufnr = assert(self.bufnr, "preview buffer was not created")
+  opts.fill(bufnr)
+
+  if not self:_is_current(target, request_id) then
+    wipe_hidden_buffer(bufnr)
+    return
+  end
 
   self:_open_or_reuse_window(layout)
 
@@ -240,41 +270,44 @@ end
 ---@param node eda.TreeNode
 function Preview:show_directory(node)
   if not self.config.enabled then
+    self:close()
     return
   end
   if not self.window or not util.is_valid_win(self.window.winid) then
     return
   end
-  if not self.store or not self.scanner or not self.decorator_chain then
-    -- Tree deps not attached; cannot render directory preview.
+  local store, scanner = self.store, self.scanner
+  if not store or not scanner or not self.decorator_chain then
+    self:close()
     return
   end
 
-  self._pending_target = node.id
+  local request_id = self:_begin_request(node.id)
 
   if node.children_state == "loaded" then
-    self:_render_directory(node)
+    self:_render_directory(node, request_id)
     return
   end
 
-  self.scanner:scan(node.id, function()
+  scanner:scan(node.id, function()
     vim.schedule(function()
-      if self._pending_target ~= node.id then
+      if not self:_is_current(node.id, request_id) or self.store ~= store then
         return
       end
-      local fresh = self.store:get(node.id)
+      local fresh = store:get(node.id)
       if not fresh or fresh.children_state ~= "loaded" then
         return
       end
-      self:_render_directory(fresh)
+      self:_render_directory(fresh, request_id)
     end)
   end)
 end
 
 ---Paint the directory subtree into the preview buffer.
 ---@param node eda.TreeNode
-function Preview:_render_directory(node)
-  self:_present(node.id, {
+---@param request_id integer
+function Preview:_render_directory(node, request_id)
+  self:_present(node.id, request_id, {
     fill = function(bufnr)
       vim.bo[bufnr].filetype = ""
 
@@ -298,20 +331,26 @@ end
 
 ---Close the preview window.
 function Preview:close()
+  local winid, bufnr = self.winid, self.bufnr
+  self:_begin_request(nil)
+  self._current_target = nil
   if self._debounced then
     self._debounced.dispose()
     self._debounced = nil
   end
-  if self.bufnr and vim.api.nvim_buf_is_valid(self.bufnr) then
-    image.detach(self.bufnr)
-  end
-  if util.is_valid_win(self.winid) then
-    vim.api.nvim_win_close(self.winid, true)
-  end
   self.winid = nil
+  self.bufnr = nil
+  self.painter = nil
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+    image.detach(bufnr)
+  end
+  if winid and util.is_valid_win(winid) then
+    vim.api.nvim_win_close(winid, true)
+  end
+  wipe_hidden_buffer(bufnr)
 
   -- Restore filer to original size in float mode
-  if self.window and self.window.kind == "float" and util.is_valid_win(self.window.winid) then
+  if winid and self.window and self.window.kind == "float" and util.is_valid_win(self.window.winid) then
     local Window = require("eda.window")
     local orig = Window._compute_layout("float", self.window.config)
     vim.api.nvim_win_set_config(self.window.winid, {
@@ -402,6 +441,7 @@ end
 ---@param node eda.TreeNode?
 function Preview:update(node)
   if not self.config.enabled then
+    self:close()
     return
   end
 
@@ -409,6 +449,8 @@ function Preview:update(node)
     self:close()
     return
   end
+
+  self:_begin_request(nil)
 
   if not self._debounced then
     self._debounced = util.debounce(self.config.debounce, function(target)

--- a/tests/e2e/test_preview.lua
+++ b/tests/e2e/test_preview.lua
@@ -470,4 +470,46 @@ T["max_file_size"]["large file is not previewed when exceeding max_file_size"] =
   )
 end
 
+T["preview"]["root changes rebind preview dependencies and show the new tree"] = function()
+  e2e.setup_eda(child)
+  e2e.create_file(tmp .. "/next/visible.txt", "NEW ROOT")
+  e2e.exec(child, [[require("eda.config").get().preview.enabled = true]])
+  e2e.open_eda(child, tmp)
+  e2e.exec(
+    child,
+    string.format(
+      [[
+    local eda = require("eda")
+    eda._change_root(eda.get_current(), %q, {})
+  ]],
+      tmp .. "/next"
+    )
+  )
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return ex._initial_scan_complete and ex.preview.store == ex.store and ex.preview.scanner == ex.scanner
+  ]]
+  )
+  e2e.exec(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    ex.preview:show_directory(ex.store:get(ex.store.root_id))
+  ]]
+  )
+  e2e.wait_until(
+    child,
+    [[
+    local p = require("eda").get_current().preview
+    if not p.winid or not vim.api.nvim_win_is_valid(p.winid) then return false end
+    for _, line in ipairs(vim.api.nvim_buf_get_lines(p.bufnr, 0, -1, false)) do
+      if line:find("visible.txt", 1, true) then return true end
+    end
+    return false
+  ]]
+  )
+end
+
 return T

--- a/tests/preview/test_image.lua
+++ b/tests/preview/test_image.lua
@@ -705,4 +705,53 @@ T["Preview"]["a hidden image stays hidden across FocusGained and reposition"] = 
   teardown_preview(p, env)
 end
 
+T["Preview"]["a pending conversion cannot attach an image after close"] = function()
+  stub_terminal()
+  saved.to_png = convert.to_png
+  local complete
+  convert.to_png = function(_, _, callback)
+    complete = callback
+  end
+  local p, env = setup_preview()
+  p:show(env.jpg)
+  helpers.wait_for(1000, function()
+    return complete ~= nil
+  end)
+  MiniTest.expect.equality(type(complete), "function")
+  p.config.enabled = false
+  p:close()
+  captured = {}
+  complete(nil, env.png)
+  MiniTest.expect.equality(find("a=p"), nil)
+  MiniTest.expect.equality(find("a=t"), nil)
+  MiniTest.expect.equality(p.winid, nil)
+  teardown_preview(p, env)
+end
+
+T["Preview"]["same-path image requests reject the earlier conversion"] = function()
+  stub_terminal()
+  saved.to_png = convert.to_png
+  local conversions = {}
+  convert.to_png = function(_, _, callback)
+    conversions[#conversions + 1] = callback
+  end
+  local p, env = setup_preview()
+  p:show(env.jpg)
+  helpers.wait_for(1000, function()
+    return #conversions == 1
+  end)
+  p:show(env.jpg)
+  helpers.wait_for(1000, function()
+    return #conversions == 2
+  end)
+  MiniTest.expect.equality(#conversions, 2)
+  conversions[2](nil, env.png)
+  MiniTest.expect.equality(find("a=p") ~= nil, true)
+  captured = {}
+  conversions[1](nil, env.png)
+  MiniTest.expect.equality(find("a=t"), nil)
+  MiniTest.expect.equality(find("a=p"), nil)
+  teardown_preview(p, env)
+end
+
 return T

--- a/tests/preview/test_lifecycle.lua
+++ b/tests/preview/test_lifecycle.lua
@@ -1,0 +1,196 @@
+local Preview = require("eda.preview")
+local Store = require("eda.tree.store")
+local config = require("eda.config")
+local helpers = require("helpers")
+local preview, tmp, filer, buffer, reads, original_read
+
+local function flush()
+  local done = false
+  vim.schedule(function()
+    done = true
+  end)
+  helpers.wait_for(1000, function()
+    return done
+  end)
+  MiniTest.expect.equality(done, true)
+end
+
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      config.setup({
+        preview = { enabled = true, debounce = 1000 },
+        icon = { provider = "none" },
+        git = { enabled = false },
+      })
+      tmp = helpers.create_temp_dir()
+      helpers.create_file(tmp .. "/file.txt", "FILE")
+      helpers.create_file(tmp .. "/next.txt", "NEXT")
+      buffer = vim.api.nvim_create_buf(false, true)
+      vim.cmd("topleft vsplit")
+      filer = vim.api.nvim_get_current_win()
+      vim.api.nvim_win_set_buf(filer, buffer)
+      vim.api.nvim_win_set_width(filer, math.floor(vim.o.columns * 0.3))
+      preview = Preview.new(config.get().preview)
+      preview:attach({ winid = filer, kind = "split_left", config = config.get() })
+      reads = {}
+      original_read = vim.uv.fs_read
+      vim.uv.fs_read = function(fd, _, _, callback)
+        local read = { fd = fd, done = false }
+        read.finish = function(data)
+          read.done = true
+          callback(nil, data)
+        end
+        reads[#reads + 1] = read
+      end
+    end,
+    post_case = function()
+      preview:close()
+      vim.uv.fs_read = original_read
+      for _, read in ipairs(reads) do
+        if not read.done then
+          vim.uv.fs_close(read.fd)
+        end
+      end
+      if vim.api.nvim_win_is_valid(filer) then
+        vim.api.nvim_win_close(filer, true)
+      end
+      if vim.api.nvim_buf_is_valid(buffer) then
+        vim.api.nvim_buf_delete(buffer, { force = true })
+      end
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function show_read(path, count)
+  preview:show(path)
+  helpers.wait_for(1000, function()
+    return #reads == count
+  end)
+  MiniTest.expect.equality(#reads, count)
+end
+
+for _, action in ipairs({ "close", "disable", "disable_and_close" }) do
+  T[action .. " prevents a pending text read from opening a preview"] = function()
+    show_read(tmp .. "/file.txt", 1)
+    if action ~= "close" then
+      preview.config.enabled = false
+    end
+    if action ~= "disable" then
+      preview:close()
+    end
+    reads[1].finish("STALE")
+    flush()
+    MiniTest.expect.equality(preview.winid, nil)
+  end
+end
+
+T["same-path close and reopen rejects the earlier read"] = function()
+  show_read(tmp .. "/file.txt", 1)
+  preview:close()
+  show_read(tmp .. "/file.txt", 2)
+  reads[2].finish("NEW")
+  flush()
+  MiniTest.expect.equality(vim.api.nvim_buf_get_lines(preview.bufnr, 0, -1, false), { "NEW" })
+  reads[1].finish("OLD")
+  flush()
+  MiniTest.expect.equality(vim.api.nvim_buf_get_lines(preview.bufnr, 0, -1, false), { "NEW" })
+end
+
+T["a new debounced target immediately supersedes an outstanding read"] = function()
+  show_read(tmp .. "/file.txt", 1)
+  preview:update({ type = "file", path = tmp .. "/next.txt" })
+  reads[1].finish("STALE")
+  flush()
+  MiniTest.expect.equality(preview.winid, nil)
+end
+
+local function directory_request()
+  local store = Store.new()
+  store:set_root(tmp)
+  local node = store:get(store.root_id)
+  local complete
+  local scanner = {
+    scan = function(_, _, callback)
+      complete = callback
+    end,
+  }
+  preview:attach(
+    preview.window,
+    { store = store, scanner = scanner, decorator_chain = require("eda.render.decorator").Chain.new() }
+  )
+  preview:show_directory(node)
+  MiniTest.expect.equality(type(complete), "function")
+  return store, node, function()
+    node.children_state = "loaded"
+    complete()
+    flush()
+  end
+end
+
+T["close invalidates a pending directory scan"] = function()
+  local _, _, complete = directory_request()
+  preview:close()
+  complete()
+  MiniTest.expect.equality(preview.winid, nil)
+end
+
+T["reattach invalidates directory requests with a reused node ID"] = function()
+  local _, _, complete = directory_request()
+  local replacement = Store.new()
+  replacement:set_root(tmp .. "/replacement")
+  local root = replacement:get(replacement.root_id)
+  root.children_state = "loaded"
+  preview:attach(
+    preview.window,
+    { store = replacement, scanner = {}, decorator_chain = require("eda.render.decorator").Chain.new() }
+  )
+  complete()
+  MiniTest.expect.equality(preview.winid, nil)
+  preview:show_directory(root)
+  MiniTest.expect.equality(preview.winid ~= nil, true)
+end
+
+T["closing from a FileType callback prevents subsequent presentation"] = function()
+  helpers.create_file(tmp .. "/file.lua", "return {}")
+  local closed, cancelled_buf = false, nil
+  local hook = vim.api.nvim_create_autocmd("FileType", {
+    pattern = "lua",
+    once = true,
+    callback = function(args)
+      closed = true
+      cancelled_buf = args.buf
+      preview:close()
+    end,
+  })
+  local ok, err = pcall(function()
+    show_read(tmp .. "/file.lua", 1)
+    reads[1].finish("return {}")
+    flush()
+    MiniTest.expect.equality(closed, true)
+    MiniTest.expect.equality(preview.winid, nil)
+    MiniTest.expect.equality(vim.api.nvim_buf_is_valid(cancelled_buf), false)
+  end)
+  pcall(vim.api.nvim_del_autocmd, hook)
+  assert(ok, err)
+end
+
+T["disabled updates do not reconfigure a filer that has no preview"] = function()
+  local original = vim.api.nvim_win_set_config
+  local changes = 0
+  vim.api.nvim_win_set_config = function()
+    changes = changes + 1
+  end
+  preview.window.kind = "float"
+  preview.config.enabled = false
+  local ok, err = pcall(function()
+    preview:update(nil)
+  end)
+  vim.api.nvim_win_set_config = original
+  preview.window.kind = "split_left"
+  assert(ok, err)
+  MiniTest.expect.equality(changes, 0)
+end
+
+return T


### PR DESCRIPTION
## Summary

A pending text read could reopen a closed or disabled preview, and an older request for the same file could overwrite a newer result. Track a unique request ID as well as the target for text, directory, and image previews. Close, disable, a newer update, or reattachment invalidates earlier requests; presentation and image callbacks check that ownership before displaying results.

Rebind preview dependencies when the explorer changes root. Recheck ownership after FileType hooks, release scratch buffers whose presentation was cancelled, and avoid reconfiguring a float filer on disabled cursor updates when no preview existed.

Validation: formatting, lint, type checks, unit and E2E tests. New regressions hold read/scan/conversion callbacks to exercise close/disable, reversed completion of same-path requests, pending debounce updates, reused directory IDs, FileType hooks, and root changes. The image suite uses terminal/converter stubs and also passes on Neovim nightly. Self-reviewed all presentation and cleanup paths.

## References

Closes #63.
