### PR TITLE
fix: unify mutation results and event delivery

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -1129,18 +1129,47 @@ Fired when the explorer window closes.
 
 ### `EdaMutationPre`
 
-Fired before file operations are executed.
+Fired once for each executed batch from buffer writes, delete, duplicate, and
+copy/cut paste. It runs after planning and any required confirmation, before
+filesystem operations begin. Empty or cancelled batches emit no mutation events.
 
 `data`: `{ operations = table[] }`
 
+`operations` lists the planned operations in execution order:
+
+| Type | Fields |
+|------|--------|
+| `create` | `path`, `entry_type` (`"file"` or `"directory"`) |
+| `delete` | `path`, `entry_type` (`"file"` or `"directory"`) |
+| `move` | `src`, `dst`, `path` (same as `dst`) |
+| `copy` | `src`, `dst`, `path` (same as `dst`) |
+
+Mutation hooks are notifications, not cancellation hooks. A hook error is
+reported and does not cancel the batch or suppress its completion callback.
+
 ### `EdaMutationPost`
 
-Fired after file operations complete.
+Fired once after the batch finishes or stops at its first error, before any
+optional explorer refresh. It is delivered even if the originating explorer was
+closed while operations were running. The tree may still show its previous
+state when this event fires.
 
 `data`: `{ operations = table[], results = table }`
 
-Useful for integration with plugins like nvim-lsp-file-operations to
-automatically update LSP workspace paths on file rename/move.
+`operations` is the complete plan from `EdaMutationPre`. `results` contains:
+
+- `completed`: successfully completed operations, in execution order; empty if
+  the first operation failed.
+- `failed`: the operation that failed, or `nil` on success.
+- `error`: the failure message, or `nil` on success.
+
+Operations after `failed` are not attempted. Failed and unattempted targets stay
+available in marks or the paste register for retry; completed entries are
+removed. A failed recursive operation may leave partial filesystem changes and
+is not included in `completed`.
+
+Integrations such as LSP workspace notifications must use `results.completed`,
+rather than the full `operations` plan, to report successful changes only.
 
 ### `EdaRootChanged`
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -1229,19 +1229,48 @@ Fired when the explorer window closes.
 
 EDAMUTATIONPRE ~
 
-Fired before file operations are executed.
+Fired once for each executed batch from buffer writes, delete, duplicate, and
+copy/cut paste. It runs after planning and any required confirmation, before
+filesystem operations begin. Empty or cancelled batches emit no mutation
+events.
 
 `data`: `{ operations = table[] }`
+
+`operations` lists the planned operations in execution order:
+
+  Type     Fields
+  -------- ------------------------------------------
+  create   path, entry_type ("file" or "directory")
+  delete   path, entry_type ("file" or "directory")
+  move     src, dst, path (same as dst)
+  copy     src, dst, path (same as dst)
+Mutation hooks are notifications, not cancellation hooks. A hook error is
+reported and does not cancel the batch or suppress its completion callback.
 
 
 EDAMUTATIONPOST ~
 
-Fired after file operations complete.
+Fired once after the batch finishes or stops at its first error, before any
+optional explorer refresh. It is delivered even if the originating explorer was
+closed while operations were running. The tree may still show its previous
+state when this event fires.
 
 `data`: `{ operations = table[], results = table }`
 
-Useful for integration with plugins like nvim-lsp-file-operations to
-automatically update LSP workspace paths on file rename/move.
+`operations` is the complete plan from `EdaMutationPre`. `results` contains:
+
+- `completed`: successfully completed operations, in execution order; empty if
+    the first operation failed.
+- `failed`: the operation that failed, or `nil` on success.
+- `error`: the failure message, or `nil` on success.
+
+Operations after `failed` are not attempted. Failed and unattempted targets
+stay available in marks or the paste register for retry; completed entries are
+removed. A failed recursive operation may leave partial filesystem changes and
+is not included in `completed`.
+
+Integrations such as LSP workspace notifications must use `results.completed`,
+rather than the full `operations` plan, to report successful changes only.
 
 
 EDAROOTCHANGED ~

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -661,25 +661,36 @@ action.register("mark_toggle", function(ctx)
   end
 end, { desc = "Mark/unmark node (Visual selection or cursor)" })
 
---- Delete action: unified mark-aware deletion.
---- Targets are resolved with priority Visual > marks > cursor via _get_target_nodes.
---- When origin is "marks", marks for completed deletions are cleared pre-rescan
---- (so partial-failure marks on failed/unattempted ops survive for retry).
---- Confirmation routing goes through eda._should_confirm to honor cfg.confirm.delete,
---- matching the buffer-edit delete path.
+---@param ctx eda.ActionContext
+---@param from_marks boolean
+---@param result eda.ExecuteResult
+---@param verb string
+local function finish_targets(ctx, from_marks, result, verb)
+  if from_marks then
+    local completed = {}
+    for _, op in ipairs(result.completed) do
+      completed[op.src or op.path] = true
+    end
+    for _, node in pairs(ctx.store.nodes) do
+      if completed[node.path] then
+        node._marked = nil
+      end
+    end
+  end
+  get_eda().refresh_all()
+  if not result.error then
+    vim.notify(verb .. " " .. #result.completed .. " item(s)")
+  elseif #result.completed > 0 then
+    vim.notify(verb .. " " .. #result.completed .. " item(s), error: " .. result.error, vim.log.levels.WARN)
+  end
+end
+
 action.register("delete", function(ctx)
-  -- M._get_target_nodes is used (not local get_target_nodes) because it is defined
-  -- later in the file; module-field lookup is deferred until call time.
   local target = M._get_target_nodes(ctx)
   if #target.nodes == 0 then
     vim.notify("No items selected")
     return
   end
-  local from_marks = target.origin == "marks"
-
-  local Fs = require("eda.fs")
-  local Confirm = require("eda.buffer.confirm")
-  local util = require("eda.util")
 
   local operations = {}
   for _, node in ipairs(target.nodes) do
@@ -690,59 +701,14 @@ action.register("delete", function(ctx)
     })
   end
 
-  local function clear_marks_for_completed(completed)
-    for _, op in ipairs(completed) do
-      for _, n in pairs(ctx.store.nodes) do
-        if n.path == op.path then
-          n._marked = nil
-        end
-      end
-    end
-  end
-
   local function execute()
-    vim.api.nvim_exec_autocmds("User", { pattern = "EdaMutationPre", data = { operations = operations } })
-    Fs.execute_operations(operations, { delete_to_trash = ctx.config.delete_to_trash }, function(result)
-      vim.schedule(function()
-        if not util.is_valid_buf(ctx.buffer.bufnr) then
-          return
-        end
-        if from_marks and result.completed then
-          clear_marks_for_completed(result.completed)
-        end
-        if result.error and (not result.completed or #result.completed == 0) then
-          vim.notify("Delete failed: " .. result.error, vim.log.levels.ERROR)
-          vim.api.nvim_exec_autocmds(
-            "User",
-            { pattern = "EdaMutationPost", data = { operations = operations, results = result } }
-          )
-          return
-        end
-        ctx.scanner:rescan_preserving_state(ctx.store.root_id, function()
-          vim.schedule(function()
-            if not util.is_valid_buf(ctx.buffer.bufnr) then
-              return
-            end
-            refresh(ctx)
-            refresh_git(ctx)
-            vim.api.nvim_exec_autocmds(
-              "User",
-              { pattern = "EdaMutationPost", data = { operations = operations, results = result } }
-            )
-            local completed_count = result.completed and #result.completed or 0
-            if result.error then
-              vim.notify("Deleted " .. completed_count .. " item(s), error: " .. result.error, vim.log.levels.WARN)
-            else
-              vim.notify("Deleted " .. completed_count .. " item(s)")
-            end
-          end)
-        end)
-      end)
+    require("eda.mutation").execute(operations, { delete_to_trash = ctx.config.delete_to_trash }, function(result)
+      finish_targets(ctx, target.origin == "marks", result, "Deleted")
     end)
   end
 
   if get_eda()._should_confirm(ctx.config.confirm, operations) then
-    Confirm.show(operations, ctx.explorer.root_path, execute, function() end)
+    require("eda.buffer.confirm").show(operations, ctx.explorer.root_path, execute, function() end)
   else
     execute()
   end
@@ -832,96 +798,27 @@ action.register("mark_clear_all", function(ctx)
   end
 end, { desc = "Clear all marks" })
 
---- Duplicate action: unified mark-aware duplication.
---- Targets are resolved with priority Visual > marks > cursor via _get_target_nodes.
---- Each target is copied to its parent directory with `_copy` suffix (collision-aware).
---- Directories are allowed (Fs.copy uses `cp -R`). When origin is "marks", marks for
---- completed copies are cleared pre-rescan so failed/unattempted ops survive for retry.
 action.register("duplicate", function(ctx)
-  -- M._get_target_nodes is used (not local get_target_nodes) because it is defined
-  -- later in the file; module-field lookup is deferred until call time.
   local target = M._get_target_nodes(ctx)
   if #target.nodes == 0 then
     vim.notify("No items selected")
     return
   end
-  local from_marks = target.origin == "marks"
 
-  local Fs = require("eda.fs")
-  local util = require("eda.util")
-
-  local operations = {}
+  local operations, reserved = {}, {}
   for _, node in ipairs(target.nodes) do
     local parent_dir = vim.fn.fnamemodify(node.path, ":h")
-    table.insert(operations, {
-      type = "copy",
-      src = node.path,
-      dst = M._resolve_unique_dst(parent_dir, node.name),
-    })
+    local dst = M._resolve_unique_dst(parent_dir, node.name, reserved)
+    table.insert(operations, { type = "copy", path = dst, src = node.path, dst = dst })
   end
 
-  vim.api.nvim_exec_autocmds("User", { pattern = "EdaMutationPre", data = { operations = operations } })
-
-  local remaining = #operations
-  local errors = {}
-  local completed = {}
-  local first_failed
-
-  local function finalize()
-    vim.schedule(function()
-      if not util.is_valid_buf(ctx.buffer.bufnr) then
-        return
-      end
-      if from_marks then
-        for _, op in ipairs(completed) do
-          for _, n in pairs(ctx.store.nodes) do
-            if n.path == op.src then
-              n._marked = nil
-            end
-          end
-        end
-      end
-      ctx.scanner:rescan_preserving_state(ctx.store.root_id, function()
-        vim.schedule(function()
-          if not util.is_valid_buf(ctx.buffer.bufnr) then
-            return
-          end
-          refresh(ctx)
-          refresh_git(ctx)
-          local result = { completed = completed, failed = first_failed, error = errors[1] }
-          vim.api.nvim_exec_autocmds(
-            "User",
-            { pattern = "EdaMutationPost", data = { operations = operations, results = result } }
-          )
-          local n_completed = #completed
-          if #errors == 0 then
-            vim.notify("Duplicated " .. n_completed .. " item(s)")
-          elseif n_completed > 0 then
-            vim.notify("Duplicated " .. n_completed .. " item(s), error: " .. errors[1], vim.log.levels.WARN)
-          else
-            vim.notify("Duplicate failed: " .. errors[1], vim.log.levels.ERROR)
-          end
-        end)
-      end)
-    end)
-  end
-
-  for _, op in ipairs(operations) do
-    Fs.copy(op.src, op.dst, function(err)
-      if err then
-        table.insert(errors, err)
-        if not first_failed then
-          first_failed = op
-        end
-      else
-        table.insert(completed, op)
-      end
-      remaining = remaining - 1
-      if remaining == 0 then
-        finalize()
-      end
-    end)
-  end
+  require("eda.mutation").execute(
+    operations,
+    { delete_to_trash = ctx.config.delete_to_trash, no_replace = true },
+    function(result)
+      finish_targets(ctx, target.origin == "marks", result, "Duplicated")
+    end
+  )
 end, { desc = "Duplicate target nodes (Visual > marks > cursor)" })
 
 action.register("system_open", function(ctx)
@@ -1251,7 +1148,6 @@ local active_pastes = {}
 
 action.register("paste", function(ctx)
   local register = require("eda.register")
-  local Fs = require("eda.fs")
   local reg = register.get()
   if not reg then
     vim.notify("Register is empty")
@@ -1282,49 +1178,34 @@ action.register("paste", function(ctx)
 
   local planned, reserved = {}, {}
   for _, src_path in ipairs(reg.paths) do
+    local dst = resolve_unique_dst(target_dir, vim.fn.fnamemodify(src_path, ":t"), reserved)
     planned[#planned + 1] = {
+      type = reg.operation == "cut" and "move" or "copy",
+      path = dst,
       src = src_path,
-      dst = resolve_unique_dst(target_dir, vim.fn.fnamemodify(src_path, ":t"), reserved),
+      dst = dst,
     }
   end
   active_pastes[reg] = true
-  local index = 0
-  local function finish(err)
-    active_pastes[reg] = nil
-    if register.get() == reg then
-      if err then
-        local pending = {}
-        for i = index, #planned do
-          pending[#pending + 1] = planned[i].src
+  require("eda.mutation").execute(
+    planned,
+    { delete_to_trash = ctx.config.delete_to_trash, no_replace = true },
+    function(result)
+      active_pastes[reg] = nil
+      if register.get() == reg then
+        if result.error then
+          local pending = {}
+          for i = #result.completed + 1, #planned do
+            pending[#pending + 1] = planned[i].src
+          end
+          register.set(pending, reg.operation)
+        else
+          register.clear()
         end
-        register.set(pending, reg.operation)
-      else
-        register.clear()
       end
+      get_eda().refresh_all()
     end
-    if err then
-      vim.notify(err, vim.log.levels.ERROR)
-    end
-    get_eda().refresh_all()
-  end
-  local function next_entry(err)
-    if err then
-      finish(err)
-      return
-    end
-    index = index + 1
-    local entry = planned[index]
-    if not entry then
-      finish()
-      return
-    end
-    if reg.operation == "cut" then
-      Fs.move(entry.src, entry.dst, next_entry, { no_replace = true })
-    else
-      Fs.copy(entry.src, entry.dst, next_entry, { no_replace = true })
-    end
-  end
-  next_entry()
+  )
 end, { desc = "Paste from register" })
 
 action.register("help", function(ctx)

--- a/lua/eda/fs.lua
+++ b/lua/eda/fs.lua
@@ -93,10 +93,13 @@ function M.copy(src, dst, cb, opts)
   end
   vim.schedule(function()
     local parent = vim.fn.fnamemodify(dst, ":h")
-    vim.fn.mkdir(parent, "p")
+    local parent_ok, parent_err = pcall(vim.fn.mkdir, parent, "p")
+    if not parent_ok then
+      cb("Failed to create destination parent: " .. tostring(parent_err))
+      return
+    end
 
-    -- Use system cp for recursive copy
-    vim.system({ "cp", "-R", src, dst }, {}, function(result)
+    local ok, err = pcall(vim.system, { "cp", "-R", src, dst }, {}, function(result)
       vim.schedule(function()
         if result.code ~= 0 then
           cb("Failed to copy: " .. (result.stderr or ""))
@@ -105,6 +108,9 @@ function M.copy(src, dst, cb, opts)
         end
       end)
     end)
+    if not ok then
+      cb("Failed to start cp: " .. tostring(err))
+    end
   end)
 end
 
@@ -166,9 +172,12 @@ end
 ---@field failed eda.Operation?
 ---@field error string?
 
----Execute a list of operations sequentially. Halts on first error.
+---@class eda.ExecuteOptions
+---@field delete_to_trash boolean
+---@field no_replace? boolean
+
 ---@param operations eda.Operation[]
----@param opts { delete_to_trash: boolean }
+---@param opts eda.ExecuteOptions
 ---@param cb fun(result: eda.ExecuteResult)
 function M.execute_operations(operations, opts, cb)
   local completed = {}
@@ -182,16 +191,20 @@ function M.execute_operations(operations, opts, cb)
     end
 
     local op = operations[idx]
+    local settled = false
 
     local function on_done(err)
+      if settled then
+        return
+      end
+      settled = true
       if err then
-        -- Format partial failure report
         local msg = ""
         if #completed > 0 then
           local parts = {}
           for _, c in ipairs(completed) do
-            if c.type == "move" then
-              table.insert(parts, "MOVE " .. c.src .. " → " .. c.dst)
+            if c.type == "move" or c.type == "copy" then
+              table.insert(parts, c.type:upper() .. " " .. c.src .. " → " .. c.dst)
             elseif c.type == "create" then
               table.insert(parts, "CREATE " .. c.path)
             elseif c.type == "delete" then
@@ -210,18 +223,31 @@ function M.execute_operations(operations, opts, cb)
       next_op()
     end
 
-    if op.type == "create" then
-      M.create(op.path, op.entry_type == "directory", on_done)
-    elseif op.type == "delete" then
-      if opts.delete_to_trash then
-        M.trash(op.path, on_done)
+    local ok, err = pcall(function()
+      if op.type == "create" then
+        M.create(op.path, op.entry_type == "directory", on_done)
+      elseif op.type == "delete" then
+        if opts.delete_to_trash then
+          M.trash(op.path, on_done)
+        else
+          M.delete(op.path, on_done)
+        end
+      elseif op.type == "move" or op.type == "copy" then
+        local transfer = op.type == "move" and M.move or M.copy
+        if opts.no_replace then
+          transfer(op.src, op.dst, on_done, { no_replace = true })
+        else
+          transfer(op.src, op.dst, on_done)
+        end
       else
-        M.delete(op.path, on_done)
+        on_done("Unknown operation type: " .. tostring(op.type))
       end
-    elseif op.type == "move" then
-      M.move(op.src, op.dst, on_done)
-    else
-      on_done("Unknown operation type: " .. tostring(op.type))
+    end)
+    if not ok then
+      if settled then
+        error(err, 0)
+      end
+      on_done(tostring(err))
     end
   end
 

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -1067,7 +1067,7 @@ function M._handle_write(explorer)
   end
   local Parser = require("eda.buffer.parser")
   local Diff = require("eda.tree.diff")
-  local Fs = require("eda.fs")
+  local Mutation = require("eda.mutation")
   local Confirm = require("eda.buffer.confirm")
 
   local buffer = explorer.buffer
@@ -1119,22 +1119,8 @@ function M._handle_write(explorer)
       end
     end
 
-    local pre_ok, pre_err = pcall(fire_event, "EdaMutationPre", { operations = operations })
-    if not pre_ok then
-      release()
-      vim.notify("eda: mutation hook failed: " .. tostring(pre_err), vim.log.levels.ERROR)
-      return
-    end
-    Fs.execute_operations(operations, { delete_to_trash = cfg.delete_to_trash }, function(result)
+    Mutation.execute(operations, { delete_to_trash = cfg.delete_to_trash }, function(result)
       vim.schedule(function()
-        if not util.is_valid_buf(buffer.bufnr) or explorer.generation ~= generation then
-          release()
-          return
-        end
-        local post_ok, post_err = pcall(fire_event, "EdaMutationPost", { operations = operations, results = result })
-        if not post_ok then
-          vim.notify("eda: mutation hook failed: " .. tostring(post_err), vim.log.levels.ERROR)
-        end
         if not util.is_valid_buf(buffer.bufnr) or explorer.generation ~= generation then
           release()
           return

--- a/lua/eda/mutation.lua
+++ b/lua/eda/mutation.lua
@@ -1,0 +1,28 @@
+local Fs = require("eda.fs")
+
+local M = {}
+
+local function emit(pattern, data)
+  local ok, err = pcall(vim.api.nvim_exec_autocmds, "User", { pattern = pattern, data = data })
+  if not ok then
+    vim.notify("eda: mutation hook failed: " .. tostring(err), vim.log.levels.ERROR)
+  end
+end
+
+---@param operations eda.Operation[]
+---@param opts eda.ExecuteOptions
+---@param cb fun(result: eda.ExecuteResult)
+function M.execute(operations, opts, cb)
+  if #operations == 0 then
+    cb({ completed = {} })
+    return
+  end
+  emit("EdaMutationPre", { operations = operations })
+  Fs.execute_operations(operations, opts, function(result)
+    -- Tying delivery to a rescan or a live buffer loses completed mutations after close.
+    emit("EdaMutationPost", { operations = operations, results = result })
+    cb(result)
+  end)
+end
+
+return M

--- a/lua/eda/tree/diff.lua
+++ b/lua/eda/tree/diff.lua
@@ -3,7 +3,7 @@ local util = require("eda.util")
 local M = {}
 
 ---@class eda.Operation
----@field type "create"|"delete"|"move"
+---@field type "create"|"delete"|"move"|"copy"
 ---@field path string
 ---@field src string?
 ---@field dst string?

--- a/tests/e2e/test_mutation_events.lua
+++ b/tests/e2e/test_mutation_events.lua
@@ -1,0 +1,206 @@
+local e2e = require("e2e.helpers")
+local child, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      e2e.setup_eda(child)
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      for _, name in ipairs({ "a", "b", "c" }) do
+        e2e.create_file(tmp .. "/" .. name, name)
+      end
+      e2e.create_file(tmp .. "/dest/keep", "KEEP")
+      e2e.exec(
+        child,
+        [[
+        _G.events = {}
+        vim.api.nvim_create_autocmd("User", {
+          pattern = { "EdaMutationPre", "EdaMutationPost" },
+          callback = function(args)
+            table.insert(_G.events, { name = args.match, data = vim.deepcopy(args.data) })
+          end,
+        })
+      ]]
+      )
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function prepare(entry)
+  local paste = entry == "copy-paste" or entry == "cut-paste"
+  e2e.open_eda(child, paste and (tmp .. "/dest") or tmp)
+  if paste then
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      require("eda.register").set({ %q, %q, %q }, %q)
+    ]],
+        tmp .. "/a",
+        tmp .. "/b",
+        tmp .. "/c",
+        entry == "cut-paste" and "cut" or "copy"
+      )
+    )
+  elseif entry == "write" then
+    e2e.feed(child, "Go")
+    e2e.feed_insert(child, "new_a\nnew_b\nnew_c")
+  else
+    e2e.exec(
+      child,
+      [[
+      for _, node in pairs(require("eda").get_current().store.nodes) do
+        if node.name == "a" or node.name == "b" or node.name == "c" then node._marked = true end
+      end
+    ]]
+    )
+  end
+end
+
+local function inject(entry, scenario)
+  local method = ({
+    write = "create",
+    delete = "delete",
+    duplicate = "copy",
+    ["copy-paste"] = "copy",
+    ["cut-paste"] = "move",
+  })[entry]
+  e2e.exec(
+    child,
+    string.format(
+      [[
+    local Fs = require("eda.fs")
+    local original = Fs[%q]
+    local scenario = %q
+    _G.calls = 0
+    Fs[%q] = function(...)
+      _G.calls = _G.calls + 1
+      local args = { ... }
+      local slot = %d
+      local callback = args[slot]
+      if (scenario == "first failure" and _G.calls == 1) or (scenario == "partial failure" and _G.calls == 2) then
+        callback("injected failure")
+        return
+      end
+      if scenario == "close" and _G.calls == 1 then
+        args[slot] = function(err)
+          _G.release = function() callback(err) end
+        end
+      end
+      original(unpack(args))
+    end
+  ]],
+      method,
+      scenario,
+      method,
+      method == "delete" and 2 or 3
+    )
+  )
+end
+
+for _, entry in ipairs({ "write", "delete", "duplicate", "copy-paste", "cut-paste" }) do
+  for _, scenario in ipairs({ "success", "first failure", "partial failure", "close" }) do
+    T[entry .. " delivers one result after " .. scenario] = function()
+      prepare(entry)
+      inject(entry, scenario)
+      local keys = ({ write = ":w<CR>", delete = "D", duplicate = "gd", ["copy-paste"] = "gp", ["cut-paste"] = "gp" })[entry]
+      e2e.feed(child, keys)
+      if scenario == "close" then
+        e2e.wait_until(child, "_G.release ~= nil")
+        e2e.exec(child, [[require("eda").close(); _G.release()]])
+      end
+      e2e.wait_until(child, "#_G.events >= 2")
+      local events = e2e.exec(child, "return _G.events")
+      MiniTest.expect.equality(#events, 2)
+      MiniTest.expect.equality(events[1].name, "EdaMutationPre")
+      MiniTest.expect.equality(events[2].name, "EdaMutationPost")
+      local ops, result = events[1].data.operations, events[2].data.results
+      MiniTest.expect.equality(#ops, 3)
+      MiniTest.expect.equality(events[2].data.operations, ops)
+      local count = scenario == "first failure" and 0 or (scenario == "partial failure" and 1 or 3)
+      MiniTest.expect.equality(#result.completed, count)
+      MiniTest.expect.equality(e2e.exec(child, "return _G.calls"), math.min(count + 1, 3))
+      for i, op in ipairs(ops) do
+        local completed = i <= count
+        if completed then
+          MiniTest.expect.equality(result.completed[i], op)
+        end
+        if entry == "write" then
+          MiniTest.expect.equality(vim.fn.filereadable(op.path), completed and 1 or 0)
+        elseif entry == "delete" then
+          MiniTest.expect.equality(vim.fn.filereadable(op.path), completed and 0 or 1)
+        else
+          MiniTest.expect.equality(vim.fn.filereadable(op.dst), completed and 1 or 0)
+          if completed then
+            MiniTest.expect.equality(vim.fn.readfile(op.dst), { vim.fn.fnamemodify(op.src, ":t") })
+          end
+          MiniTest.expect.equality(vim.fn.filereadable(op.src), entry == "cut-paste" and completed and 0 or 1)
+        end
+      end
+      if count < 3 then
+        MiniTest.expect.equality(result.failed, ops[count + 1])
+        MiniTest.expect.equality(result.error, "injected failure")
+      else
+        MiniTest.expect.equality(result.failed, nil)
+        MiniTest.expect.equality(result.error, nil)
+      end
+      if entry == "copy-paste" or entry == "cut-paste" then
+        local pending = {}
+        for i = count + 1, #ops do
+          pending[#pending + 1] = ops[i].src
+        end
+        MiniTest.expect.equality(
+          e2e.exec(
+            child,
+            [[
+          local reg = require("eda.register").get()
+          return reg and reg.paths or {}
+        ]]
+          ),
+          pending
+        )
+      elseif (entry == "delete" or entry == "duplicate") and scenario ~= "close" then
+        local pending = {}
+        for i = count + 1, #ops do
+          pending[#pending + 1] = ops[i].src or ops[i].path
+        end
+        table.sort(pending)
+        local marked = e2e.exec(
+          child,
+          [[
+          local paths = {}
+          for _, node in pairs(require("eda").get_current().store.nodes) do
+            if node._marked then paths[#paths + 1] = node.path end
+          end
+          table.sort(paths)
+          return paths
+        ]]
+        )
+        MiniTest.expect.equality(marked, pending)
+      end
+      MiniTest.expect.equality(vim.fn.readfile(tmp .. "/dest/keep"), { "KEEP" })
+    end
+  end
+end
+
+for _, entry in ipairs({ "delete", "duplicate" }) do
+  T[entry .. " completes without replacing unsaved buffer text"] = function()
+    prepare(entry)
+    e2e.feed(child, "Go")
+    e2e.feed_insert(child, "pending_create")
+    local lines = e2e.get_buf_lines(child)
+    e2e.feed(child, entry == "delete" and "D" or "gd")
+    e2e.wait_until(child, "#_G.events == 2")
+    MiniTest.expect.equality(e2e.exec(child, "return #_G.events[2].data.results.completed"), 3)
+    MiniTest.expect.equality(e2e.get_buf_lines(child), lines)
+    MiniTest.expect.equality(e2e.exec(child, "return vim.bo.modified"), true)
+    MiniTest.expect.equality(e2e.exec(child, [[return require("eda").get_current().refresh.pending]]), true)
+    MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/pending_create"), 0)
+  end
+end
+
+return T

--- a/tests/fs/test_batch_results.lua
+++ b/tests/fs/test_batch_results.lua
@@ -1,0 +1,145 @@
+local Fs = require("eda.fs")
+local helpers = require("helpers")
+local originals, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      originals = { create = Fs.create, copy = Fs.copy, system = vim.system, exec = vim.api.nvim_exec_autocmds }
+      tmp = helpers.create_temp_dir()
+    end,
+    post_case = function()
+      Fs.create, Fs.copy = originals.create, originals.copy
+      vim.system, vim.api.nvim_exec_autocmds = originals.system, originals.exec
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+local function run(ops, opts)
+  local result
+  Fs.execute_operations(ops, opts or { delete_to_trash = false }, function(value)
+    result = value
+  end)
+  helpers.wait_for(3000, function()
+    return result ~= nil
+  end)
+  return result
+end
+
+T["executes copy before a dependent move"] = function()
+  helpers.create_file(tmp .. "/source", "source")
+  local ops = {
+    { type = "copy", src = tmp .. "/source", dst = tmp .. "/copy" },
+    { type = "move", src = tmp .. "/copy", dst = tmp .. "/moved" },
+  }
+  local result = run(ops, { delete_to_trash = false, no_replace = true })
+  MiniTest.expect.equality(result.completed, ops)
+  MiniTest.expect.equality(result.error, nil)
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/moved"), { "source" })
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/source"), { "source" })
+end
+
+T["reports a synchronous dispatch error without attempting the next operation"] = function()
+  local calls = 0
+  Fs.create = function()
+    calls = calls + 1
+    error("dispatch failed")
+  end
+  local ops = { { type = "create", path = "a" }, { type = "create", path = "b" } }
+  local result = run(ops)
+  MiniTest.expect.equality(calls, 1)
+  MiniTest.expect.equality(result.completed, {})
+  MiniTest.expect.equality(result.failed, ops[1])
+  MiniTest.expect.equality(result.error:find("dispatch failed", 1, true) ~= nil, true)
+end
+
+T["ignores duplicate callbacks and settles the batch once"] = function()
+  local pending, calls, results = {}, 0, {}
+  Fs.create = function(_, _, cb)
+    calls = calls + 1
+    pending[calls] = cb
+  end
+  local ops = { { type = "create", path = "a" }, { type = "create", path = "b" } }
+  Fs.execute_operations(ops, { delete_to_trash = false }, function(result)
+    results[#results + 1] = result
+  end)
+  pending[1]()
+  pending[1]("late error")
+  pending[2]()
+  pending[2]()
+  MiniTest.expect.equality(calls, 2)
+  MiniTest.expect.equality(#results, 1)
+  MiniTest.expect.equality(results[1].completed, ops)
+end
+
+T["does not turn a completion callback error into an operation failure"] = function()
+  Fs.create = function(_, _, cb)
+    cb()
+  end
+  local calls = 0
+  local ok, err = pcall(
+    Fs.execute_operations,
+    { { type = "create", path = "a" } },
+    { delete_to_trash = false },
+    function()
+      calls = calls + 1
+      error("completion failed")
+    end
+  )
+  MiniTest.expect.equality(ok, false)
+  MiniTest.expect.equality(tostring(err):find("completion failed", 1, true) ~= nil, true)
+  MiniTest.expect.equality(calls, 1)
+end
+
+for _, failure in ipairs({ "parent", "spawn" }) do
+  T["copy reports " .. failure .. " failures through the result"] = function()
+    helpers.create_file(tmp .. "/source", "source")
+    if failure == "parent" then
+      helpers.create_file(tmp .. "/blocked", "blocker")
+    else
+      vim.system = function()
+        error("spawn failed")
+      end
+    end
+    local result = run({ { type = "copy", src = tmp .. "/source", dst = tmp .. "/blocked/target" } })
+    MiniTest.expect.equality(#result.completed, 0)
+    local message = failure == "parent" and "Failed to create destination parent" or "Failed to start cp"
+    MiniTest.expect.equality(result.error:find(message, 1, true) ~= nil, true)
+    MiniTest.expect.equality(vim.fn.readfile(tmp .. "/source"), { "source" })
+  end
+end
+
+T["hook dispatch failures do not suppress execution or completion"] = function()
+  local events, result = {}, nil
+  vim.api.nvim_exec_autocmds = function(_, opts)
+    events[#events + 1] = opts.pattern
+    error("hook failed")
+  end
+  require("eda.mutation").execute(
+    { { type = "create", path = tmp .. "/new" } },
+    { delete_to_trash = false },
+    function(value)
+      result = value
+    end
+  )
+  helpers.wait_for(3000, function()
+    return result ~= nil
+  end)
+  MiniTest.expect.equality(events, { "EdaMutationPre", "EdaMutationPost" })
+  MiniTest.expect.equality(#result.completed, 1)
+  MiniTest.expect.equality(vim.fn.filereadable(tmp .. "/new"), 1)
+end
+
+T["empty mutation plans emit no events"] = function()
+  local events, result = {}, nil
+  vim.api.nvim_exec_autocmds = function(_, opts)
+    events[#events + 1] = opts.pattern
+  end
+  require("eda.mutation").execute({}, { delete_to_trash = false }, function(value)
+    result = value
+  end)
+  MiniTest.expect.equality(events, {})
+  MiniTest.expect.equality(result.completed, {})
+end
+
+return T


### PR DESCRIPTION
## Summary

Copy/cut paste emitted no mutation events, while writes, deletes, and duplicates could lose completion notifications after the explorer closed. Route all four entry points through a shared mutation boundary that emits one pre/post pair and reports the completed prefix, first failure, and error independently of UI lifetime.

Execute duplicates sequentially and preserve failed/unattempted marks and register entries for retry. Keep exclusive transfer behavior and batch destination reservations, catch dispatch errors without double completion, and refresh delete/duplicate results through the dirty-buffer coordinator. Document event timing and result payloads and regenerate vimdoc.

Validation: formatting, lint, type checks, unit and E2E tests. Entry-point contract tests exercise success, first failure, partial completion, and closing during pending I/O for write, delete, duplicate, copy-paste, and cut-paste. Additional tests cover unsaved buffer edits, synchronous errors, and duplicate callbacks. Self-reviewed event ownership, failure accounting, lifecycle guards, retry state, and the complete diff.

## References

Closes #64.
