### PR TITLE
fix: reconcile watched directory changes without replacing the tree

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -800,6 +800,19 @@ A refresh already in progress cannot replace the snapshot used by a new edit.
 If a file operation fails because the filesystem changed, the edit remains
 unsaved and the error is reported.
 
+The explorer watches its root and visible, expanded directories using
+nonrecursive filesystem watches. Collapsing or hiding a directory releases its
+watch; expanding it again reloads its contents and any previously open
+descendants. Changing the root or closing the explorer releases the old watches.
+
+Notifications with a known directory scope rescan that directory's direct
+children. Bursts are coalesced, unchanged nodes keep their identity, and an
+unchanged result skips structural repainting. Git status may still require a
+repaint. If a notification has no filename, eda conservatively refreshes the root
+and open subtrees. `<C-l>` also performs a full refresh and discards pending
+buffer edits. Filesystem watch delivery depends on the operating system and
+filesystem; use `<C-l>` when a filesystem does not deliver notifications.
+
 ## Mappings
 
 Default key mappings in the explorer buffer. Customize via the `mappings`

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -822,6 +822,20 @@ A refresh already in progress cannot replace the snapshot used by a new edit.
 If a file operation fails because the filesystem changed, the edit remains
 unsaved and the error is reported.
 
+The explorer watches its root and visible, expanded directories using
+nonrecursive filesystem watches. Collapsing or hiding a directory releases its
+watch; expanding it again reloads its contents and any previously open
+descendants. Changing the root or closing the explorer releases the old
+watches.
+
+Notifications with a known directory scope rescan that directory’s direct
+children. Bursts are coalesced, unchanged nodes keep their identity, and an
+unchanged result skips structural repainting. Git status may still require a
+repaint. If a notification has no filename, eda conservatively refreshes the
+root and open subtrees. `<C-l>` also performs a full refresh and discards
+pending buffer edits. Filesystem watch delivery depends on the operating system
+and filesystem; use `<C-l>` when a filesystem does not deliver notifications.
+
 
 MAPPINGS                                          *eda.nvim-eda.nvim-mappings*
 

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -127,8 +127,12 @@ action.register("select", function(ctx)
     node.open = not node.open
     ctx.explorer._incremental_hint = { toggled_node_id = node.id }
     if node.open and node.children_state == "unloaded" then
-      ctx.scanner:scan(node.id, function()
+      local generation = ctx.explorer.generation
+      ctx.scanner:scan_expanded(node.id, function()
         vim.schedule(function()
+          if ctx.explorer.generation ~= generation or not require("eda.util").is_valid_buf(ctx.buffer.bufnr) then
+            return
+          end
           refresh_preserving(ctx)
         end)
       end)
@@ -677,7 +681,7 @@ local function finish_targets(ctx, from_marks, result, verb)
       end
     end
   end
-  get_eda().refresh_all()
+  get_eda()._refresh_after_mutation(result)
   if not result.error then
     vim.notify(verb .. " " .. #result.completed .. " item(s)")
   elseif #result.completed > 0 then
@@ -1203,7 +1207,7 @@ action.register("paste", function(ctx)
           register.clear()
         end
       end
-      get_eda().refresh_all()
+      get_eda()._refresh_after_mutation(result)
     end
   )
 end, { desc = "Paste from register" })

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -603,6 +603,7 @@ function M.open(opts)
         vim.bo[buf.bufnr].modifiable = false
         buf.flat_lines = {}
         explorer._last_painted_gen = explorer._render_gen
+        explorer.refresh:sync_watchers()
         explorer._incremental_hint = nil
         explorer._empty_state_rendered = true
         buf.target_node_id = nil
@@ -704,6 +705,7 @@ function M.open(opts)
     buf.target_node_id = nil
     buf.focus_node_id = nil
     explorer._last_painted_gen = explorer._render_gen
+    explorer.refresh:sync_watchers()
     if k == "float" then
       refresh_float_title(explorer)
     end
@@ -1009,12 +1011,7 @@ function M.open(opts)
         end)
       end
 
-      local gen = explorer.generation
-      watcher:watch(root_path, function()
-        if explorer.generation == gen and util.is_valid_buf(buffer.bufnr) then
-          explorer.refresh:request()
-        end
-      end)
+      explorer.refresh:sync_watchers()
     end)
   end
 
@@ -1337,11 +1334,7 @@ function M._change_root(explorer, new_path, opts)
         end)
       end
 
-      explorer.watcher:watch(new_path, function()
-        if explorer.generation == gen and util.is_valid_buf(explorer.buffer.bufnr) then
-          explorer.refresh:request()
-        end
-      end)
+      explorer.refresh:sync_watchers()
     end)
   end
 
@@ -1448,6 +1441,13 @@ end
 function M.refresh_all()
   for _, explorer in ipairs(M._instances) do
     explorer.refresh:request()
+  end
+end
+
+---@param result eda.ExecuteResult
+function M._refresh_after_mutation(result)
+  for _, explorer in ipairs(M._instances) do
+    explorer.refresh:after_mutation(result)
   end
 end
 

--- a/lua/eda/refresh.lua
+++ b/lua/eda/refresh.lua
@@ -9,13 +9,19 @@ local git = require("eda.git")
 ---@field pending boolean
 ---@field running boolean
 ---@field epoch integer
+---@field paths table<string, boolean>
+---@field full boolean
+---@field _scheduled boolean
 local Refresh = {}
 Refresh.__index = Refresh
 
 ---@param explorer eda.Explorer
 ---@return eda.Refresh
 function Refresh.new(explorer)
-  local self = setmetatable({ explorer = explorer, pending = false, running = false, epoch = 0 }, Refresh)
+  local self = setmetatable(
+    { explorer = explorer, pending = false, running = false, epoch = 0, paths = {}, full = false, _scheduled = false },
+    Refresh
+  )
   local function flush_later()
     if self.pending then
       -- Flushing synchronously would see the temporary clean state before edit replay.
@@ -47,11 +53,112 @@ function Refresh:reset()
   self.epoch = self.epoch + 1
   self.pending = false
   self.running = false
+  self.paths = {}
+  self.full = false
+  self._scheduled = false
 end
 
-function Refresh:request()
+---@param path string
+---@return string?
+function Refresh:directory_for(path)
+  local ex = self.explorer
+  while path == ex.root_path or path:sub(1, #ex.root_path + 1) == ex.root_path .. "/" or ex.root_path == "/" do
+    local node = ex.store:get_by_path(path)
+    if node and node.type == "directory" and (node.children_state == "loaded" or node.children_ids ~= nil) then
+      return node.path
+    end
+    local parent = vim.fn.fnamemodify(path, ":h")
+    if parent == path then
+      break
+    end
+    path = parent
+  end
+end
+
+---@param path? string
+function Refresh:request(path)
   self.pending = true
-  self:flush()
+  local directory = path and self:directory_for(path)
+  if directory then
+    self.paths[directory] = true
+  else
+    self.full = true
+  end
+  if not self._scheduled then
+    self._scheduled = true
+    local epoch = self.epoch
+    vim.schedule(function()
+      if self.epoch == epoch then
+        self._scheduled = false
+        self:flush()
+      end
+    end)
+  end
+end
+
+---@param result eda.ExecuteResult
+function Refresh:after_mutation(result)
+  local operations = vim.list_extend({}, result.completed)
+  if result.failed then
+    operations[#operations + 1] = result.failed
+  end
+  for _, op in ipairs(operations) do
+    local paths = op.src and { op.src, op.dst } or { op.path }
+    for _, path in ipairs(paths) do
+      local directory = self:directory_for(vim.fn.fnamemodify(path, ":h"))
+      if directory then
+        self:request(directory)
+      end
+    end
+  end
+end
+
+function Refresh:sync_watchers()
+  local ex = self.explorer
+  if not util.is_valid_buf(ex.buffer.bufnr) then
+    return
+  end
+  local wanted = { [ex.root_path] = true }
+  for _, line in ipairs(ex.buffer.flat_lines) do
+    local node = line.node
+    if node.type == "directory" and node.open and node.children_state == "loaded" then
+      wanted[node.path] = true
+    end
+  end
+  for path in pairs(ex.watcher._handles) do
+    if not wanted[path] then
+      ex.watcher:unwatch(path)
+      local node = ex.store:get_by_path(path)
+      if node then
+        -- Collapsed directories have no watch coverage and must be checked on expansion.
+        node.children_state = "unloaded"
+      end
+    end
+  end
+  local generation = ex.generation
+  for path in pairs(wanted) do
+    if not ex.watcher._handles[path] then
+      ex.watcher:watch(path, function(filename)
+        if ex.generation ~= generation or not util.is_valid_buf(ex.buffer.bufnr) then
+          return
+        end
+        self:request(filename and vim.fn.fnamemodify(path .. "/" .. filename, ":h") or nil)
+      end)
+    end
+  end
+end
+
+local function child_fields(node)
+  return {
+    name = node.name,
+    path = node.path,
+    type = node.type,
+    link_target = node.link_target,
+    link_broken = node.link_broken,
+    error = node.error,
+    open = node.open,
+    _marked = node._marked,
+  }
 end
 
 function Refresh:flush()
@@ -60,10 +167,12 @@ function Refresh:flush()
   if not self.pending or self.running or not util.is_valid_buf(bufnr) then
     return
   end
-  if vim.bo[bufnr].modified or not ex._initial_scan_complete or ex.scanner._active_fds > 0 then
+  if vim.bo[bufnr].modified or ex._writing or not ex._initial_scan_complete or ex.scanner._active_fds > 0 then
     return
   end
 
+  local paths, full = self.paths, self.full
+  self.paths, self.full = {}, false
   self.pending = false
   self.running = true
   local epoch, generation, render_gen = self.epoch, ex.generation, ex._render_gen
@@ -72,13 +181,11 @@ function Refresh:flush()
   local next_id, store_gen = store.next_id, store.generation
   local candidate = Store.new()
   candidate:set_root(ex.root_path)
-  candidate.next_id = next_id
   local cfg = config.get()
   local scanner = Scanner.new(candidate, cfg)
+  local roots = {}
 
-  -- Guarding only the watcher event misses edits started during asynchronous I/O.
-  -- Applying directory results directly would invalidate the dirty snapshot's IDs.
-  scanner:rescan_preserving_state(candidate.root_id, function()
+  local function commit()
     if self.epoch ~= epoch then
       return
     end
@@ -88,6 +195,7 @@ function Refresh:flush()
     end
     if
       vim.bo[bufnr].modified
+      or ex._writing
       or vim.api.nvim_buf_get_changedtick(bufnr) ~= changedtick
       or ex._render_gen ~= render_gen
       or store.next_id ~= next_id
@@ -95,15 +203,38 @@ function Refresh:flush()
       or ex.scanner._active_fds > 0
     then
       self.pending = true
+      self.full = self.full or full
+      for path in pairs(paths) do
+        self.paths[path] = true
+      end
       self:flush()
       return
     end
 
-    store.nodes = candidate.nodes
-    store.path_index = candidate.path_index
-    store.next_id = candidate.next_id
-    store:next_generation()
-    ex.buffer:render(store)
+    local changed = false
+    local function adopt(id)
+      local source = candidate:get(id)
+      local target = source and store:get_by_path(source.path)
+      if not source or not target or target.type ~= "directory" or source.children_state ~= "loaded" then
+        return
+      end
+      local entries = {}
+      for _, child_id in ipairs(source.children_ids or {}) do
+        entries[#entries + 1] = child_fields(candidate:get(child_id))
+      end
+      changed = store:reconcile_children(target.id, entries) or changed
+      for _, child_id in ipairs(source.children_ids or {}) do
+        adopt(child_id)
+      end
+    end
+    for _, id in ipairs(roots) do
+      adopt(id)
+    end
+    if changed then
+      ex.buffer:render(store)
+    else
+      self:sync_watchers()
+    end
     if cfg.git.enabled then
       git.status(ex.root_path, function()
         if self.epoch == epoch and ex.generation == generation and util.is_valid_buf(bufnr) then
@@ -112,7 +243,36 @@ function Refresh:flush()
       end)
     end
     self:flush()
-  end, store)
+  end
+
+  -- Applying I/O results directly would replace IDs underneath pending buffer edits.
+  if full then
+    roots[1] = candidate.root_id
+    scanner:rescan_preserving_state(candidate.root_id, commit, store)
+    return
+  end
+
+  local directories = vim.tbl_keys(paths)
+  table.sort(directories, function(a, b)
+    return #a < #b
+  end)
+  for _, path in ipairs(directories) do
+    roots[#roots + 1] = path == ex.root_path and candidate.root_id
+      or candidate:add({ name = vim.fn.fnamemodify(path, ":t"), path = path, type = "directory" })
+  end
+  local remaining = #roots
+  if remaining == 0 then
+    commit()
+    return
+  end
+  for _, id in ipairs(roots) do
+    scanner:scan(id, function()
+      remaining = remaining - 1
+      if remaining == 0 then
+        commit()
+      end
+    end)
+  end
 end
 
 return Refresh

--- a/lua/eda/tree/scanner.lua
+++ b/lua/eda/tree/scanner.lua
@@ -188,7 +188,7 @@ function Scanner:_apply_entries(node_id, entries)
     return
   end
 
-  self.store:remove_children(node_id)
+  local children = {}
 
   local follow_symlinks = self.config.follow_symlinks ~= false
   local show_hidden = self.config.show_hidden ~= false
@@ -239,11 +239,11 @@ function Scanner:_apply_entries(node_id, entries)
       end
     end
 
-    self.store:add(fields)
+    table.insert(children, fields)
     ::continue_entry::
   end
 
-  node.children_state = "loaded"
+  self.store:reconcile_children(node_id, children)
 end
 
 ---Scan ancestor directories from root to target path.
@@ -313,6 +313,26 @@ function Scanner:scan_ancestors(target_path, callback)
   end
 
   scan_next()
+end
+
+---@param node_id integer
+---@param callback fun()
+function Scanner:scan_expanded(node_id, callback)
+  self:scan(node_id, function()
+    local open_dirs = {}
+    local function collect(id)
+      local node = self.store:get(id)
+      if not node or not Node.is_dir(node) or not node.open then
+        return
+      end
+      open_dirs[node.path] = true
+      for _, child_id in ipairs(node.children_ids or {}) do
+        collect(child_id)
+      end
+    end
+    collect(node_id)
+    self:scan_open_unloaded(open_dirs, callback)
+  end)
 end
 
 ---Recursively scan open directories up to a depth limit.
@@ -391,7 +411,14 @@ function Scanner:scan_open_unloaded(open_dirs, callback)
   local dirs_to_scan = {}
   for path in pairs(open_dirs) do
     local node = self.store:get_by_path(path)
-    if node and Node.is_dir(node) and node.open and node.children_state == "unloaded" then
+    local parent = node and node.parent_id and self.store:get(node.parent_id)
+    if
+      node
+      and Node.is_dir(node)
+      and node.open
+      and node.children_state == "unloaded"
+      and (not parent or parent.children_state == "loaded")
+    then
       dirs_to_scan[#dirs_to_scan + 1] = node.id
     end
   end
@@ -432,6 +459,12 @@ function Scanner:rescan_preserving_state(root_id, callback, state_store)
       if node._marked then
         marked_by_path[node.path] = true
       end
+    end
+  end
+  for path in pairs(open_by_path) do
+    local node = self.store:get_by_path(path)
+    if node then
+      node.children_state = "unloaded"
     end
   end
   self:scan(root_id, function()

--- a/lua/eda/tree/store.lua
+++ b/lua/eda/tree/store.lua
@@ -130,35 +130,89 @@ function Store:remove(id)
   self.nodes[id] = nil
 end
 
----Remove all children and descendants of a node from the store.
----The parent node itself is kept with an empty children_ids.
+local function purge(store, id)
+  local node = store.nodes[id]
+  if not node then
+    return
+  end
+  for _, child_id in ipairs(node.children_ids or {}) do
+    purge(store, child_id)
+  end
+  store.path_index[util.nfc_normalize(node.path)] = nil
+  store.nodes[id] = nil
+end
+
 ---@param parent_id integer
 function Store:remove_children(parent_id)
   local parent = self.nodes[parent_id]
-  if not parent or not parent.children_ids then
+  if not parent then
     return
   end
-
-  local function purge(id)
-    local node = self.nodes[id]
-    if not node then
-      return
-    end
-    if node.children_ids then
-      for _, child_id in ipairs(node.children_ids) do
-        purge(child_id)
-      end
-    end
-    self.path_index[util.nfc_normalize(node.path)] = nil
-    self.nodes[id] = nil
-  end
-
-  for _, child_id in ipairs(parent.children_ids) do
-    purge(child_id)
+  for _, child_id in ipairs(parent.children_ids or {}) do
+    purge(self, child_id)
   end
   parent.children_ids = {}
   parent._sorted_children_ids = nil
   parent._sorted_children = nil
+end
+
+---@param parent_id integer
+---@param entries table[]
+---@return boolean changed
+function Store:reconcile_children(parent_id, entries)
+  local parent = self.nodes[parent_id]
+  if not parent then
+    return false
+  end
+  local remaining, by_path = {}, {}
+  for _, id in ipairs(parent.children_ids or {}) do
+    local child = self.nodes[id]
+    if child then
+      remaining[id] = true
+      by_path[util.nfc_normalize(child.path)] = child
+    end
+  end
+  local children, changed = {}, false
+  for _, fields in ipairs(entries) do
+    local previous = by_path[util.nfc_normalize(fields.path)]
+    if previous then
+      remaining[previous.id] = nil
+    end
+    local unchanged = previous
+      and previous.name == fields.name
+      and previous.path == fields.path
+      and previous.type == fields.type
+      and previous.link_target == fields.link_target
+      and previous.link_broken == (fields.link_broken or false)
+      and previous.error == fields.error
+    if unchanged then
+      children[#children + 1] = previous.id
+    else
+      if previous then
+        -- Reusing a followed symlink's children would keep entries from its former target.
+        purge(self, previous.id)
+      end
+      fields.parent_id = parent_id
+      local id = self:add(fields)
+      self.nodes[id]._marked = fields._marked
+      children[#children + 1] = id
+      changed = true
+    end
+  end
+  for id in pairs(remaining) do
+    purge(self, id)
+    changed = true
+  end
+  if changed or parent.children_ids == nil then
+    parent.children_ids = children
+    parent._sorted_children_ids = nil
+    parent._sorted_children = nil
+  end
+  parent.children_state = "loaded"
+  if changed then
+    self:next_generation()
+  end
+  return changed
 end
 
 local sort_key_cache = {}

--- a/lua/eda/watcher.lua
+++ b/lua/eda/watcher.lua
@@ -3,7 +3,6 @@ local util = require("eda.util")
 ---@class eda.Watcher
 ---@field _handles table<string, uv.uv_fs_event_t>
 ---@field _debounced table<string, eda.Debounce>
----@field pending_operations table<string, boolean>
 local Watcher = {}
 Watcher.__index = Watcher
 
@@ -13,7 +12,6 @@ function Watcher.new()
   return setmetatable({
     _handles = {},
     _debounced = {},
-    pending_operations = {},
   }, Watcher)
 end
 
@@ -31,11 +29,6 @@ function Watcher:watch(path, callback)
   end
 
   local debounced = util.debounce(50, function(filename, events)
-    -- Check if this is an echo from our own operation
-    local full_path = path .. "/" .. (filename or "")
-    if self.pending_operations[full_path] then
-      return
-    end
     callback(filename, events)
   end)
 
@@ -44,9 +37,10 @@ function Watcher:watch(path, callback)
 
   local ok = handle:start(path, {}, function(err, filename, events)
     if err then
-      return
+      debounced.call(nil, events)
+    else
+      debounced.call(filename, events)
     end
-    debounced.call(filename, events)
   end)
 
   if not ok then
@@ -75,18 +69,6 @@ function Watcher:unwatch_all()
   for path in pairs(self._handles) do
     self:unwatch(path)
   end
-end
-
----Add a pending operation (suppress watcher echo).
----@param path string
-function Watcher:add_pending(path)
-  self.pending_operations[path] = true
-end
-
----Remove a pending operation.
----@param path string
-function Watcher:remove_pending(path)
-  self.pending_operations[path] = nil
 end
 
 return Watcher

--- a/tests/e2e/test_directory_watchers.lua
+++ b/tests/e2e/test_directory_watchers.lua
@@ -1,0 +1,271 @@
+local e2e = require("e2e.helpers")
+local child, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      e2e.setup_eda(child)
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_file(tmp .. "/a/nested/file", "A")
+      e2e.create_file(tmp .. "/b/keep", "B")
+      e2e.create_file(tmp .. "/root_file", "ROOT")
+      e2e.exec(
+        child,
+        [[
+        _G.callbacks, _G.scans = {}, {}
+        local Watcher = require("eda.watcher")
+        local watch = Watcher.watch
+        Watcher.watch = function(self, path, callback)
+          _G.callbacks[path] = callback
+          watch(self, path, function(...)
+            if not _G.mute_watch_events then
+              _G.watch_events = (_G.watch_events or 0) + 1
+              callback(...)
+            end
+          end)
+        end
+        local Scanner = require("eda.tree.scanner")
+        local scan = Scanner._do_scan_io
+        Scanner._do_scan_io = function(self, id, ...)
+          table.insert(_G.scans, self.store:get(id).path)
+          return scan(self, id, ...)
+        end
+      ]]
+      )
+      e2e.open_eda(child, tmp)
+      e2e.feed(child, "gE")
+      e2e.wait_until(child, [[#require("eda").get_current().buffer.flat_lines == 6]])
+      e2e.exec(
+        child,
+        [[
+        local ex = require("eda").get_current()
+        _G.original = ex.store:get_by_path(ex.root_path .. "/b/keep")
+        _G.scans, _G.paints = {}, 0
+        local paint = ex.buffer.painter.paint
+        ex.buffer.painter.paint = function(self, ...)
+          _G.paints = _G.paints + 1
+          return paint(self, ...)
+        end
+      ]]
+      )
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+for _, operation in ipairs({ "create", "rename", "delete" }) do
+  T["observes real nested " .. operation .. " without scanning unrelated subtrees"] = function()
+    MiniTest.expect.equality(
+      e2e.exec(child, [[return vim.tbl_count(require("eda").get_current().watcher._handles)]]),
+      4
+    )
+    if operation == "create" then
+      e2e.create_file(tmp .. "/a/nested/added", "NEW")
+    elseif operation == "rename" then
+      assert(vim.uv.fs_rename(tmp .. "/a/nested/file", tmp .. "/a/nested/added"))
+    else
+      assert(vim.uv.fs_unlink(tmp .. "/a/nested/file"))
+    end
+    e2e.wait_until(
+      child,
+      string.format(
+        [[
+      local ex = require("eda").get_current()
+      local file = ex.store:get_by_path(ex.root_path .. "/a/nested/file")
+      local added = ex.store:get_by_path(ex.root_path .. "/a/nested/added")
+      return %s and not ex.refresh.pending and not ex.refresh.running
+    ]],
+        operation == "create" and "file ~= nil and added ~= nil"
+          or operation == "rename" and "file == nil and added ~= nil"
+          or "file == nil and added == nil"
+      )
+    )
+    MiniTest.expect.equality(
+      e2e.exec(
+        child,
+        [[
+      local ex = require("eda").get_current()
+      for _, path in ipairs(_G.scans) do
+        if path == ex.root_path .. "/b" then return false end
+      end
+      return ex.store:get_by_path(ex.root_path .. "/b/keep") == _G.original
+    ]]
+      ),
+      true
+    )
+  end
+end
+
+T["coalesces known bursts and skips unchanged echo paints"] = function()
+  MiniTest.expect.equality(
+    e2e.exec(child, [[return _G.callbacks[require("eda").get_current().root_path .. "/a/nested"] ~= nil]]),
+    true
+  )
+  e2e.exec(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    _G.mute_watch_events = true
+    vim.fn.writefile({ "NEW" }, ex.root_path .. "/a/nested/added")
+    for _ = 1, 25 do _G.callbacks[ex.root_path .. "/a/nested"]("added", { rename = true }) end
+  ]]
+  )
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return ex.store:get_by_path(ex.root_path .. "/a/nested/added") ~= nil
+      and not ex.refresh.pending and not ex.refresh.running
+  ]]
+  )
+  MiniTest.expect.equality(e2e.exec(child, "return { #_G.scans, _G.paints }"), { 1, 1 })
+  e2e.exec(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    _G.callbacks[ex.root_path .. "/a/nested"]("added", { rename = true })
+  ]]
+  )
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return #_G.scans == 2 and not ex.refresh.pending and not ex.refresh.running
+  ]]
+  )
+  MiniTest.expect.equality(e2e.exec(child, "return _G.paints"), 1)
+end
+
+T["bounds handles across repeated collapse expand root change and close"] = function()
+  for _ = 1, 5 do
+    e2e.exec(child, [[vim.fn.search("^a/$", "w")]])
+    e2e.feed(child, "<CR>")
+    e2e.wait_until(
+      child,
+      [[not require("eda").get_current().store:get_by_path(require("eda").get_current().root_path .. "/a").open]]
+    )
+    MiniTest.expect.equality(
+      e2e.exec(child, [[return vim.tbl_count(require("eda").get_current().watcher._handles)]]),
+      2
+    )
+    e2e.feed(child, "<CR>")
+    e2e.wait_until(child, [[vim.tbl_count(require("eda").get_current().watcher._handles) == 4]])
+  end
+  e2e.exec(
+    child,
+    [[
+    _G.explorer = require("eda").get_current()
+    require("eda")._change_root(_G.explorer, _G.explorer.root_path .. "/b")
+  ]]
+  )
+  e2e.wait_until(child, "_G.explorer._initial_scan_complete")
+  MiniTest.expect.equality(e2e.exec(child, "return vim.tbl_count(_G.explorer.watcher._handles)"), 1)
+  e2e.exec(child, [[require("eda").close()]])
+  MiniTest.expect.equality(e2e.exec(child, "return vim.tbl_count(_G.explorer.watcher._handles)"), 0)
+end
+
+T["unknown event scope refreshes open subtrees while retaining identities"] = function()
+  e2e.exec(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    _G.mute_watch_events = true
+    vim.fn.writefile({ "NEW" }, ex.root_path .. "/a/nested/added")
+    _G.callbacks[ex.root_path]()
+  ]]
+  )
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return ex.store:get_by_path(ex.root_path .. "/a/nested/added") ~= nil
+      and not ex.refresh.pending and not ex.refresh.running
+  ]]
+  )
+  MiniTest.expect.equality(e2e.exec(child, "return #_G.scans"), 4)
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = require("eda").get_current()
+    return ex.store:get_by_path(ex.root_path .. "/b/keep") == _G.original
+  ]]
+    ),
+    true
+  )
+end
+
+T["defers a nested event until undo discards unsaved edits"] = function()
+  e2e.exec(child, [[vim.fn.search("^root_file$", "w")]])
+  e2e.feed(child, "dd")
+  e2e.wait_until(child, "vim.bo.modified")
+  local lines = e2e.get_buf_lines(child)
+  e2e.create_file(tmp .. "/a/nested/added", "NEW")
+  e2e.wait_until(child, [[require("eda").get_current().refresh.pending]])
+  MiniTest.expect.equality(e2e.get_buf_lines(child), lines)
+  MiniTest.expect.equality(e2e.exec(child, "return #_G.scans"), 0)
+  e2e.feed(child, "u")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and not ex.refresh.pending and not ex.refresh.running
+      and ex.store:get_by_path(ex.root_path .. "/a/nested/added") ~= nil
+  ]]
+  )
+  MiniTest.expect.equality(vim.fn.readfile(tmp .. "/root_file"), { "ROOT" })
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = require("eda").get_current()
+    return ex.store:get_by_path(ex.root_path .. "/b/keep") == _G.original
+  ]]
+    ),
+    true
+  )
+end
+
+T["coalesces save echoes into one scoped scan without an extra paint"] = function()
+  e2e.exec(
+    child,
+    [[
+    _G.mute_watch_events = true
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "EdaMutationPost",
+      once = true,
+      callback = function()
+        local ex = require("eda").get_current()
+        for _ = 1, 25 do _G.callbacks[ex.root_path]("new1", { rename = true }) end
+      end,
+    })
+  ]]
+  )
+  e2e.feed(child, "Go")
+  e2e.feed_insert(child, "new1\nnew2\nnew3")
+  e2e.feed(child, ":w<CR>")
+  e2e.wait_until(
+    child,
+    [[
+    local ex = require("eda").get_current()
+    return not vim.bo.modified and not ex._writing and not ex.refresh.pending and not ex.refresh.running
+      and ex.store:get_by_path(ex.root_path .. "/new3") ~= nil
+  ]]
+  )
+  MiniTest.expect.equality(e2e.exec(child, "return { #_G.scans, _G.paints }"), { 5, 1 })
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local ex = require("eda").get_current()
+    return ex.store:get_by_path(ex.root_path .. "/b/keep") == _G.original
+  ]]
+    ),
+    true
+  )
+end
+
+return T

--- a/tests/test_open.lua
+++ b/tests/test_open.lua
@@ -489,7 +489,6 @@ T["refresh preserves directory open states"] = function()
     end
   end
 
-  -- Simulate refresh: next_generation + re-scan root (destroys children)
   store:next_generation()
   scanned = false
   scanner:scan(store.root_id, function()
@@ -499,9 +498,9 @@ T["refresh preserves directory open states"] = function()
     return scanned
   end)
 
-  -- After root re-scan, all open states are lost
   local a_after_scan = store:get_by_path(tmp .. "/a")
-  MiniTest.expect.equality(a_after_scan.open, false)
+  MiniTest.expect.equality(a_after_scan == a, true)
+  MiniTest.expect.equality(a_after_scan.open, true)
 
   -- Restore open states via scan_open_unloaded
   local done = false

--- a/tests/test_watcher.lua
+++ b/tests/test_watcher.lua
@@ -8,14 +8,6 @@ T["new creates watcher"] = function()
   MiniTest.expect.equality(type(w._handles), "table")
 end
 
-T["pending_operations management"] = function()
-  local w = Watcher.new()
-  w:add_pending("/tmp/test")
-  MiniTest.expect.equality(w.pending_operations["/tmp/test"], true)
-  w:remove_pending("/tmp/test")
-  MiniTest.expect.equality(w.pending_operations["/tmp/test"], nil)
-end
-
 T["unwatch_all clears handles"] = function()
   local w = Watcher.new()
   w:unwatch_all() -- Should not error even with no watches

--- a/tests/tree/test_reconcile.lua
+++ b/tests/tree/test_reconcile.lua
@@ -1,0 +1,61 @@
+local Store = require("eda.tree.store")
+local Scanner = require("eda.tree.scanner")
+local T = MiniTest.new_set()
+
+local function fixture()
+  local store = Store.new()
+  store:set_root("/tree")
+  local scanner = Scanner.new(store)
+  scanner:_apply_entries(store.root_id, { { name = "dir", type = "directory" }, { name = "file", type = "file" } })
+  local dir = store:get_by_path("/tree/dir")
+  dir.open, dir._marked = true, true
+  scanner:_apply_entries(dir.id, { { name = "inside", type = "file" } })
+  return store, scanner, dir
+end
+
+T["unchanged entries retain objects IDs descendants and sorting caches"] = function()
+  local store, scanner, dir = fixture()
+  local children = store:children(store.root_id)
+  local inside = store:get_by_path("/tree/dir/inside")
+  local next_id = store.next_id
+  scanner:_apply_entries(store.root_id, { { name = "file", type = "file" }, { name = "dir", type = "directory" } })
+  MiniTest.expect.equality(store:get(dir.id) == dir, true)
+  MiniTest.expect.equality(store:get(inside.id) == inside, true)
+  MiniTest.expect.equality(store:children(store.root_id) == children, true)
+  MiniTest.expect.equality(store.next_id, next_id)
+  MiniTest.expect.equality({ dir.open, dir._marked, dir.children_state }, { true, true, "loaded" })
+end
+
+T["adding and removing siblings preserves the surviving subtree"] = function()
+  local store, scanner, dir = fixture()
+  local removed = store:get_by_path("/tree/file")
+  scanner:_apply_entries(store.root_id, { { name = "dir", type = "directory" }, { name = "new", type = "file" } })
+  MiniTest.expect.equality(store:get(dir.id) == dir, true)
+  MiniTest.expect.equality(store:get_by_path("/tree/dir/inside") ~= nil, true)
+  MiniTest.expect.equality(store:get(removed.id), nil)
+  MiniTest.expect.equality(store:get_by_path("/tree/file"), nil)
+  MiniTest.expect.equality(store:get_by_path("/tree/new") ~= nil, true)
+  MiniTest.expect.equality(#store:children(store.root_id), 2)
+end
+
+T["replacing a directory purges its descendants"] = function()
+  local store, scanner, dir = fixture()
+  scanner:_apply_entries(store.root_id, { { name = "dir", type = "file" } })
+  local replacement = store:get_by_path("/tree/dir")
+  MiniTest.expect.equality(replacement.type, "file")
+  MiniTest.expect.equality(replacement.id ~= dir.id, true)
+  MiniTest.expect.equality(store:get_by_path("/tree/dir/inside"), nil)
+  MiniTest.expect.equality(store:get(dir.id), nil)
+end
+
+T["changing a followed symlink target drops its loaded subtree"] = function()
+  local store, _, dir = fixture()
+  dir.link_target = "/old"
+  store:reconcile_children(store.root_id, {
+    { name = "dir", path = "/tree/dir", type = "directory", link_target = "/new" },
+  })
+  MiniTest.expect.equality(store:get_by_path("/tree/dir").id ~= dir.id, true)
+  MiniTest.expect.equality(store:get_by_path("/tree/dir/inside"), nil)
+end
+
+return T


### PR DESCRIPTION
## Summary

Only the explorer root was watched, and every delivered change rescanned all open directories and replaced node IDs. Watch the root and visible expanded directories with nonrecursive handles, stage known directory changes independently, and reconcile children while retaining unchanged nodes, descendants, and sorting caches.

Coalesce pending directory scopes, skip structural paints for unchanged results, and request scoped refreshes after actions. Release watches on collapse/root changes/close and reload previously open descendants on re-expansion. Preserve the dirty-buffer and late-I/O commit guards. Keep full refresh for manual requests or notifications without filenames, and remove unused path-based echo suppression that could hide external writes.

Validation: formatting, lint, type checks, unit and E2E tests; new regressions exercise real nested create/rename/delete, node identity, burst scan/paint counts, dirty edits, save echoes, fallback, and repeated watcher lifecycle changes. Self-reviewed reconciliation, cached references, generation checks, and mutation recovery. Help regenerated.

On a fixed 492-entry fixture, 25 known callbacks decreased from 26 directory scans/two paints to one scan/one paint; observed time was 11.9 ms before and 3.3 ms after. Watch handles cover 13 expanded directories and follow their lifecycle. These are single-run, headless fixture observations. The 10,100-entry render benchmark, including Scenario 9, retains the incremental-paint advantage.

## References

Closes #65.
