### PR TITLE
perf: limit incremental icon updates and redraw resync

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,117 @@
+# Render benchmarks
+
+Run commands from the repository root inside `nix develop`. Keep the fixture,
+Neovim version, viewport, and machine identical when comparing revisions. Run
+benchmarks sequentially, without tests or other benchmark processes competing
+for CPU time.
+
+## Painter and pipeline scenarios
+
+```sh
+nvim --headless -l benchmarks/render.lua /path/to/fixture
+```
+
+`render.lua` reports nine scenarios, with five warmup iterations and twenty
+measured iterations per scenario. Scenario 7 profiles a **full** paint after a
+single toggle; scenario 9 compares incremental and full painting. Neither is a
+measurement of terminal display latency. The default icon provider may have no
+file icons when its optional provider is unavailable.
+
+## Actual directory-toggle workload
+
+`toggle.lua` opens the explorer, expands a 100-directory / 10,000-file fixture,
+and invokes the normal `select` action followed by an explicit redraw. It uses
+deterministic ASCII icons on every row, disables Git and the header, and uses a
+replacement window. Each of five repetitions contains five warmup pairs and
+twenty measured collapse/expand pairs: 100 samples per direction in total.
+
+Create the fixture once:
+
+```sh
+export EDA_BENCH_DIR="$(mktemp -d)"
+python3 - <<'PYTHON'
+import os
+from pathlib import Path
+root = Path(os.environ["EDA_BENCH_DIR"])
+for directory in range(100):
+    parent = root / f"dir-{directory:03d}"
+    parent.mkdir()
+    for file in range(100):
+        (parent / f"file-{file:03d}.txt").write_text("benchmark\n")
+PYTHON
+```
+
+Headless run (the script sets a 140-column, 40-row viewport):
+
+```sh
+EDA_BENCH_OUTPUT=/tmp/eda-toggle-headless.json \
+  nvim --headless --clean -n -c 'luafile benchmarks/toggle.lua'
+```
+
+Attached TUI run: set the terminal to 140 columns by 40 rows, then run:
+
+```sh
+EDA_BENCH_OUTPUT=/tmp/eda-toggle-tui.json \
+  nvim --clean -n -c 'luafile benchmarks/toggle.lua'
+```
+
+The script exits after writing JSON. Check that `ui` contains an entry for the
+TUI run and that `visible_lines` is nonzero. Explicit `:redraw` also invokes the
+decoration provider in this headless workload; ordinary headless RPC tests do
+not necessarily exercise it. `total_ms` covers action dispatch, completion,
+and Neovim's redraw work, including instrumentation. It does not measure the
+host terminal's final display latency. `render_ms` and `resync_ms` are nested
+components of the total, not additional time to add to it.
+
+The output records icon writes/namespace clears, decorated row counts, visible
+line callbacks, redraw resynchronization, each sample's repetition, the Neovim
+version, and the first ten screen rows. Use the same script on both revisions;
+copy it outside the checkout when measuring a revision that predates it.
+
+## Recorded comparison: incremental icon placement
+
+Measured on macOS arm64 with Neovim 0.12.5, comparing base `7406556` with the
+incremental icon placement and changedtick redraw guard. The attached TUI used
+a 140 x 40 PTY, with 38 visible-line callbacks per toggle. No other test or
+benchmark processes ran alongside these measurements.
+
+Actual action + redraw, mean ± sample standard deviation in milliseconds
+(100 samples per direction):
+
+| Mode | Direction | Before | After |
+| --- | --- | ---: | ---: |
+| Headless | Collapse | 25.437 ± 4.851 | 7.445 ± 3.382 |
+| Headless | Expand | 25.595 ± 5.151 | 7.487 ± 2.954 |
+| Attached TUI | Collapse | 28.444 ± 5.572 | 7.353 ± 3.799 |
+| Attached TUI | Expand | 29.209 ± 7.260 | 7.546 ± 3.314 |
+
+Across the five TUI repetitions, collapse means ranged from 26.210–32.068 ms
+before and 6.612–8.384 ms after; expand means ranged from 26.542–34.628 ms before
+and 7.127–8.107 ms after. The reduction exceeds the observed variation for this
+workload. Screen text and visible-line callback counts were unchanged.
+
+| Work per toggle | Collapse, before → after | Expand, before → after |
+| --- | ---: | ---: |
+| Icon extmark writes | 10,000 → 1 | 10,100 → 102 |
+| Redraw resynchronizations | 1 → 0 | 1 → 0 |
+| Decorated rows | 10,000 → 10,000 | 10,100 → 10,100 |
+
+Standard harness results below are mean ± standard deviation of the reported
+means from five separate runs, rather than 100 individual samples:
+
+| Scenario | Direction | Before (ms) | After (ms) |
+| --- | --- | ---: | ---: |
+| 7: profiled full paint | Collapse | 12.050 ± 0.645 | 14.017 ± 2.118 |
+| 7: profiled full paint | Expand | 12.217 ± 0.773 | 14.121 ± 2.291 |
+| 9: full paint | Collapse | 12.376 ± 0.530 | 12.162 ± 0.241 |
+| 9: full paint | Expand | 12.241 ± 0.622 | 12.108 ± 0.386 |
+| 9: incremental paint | Collapse | 2.568 ± 0.212 | 2.085 ± 0.234 |
+| 9: incremental paint | Expand | 2.640 ± 0.219 | 2.260 ± 0.291 |
+
+Scenario 7's profiled full-paint runs were slower and more variable after the
+change, while scenario 9's full-paint control was similar. These results do
+not establish an improvement to full painting. The measured benefit is
+specific to the incremental path and redundant redraw resynchronization.
+Flattening, decorating all rows, rebuilding maps/snapshots, and reading line
+lengths still scale with the visible tree. Arbitrary custom decorators retain
+their existing invocation behavior; this is not a decoration cache.

--- a/benchmarks/toggle.lua
+++ b/benchmarks/toggle.lua
@@ -1,0 +1,169 @@
+vim.o.shadafile = "NONE"
+vim.o.more = false
+vim.opt.rtp:prepend(vim.fn.getcwd())
+local fixture = assert(vim.env.EDA_BENCH_DIR, "Set EDA_BENCH_DIR to a 100 x 100 file fixture")
+local output = assert(vim.env.EDA_BENCH_OUTPUT, "Set EDA_BENCH_OUTPUT to the output JSON path")
+local counts, active, ex = {}, false, nil
+local api = vim.api
+local set_mark, clear, provider =
+  api.nvim_buf_set_extmark, api.nvim_buf_clear_namespace, api.nvim_set_decoration_provider
+api.nvim_buf_set_extmark = function(buf, ns, ...)
+  if active and ex and ns == ex.buffer.painter.ns_icon then
+    counts.icon_writes = counts.icon_writes + 1
+  end
+  return set_mark(buf, ns, ...)
+end
+api.nvim_buf_clear_namespace = function(buf, ns, ...)
+  if active and ex and ns == ex.buffer.painter.ns_icon then
+    counts.icon_clears = counts.icon_clears + 1
+  end
+  return clear(buf, ns, ...)
+end
+api.nvim_set_decoration_provider = function(ns, opts)
+  if opts.on_line then
+    local on_line = opts.on_line
+    opts.on_line = function(...)
+      if active then
+        counts.visible_lines = counts.visible_lines + 1
+      end
+      return on_line(...)
+    end
+  end
+  return provider(ns, opts)
+end
+local Chain = require("eda.render.decorator").Chain
+local decorate = Chain.decorate
+Chain.decorate = function(self, rows, ctx)
+  if active then
+    counts.decorated_rows = counts.decorated_rows + #rows
+  end
+  return decorate(self, rows, ctx)
+end
+local Painter = require("eda.render.painter")
+local resync = Painter._resync_on_redraw
+Painter._resync_on_redraw = function(self)
+  local start = vim.uv.hrtime()
+  resync(self)
+  if active then
+    counts.resync_ms = counts.resync_ms + (vim.uv.hrtime() - start) / 1e6
+    counts.resync_calls = counts.resync_calls + 1
+  end
+end
+local function run()
+  if #api.nvim_list_uis() == 0 then
+    vim.o.lines = 40
+    vim.o.columns = 140
+  end
+  local eda = require("eda")
+  eda.setup({
+    git = { enabled = false },
+    header = false,
+    confirm = false,
+    window = { kind = "replace" },
+    icon = {
+      provider = "none",
+      custom = function(_, node)
+        if node.type == "file" then
+          return "f", "EdaFileIcon"
+        end
+      end,
+      directory = { collapsed = "+", expanded = "-", empty = "+", empty_open = "-" },
+    },
+  })
+  eda.open({ dir = fixture })
+  assert(
+    vim.wait(10000, function()
+      return eda.get_current() and eda.get_current()._initial_scan_complete
+    end, 1),
+    "initial scan timeout"
+  )
+  ex = eda.get_current()
+  local ctx = {
+    explorer = ex,
+    store = ex.store,
+    scanner = ex.scanner,
+    buffer = ex.buffer,
+    window = ex.window,
+    config = require("eda.config").get(),
+  }
+  local action = require("eda.action")
+  action.dispatch("expand_all", ctx)
+  assert(
+    vim.wait(10000, function()
+      return #ex.buffer.flat_lines == 10100
+    end, 1),
+    "expand timeout"
+  )
+  local target = ex.buffer.flat_lines[1].node
+  local all_lines = #ex.buffer.flat_lines
+  assert(target.type == "directory", "Expected the first row to be a directory")
+  local child_count = #target.children_ids
+  assert(child_count == 100, "Expected 100 files in the first directory")
+  local render = ex.buffer.render
+  ex.buffer.render = function(self, ...)
+    local start = vim.uv.hrtime()
+    render(self, ...)
+    if active then
+      counts.render_ms = counts.render_ms + (vim.uv.hrtime() - start) / 1e6
+    end
+  end
+  local function toggle(open)
+    counts = {
+      icon_writes = 0,
+      icon_clears = 0,
+      decorated_rows = 0,
+      visible_lines = 0,
+      resync_ms = 0,
+      resync_calls = 0,
+      render_ms = 0,
+    }
+    api.nvim_win_set_cursor(ex.window.winid, { 1, 0 })
+    local start = vim.uv.hrtime()
+    action.dispatch("select", ctx)
+    local expected = open and all_lines or all_lines - child_count
+    assert(
+      vim.wait(10000, function()
+        return #ex.buffer.flat_lines == expected
+      end, 1),
+      "toggle timeout"
+    )
+    vim.cmd("redraw")
+    counts.total_ms = (vim.uv.hrtime() - start) / 1e6
+    counts.direction = open and "expand" or "collapse"
+    return vim.deepcopy(counts)
+  end
+  local result = { ui = api.nvim_list_uis(), version = vim.version(), fixture = fixture, samples = {} }
+  for repetition = 1, 5 do
+    active = false
+    for _ = 1, 5 do
+      toggle(false)
+      toggle(true)
+    end
+    active = true
+    for _ = 1, 20 do
+      local collapse, expand = toggle(false), toggle(true)
+      collapse.repetition, expand.repetition = repetition, repetition
+      result.samples[#result.samples + 1] = collapse
+      result.samples[#result.samples + 1] = expand
+    end
+  end
+  active = false
+  result.screen = {}
+  for row = 1, math.min(10, vim.o.lines) do
+    local line = {}
+    for col = 1, math.min(80, vim.o.columns) do
+      line[#line + 1] = vim.fn.screenstring(row, col)
+    end
+    result.screen[#result.screen + 1] = table.concat(line)
+  end
+  vim.fn.writefile({ vim.json.encode(result) }, output)
+  eda.close()
+end
+vim.schedule(function()
+  local ok, err = xpcall(run, debug.traceback)
+  if not ok then
+    vim.fn.writefile({ tostring(err) }, output .. ".error")
+    vim.cmd("cquit 1")
+  end
+  vim.cmd("qa!")
+end)

--- a/lua/eda/render/painter.lua
+++ b/lua/eda/render/painter.lua
@@ -31,6 +31,8 @@ end
 
 ---@class eda.Painter
 ---@field bufnr integer
+---@field _paint_tick integer?
+---@field _synced_tick integer?
 ---@field ns_ids integer  Namespace for node ID extmarks
 ---@field ns_hl integer   Namespace for highlight extmarks (used by decoration provider)
 ---@field ns_icon integer  Namespace for icon extmarks (non-ephemeral; Neovim bug: ephemeral inline virt_text not rendered)
@@ -83,7 +85,9 @@ function Painter.new(bufnr, indent_width)
       if buf ~= self.bufnr then
         return false
       end
-      self:_resync_on_redraw()
+      if self._synced_tick ~= vim.api.nvim_buf_get_changedtick(buf) then
+        self:_resync_on_redraw()
+      end
     end,
     on_line = function(_, _, buf, row)
       if buf ~= self.bufnr then
@@ -163,6 +167,8 @@ end
 ---scratch (e.g. preview switching between file and directory render modes).
 ---ns_hl is ephemeral and reset by the decoration provider on each redraw.
 function Painter:reset()
+  self._paint_tick = nil
+  self._synced_tick = nil
   vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_icon, 0, -1)
   vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_ids, 0, -1)
   vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_header, 0, -1)
@@ -428,6 +434,7 @@ function Painter:paint(flat_lines, decorations, opts)
     if entry and (entry.icon_text or entry.prefix_text) then
       local indent_len = fl.depth * self.indent_width
       vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, offset + i - 1, indent_len, {
+        id = fl.node_id,
         virt_text = build_icon_virt_text(entry),
         virt_text_pos = "inline",
         right_gravity = false,
@@ -444,6 +451,8 @@ function Painter:paint(flat_lines, decorations, opts)
 
   vim.bo[self.bufnr].modified = false
   self.snapshot = new_snapshot
+  self._paint_tick = vim.api.nvim_buf_get_changedtick(self.bufnr)
+  self._synced_tick = self._paint_tick
 end
 
 ---Incrementally update the buffer for a single directory toggle (collapse/expand).
@@ -454,7 +463,7 @@ end
 ---@param hint { toggled_node_id: integer }
 ---@return boolean success
 function Painter:paint_incremental(flat_lines, decorations, opts, hint)
-  if #self._flat_lines == 0 then
+  if #self._flat_lines == 0 or self._paint_tick ~= vim.api.nvim_buf_get_changedtick(self.bufnr) then
     return false
   end
 
@@ -575,10 +584,6 @@ function Painter:paint_incremental(flat_lines, decorations, opts, hint)
     for j = ins_start, ins_start + ins_count - 1 do
       new_line_strings[#new_line_strings + 1] = self:_build_line(flat_lines[j])
     end
-    -- Clear and rebuild all ns_icon extmarks: existing icons use
-    -- right_gravity=false and do not shift when lines are inserted above,
-    -- leaving siblings rendered on the wrong row.
-    vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_icon, 0, -1)
     -- Insert lines
     vim.api.nvim_buf_set_lines(self.bufnr, insert_row, insert_row, false, new_line_strings)
     -- Place ns_ids extmarks for inserted nodes
@@ -608,22 +613,30 @@ function Painter:paint_incremental(flat_lines, decorations, opts, hint)
   local toggled_name_hl = resolve_name_hl(toggled_fl.node, toggled_dec)
   self._decoration_cache[toggled_id] = build_cache_entry(toggled_dec, toggled_fl.node, toggled_name_hl, separator)
 
-  -- Rebuild all icon extmarks from decoration cache.
-  -- Both collapse and expand paths clear ns_icon in affected ranges, but
-  -- right_gravity=false icons do not auto-shift with line edits. A full
-  -- rebuild is the simplest correct approach and avoids stale icons in
-  -- headless/no-redraw contexts.
-  vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_icon, 0, -1)
-  for i, fl in ipairs(flat_lines) do
+  local function place_icon(i)
+    local fl = flat_lines[i]
+    if not fl then
+      return
+    end
     local entry = self._decoration_cache[fl.node_id]
     if entry and (entry.icon_text or entry.prefix_text) then
-      local indent_len = fl.depth * self.indent_width
-      vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, offset + i - 1, indent_len, {
+      vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, offset + i - 1, fl.depth * self.indent_width, {
+        id = fl.node_id,
         virt_text = build_icon_virt_text(entry),
         virt_text_pos = "inline",
         right_gravity = false,
       })
+    else
+      vim.api.nvim_buf_del_extmark(self.bufnr, self.ns_icon, fl.node_id)
     end
+  end
+  place_icon(toggled_new_i)
+  if is_expand then
+    for i = ins_start, ins_start + ins_count - 1 do
+      place_icon(i)
+    end
+    -- A column-zero icon with left gravity stays before a line inserted at its position.
+    place_icon(ins_start + ins_count)
   end
 
   -- Update internal state
@@ -647,11 +660,12 @@ function Painter:paint_incremental(flat_lines, decorations, opts, hint)
   self.snapshot = new_snapshot
 
   vim.bo[self.bufnr].modified = false
+  self._paint_tick = vim.api.nvim_buf_get_changedtick(self.bufnr)
+  self._synced_tick = self._paint_tick
   return true
 end
 
 ---Resync _row_to_fl and icon extmarks from current ns_ids extmark positions.
----Called by on_win on each redraw to keep decorations aligned after buffer edits.
 ---ns_ids extmarks (right_gravity=true) are the source of truth for row positions.
 function Painter:_resync_on_redraw()
   local marks = vim.api.nvim_buf_get_extmarks(self.bufnr, self.ns_ids, 0, -1, { details = true })
@@ -705,6 +719,7 @@ function Painter:_resync_on_redraw()
           if entry and (entry.icon_text or entry.prefix_text) then
             local indent_len = fl.depth * self.indent_width
             vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, m[2], indent_len, {
+              id = fl.node_id,
               virt_text = build_icon_virt_text(entry),
               virt_text_pos = "inline",
               right_gravity = false,
@@ -714,6 +729,7 @@ function Painter:_resync_on_redraw()
       end
     end
   end
+  self._synced_tick = vim.api.nvim_buf_get_changedtick(self.bufnr)
 end
 
 ---Resync icon extmarks and internal caches after user edits (e.g. dd).
@@ -760,6 +776,7 @@ function Painter:resync_highlights()
       if entry and (entry.icon_text or entry.prefix_text) then
         local indent_len = fl.depth * self.indent_width
         vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_icon, v.row, indent_len, {
+          id = fl.node_id,
           virt_text = build_icon_virt_text(entry),
           virt_text_pos = "inline",
           right_gravity = false,
@@ -783,6 +800,7 @@ function Painter:resync_highlights()
       end
     end
   end
+  self._synced_tick = vim.api.nvim_buf_get_changedtick(self.bufnr)
 end
 
 ---Get the current render snapshot.

--- a/tests/render/test_incremental_icons.lua
+++ b/tests/render/test_incremental_icons.lua
@@ -1,0 +1,184 @@
+local Store = require("eda.tree.store")
+local Flatten = require("eda.render.flatten")
+local Painter = require("eda.render.painter")
+local buffers, originals
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      buffers = {}
+      originals = {
+        set = vim.api.nvim_buf_set_extmark,
+        get = vim.api.nvim_buf_get_extmarks,
+        provider = vim.api.nvim_set_decoration_provider,
+      }
+    end,
+    post_case = function()
+      vim.api.nvim_buf_set_extmark = originals.set
+      vim.api.nvim_buf_get_extmarks = originals.get
+      vim.api.nvim_set_decoration_provider = originals.provider
+      for _, buf in ipairs(buffers) do
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end,
+  },
+})
+
+local function new_painter()
+  local buf = vim.api.nvim_create_buf(false, true)
+  buffers[#buffers + 1] = buf
+  return Painter.new(buf)
+end
+
+local function fixture()
+  local store = Store.new()
+  local root = store:set_root("/tree")
+  local function add(parent, name, dir)
+    return store:add({
+      name = name,
+      path = store:get(parent).path .. "/" .. name,
+      parent_id = parent,
+      type = dir and "directory" or "file",
+      open = dir or false,
+      children_state = dir and "loaded" or "unloaded",
+    })
+  end
+  local dir = add(root, "a", true)
+  local nested = add(dir, "nested", true)
+  for i = 1, 4 do
+    add(nested, "child" .. i, false)
+  end
+  add(dir, "sibling", false)
+  local next_dir = add(root, "b", true)
+  add(next_dir, "other", false)
+  add(root, "no_icon", false)
+  add(root, "z", false)
+  store:get(root).children_state = "loaded"
+  return store, dir, nested
+end
+
+local function decorated(store)
+  local rows = Flatten.flatten(store, store.root_id)
+  local decorations = {}
+  for i, row in ipairs(rows) do
+    local node = row.node
+    decorations[i] = node.name == "no_icon" and {}
+      or {
+        icon = node.type == "directory" and (node.open and "-" or "+") or "f",
+        icon_hl = "Special",
+        name_hl = { "EdaMarkedName", "EdaGitModifiedName" },
+        suffix = "M",
+        suffix_hl = "Special",
+      }
+  end
+  return rows, decorations
+end
+
+local function icons(painter)
+  local result = {}
+  for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(painter.bufnr, painter.ns_icon, 0, -1, { details = true })) do
+    result[#result + 1] = { mark[2], mark[3], mark[4].virt_text, mark[4].right_gravity }
+  end
+  return result
+end
+
+for _, target in ipairs({ "root child", "nested child" }) do
+  T["updates only changed icons for a " .. target .. " toggle"] = function()
+    local store, dir, nested = fixture()
+    local painter, reference = new_painter(), new_painter()
+    local rows, decorations = decorated(store)
+    painter:paint(rows, decorations)
+    local node = store:get(target == "root child" and dir or nested)
+    local writes = 0
+    vim.api.nvim_buf_set_extmark = function(buf, ns, ...)
+      if buf == painter.bufnr and ns == painter.ns_icon then
+        writes = writes + 1
+      end
+      return originals.set(buf, ns, ...)
+    end
+    for _ = 1, 3 do
+      for _, open in ipairs({ false, true }) do
+        local old_count = #rows
+        node.open = open
+        rows, decorations = decorated(store)
+        writes = 0
+        MiniTest.expect.equality(painter:paint_incremental(rows, decorations, nil, { toggled_node_id = node.id }), true)
+        local allowed = open and (#rows - old_count + 2) or 1
+        MiniTest.expect.equality(writes <= allowed, true)
+        reference:paint(rows, decorations)
+        MiniTest.expect.equality(
+          vim.api.nvim_buf_get_lines(painter.bufnr, 0, -1, false),
+          vim.api.nvim_buf_get_lines(reference.bufnr, 0, -1, false)
+        )
+        MiniTest.expect.equality(icons(painter), icons(reference))
+        MiniTest.expect.equality(painter._decoration_cache, reference._decoration_cache)
+        for i, row in ipairs(rows) do
+          MiniTest.expect.equality(
+            vim.api.nvim_buf_get_extmark_by_id(painter.bufnr, painter.ns_ids, row.node_id, {}),
+            { i - 1, 0 }
+          )
+        end
+      end
+    end
+  end
+end
+
+T["redraw skips extmark traversal after paint and after one edit resync"] = function()
+  local on_win
+  vim.api.nvim_set_decoration_provider = function(ns, opts)
+    on_win = opts.on_win
+    return originals.provider(ns, opts)
+  end
+  local store = fixture()
+  local painter = new_painter()
+  painter:paint(decorated(store))
+  local gets = 0
+  vim.api.nvim_buf_get_extmarks = function(...)
+    gets = gets + 1
+    return originals.get(...)
+  end
+  on_win(nil, nil, painter.bufnr)
+  MiniTest.expect.equality(gets, 0)
+  vim.api.nvim_buf_set_lines(painter.bufnr, 1, 1, false, { "inserted" })
+  on_win(nil, nil, painter.bufnr)
+  MiniTest.expect.equality(gets > 0, true)
+  gets = 0
+  on_win(nil, nil, painter.bufnr)
+  MiniTest.expect.equality(gets, 0)
+end
+
+T["explicit resync excludes invalidated lines after cached painting"] = function()
+  local store = fixture()
+  local painter = new_painter()
+  local rows, decorations = decorated(store)
+  painter:paint(rows, decorations)
+  vim.api.nvim_buf_set_lines(painter.bufnr, 2, 3, false, { "replacement" })
+  painter:_resync_on_redraw()
+  local marks = vim.api.nvim_buf_get_extmarks(painter.bufnr, painter.ns_icon, 0, -1, {})
+  for _, mark in ipairs(marks) do
+    MiniTest.expect.equality(mark[2] ~= 2, true)
+  end
+  local shifted = vim.api.nvim_buf_get_extmarks(painter.bufnr, painter.ns_ids, 0, -1, { details = true })
+  local valid = {}
+  for _, mark in ipairs(shifted) do
+    if not mark[4].invalid then
+      valid[mark[2]] = true
+    end
+  end
+  for _, mark in ipairs(marks) do
+    MiniTest.expect.equality(valid[mark[2]], true)
+  end
+end
+
+T["rejects incremental painting after unpainted buffer edits"] = function()
+  local store, dir = fixture()
+  local painter = new_painter()
+  painter:paint(decorated(store))
+  vim.api.nvim_buf_set_lines(painter.bufnr, 1, 1, false, { "unsaved" })
+  local before = vim.api.nvim_buf_get_lines(painter.bufnr, 0, -1, false)
+  store:get(dir).open = false
+  local rows, decorations = decorated(store)
+  MiniTest.expect.equality(painter:paint_incremental(rows, decorations, nil, { toggled_node_id = dir }), false)
+  MiniTest.expect.equality(vim.api.nvim_buf_get_lines(painter.bufnr, 0, -1, false), before)
+end
+
+return T


### PR DESCRIPTION
## Summary

A directory toggle rebuilt every persistent icon and traversed every ID/icon extmark again during redraw. Give icons stable node IDs, update only toggled/inserted/boundary rows, and skip redraw resynchronization until the buffer changes. Preserve the existing incremental range/order checks and reject unpainted buffer edits before mutating.

Add regression coverage and a reproducible action-plus-redraw benchmark with attached-TUI and headless measurements. On a fixed 10,100-row fixture, repeated attached-TUI collapse/expand means decreased from 28.4/29.2 ms to 7.4/7.5 ms; icon writes decreased from 10,000/10,100 to 1/102. Flattening and decoration still visit every visible row. The benchmark documentation includes variability and the slower, more variable Scenario 7 full-paint observations; no full-paint improvement is claimed.

Validation: formatting, lint, type checks, 843 unit tests, 230 E2E tests, and 122 render tests on Neovim nightly. Repeated standard scenarios 7/9 and actual headless/TUI workloads; attached screen text remained identical. Self-reviewed extmark gravity, invalidation, edit preservation, header offsets, reset/resync lifetime, and fallback validation.

Closes #66.
