### PR TITLE
perf: reuse the capture within dirty directory collapse

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -115,3 +115,73 @@ specific to the incremental path and redundant redraw resynchronization.
 Flattening, decorating all rows, rebuilding maps/snapshots, and reading line
 lengths still scale with the visible tree. Arbitrary custom decorators retain
 their existing invocation behavior; this is not a decoration cache.
+
+## Dirty-buffer navigation
+
+Use the same 100 x 100 fixture created above:
+
+```sh
+EDA_BENCH_OUTPUT=/tmp/eda-dirty-toggle.json \
+  nvim --headless --clean -n -c 'luafile benchmarks/dirty-toggle.lua'
+```
+
+`dirty-toggle.lua` inserts one new entry, renames another using a text edit
+that preserves its ID extmark, and deletes a third entry. These edits are in
+a different directory from the toggle target. It invokes `collapse_node`
+with the cursor on the directory and then on its child, reopening via
+`select`. Each cursor mode has five repetitions of five warmup pairs and
+twenty measured pairs (100 samples per direction per mode). Every measured
+pair verifies exact buffer text, rename/delete IDs, create anchors, and the
+modified flag outside the timed region. It never saves the fixture.
+
+Recorded on macOS arm64 / Neovim 0.12.5, base `ac08bff`, with the same fixture,
+140 x 40 headless viewport, Git disabled, and no external icon provider.
+Runs were sequential. `total_ms` includes dispatch, completion, and explicit
+redraw, but not host terminal display latency. Capture includes parsing, so
+`parse_ms` must not be added to `capture_ms`.
+
+| Cursor / direction | Capture calls before → after | Capture before → after (ms) | Total before (ms) | Total after (ms) |
+| --- | ---: | ---: | ---: | ---: |
+| Directory / collapse | 2 → 1 | 19.166 → 10.640 | 45.555 ± 3.831 | 37.601 ± 5.531 |
+| Directory / expand | 1 → 1 | 9.434 → 10.951 | 34.722 ± 4.081 | 37.631 ± 4.125 |
+| Child / collapse | 2 → 1 | 19.181 → 11.443 | 46.749 ± 4.948 | 39.425 ± 5.079 |
+| Child / expand | 1 → 1 | 9.133 → 10.250 | 35.440 ± 5.273 | 39.061 ± 5.618 |
+
+Totals are mean ± sample standard deviation. Directory-collapse repetition
+means ranged from 45.054–46.076 ms before and 36.232–38.991 ms after;
+child-collapse means ranged from 44.797–48.877 ms before and 37.252–41.643 ms
+after. The unchanged expansion control was slower after, so these timings do
+not establish a general navigation speedup. The confirmed work reduction is
+two captures to one for either `collapse_node` branch. Collapse improved by
+about 7–8 ms in this run despite that control variation.
+
+The reused capture exists only within the synchronous collapse invocation.
+It is passed directly to the existing edit-preserving render, after changing
+the directory's open flag. No buffer writes, I/O completion, root transition,
+or extmark shift intervene. A later action captures again, including after
+new edits or undo/redo. No cross-action capture cache is introduced.
+
+Parsing remains the largest capture component: collapse parsing averaged
+16.964/16.902 ms before (two calls) and 9.454/10.241 ms after (one call) for
+directory/child cursors. The parser itself has not been optimized. A future
+parser optimization should profile extmark decoding and row/path allocation
+first. Reusing parsed rows across actions would require invalidation for
+buffer text, ID extmarks, root/store identity, and painter snapshots, plus
+subtree invalidation when indentation or a parent path changes. A changedtick
+key alone would not establish those invariants, and every paint/replay also
+changes the buffer, limiting cache reuse.
+
+Scenario 8 was also run in five separate standard-harness processes per
+revision (five warmups / twenty iterations each). Its full capture call is
+unchanged by the action-level reuse; below are mean ± standard deviation of
+the five reported means, with profiled parser time shown separately:
+
+| Revision | Full capture (ms) | Profiled parser mean (ms) |
+| --- | ---: | ---: |
+| Before | 7.152 ± 0.090 | 6.387 |
+| After | 8.981 ± 0.715 | 8.338 |
+
+The standard scenario uses its existing insert/whole-line replacement fixture;
+the actual-action workload above additionally exercises a surviving rename ID
+and deletion. Neither result demonstrates that an individual parse became
+faster.

--- a/benchmarks/dirty-toggle.lua
+++ b/benchmarks/dirty-toggle.lua
@@ -1,0 +1,146 @@
+vim.o.shadafile = "NONE"
+vim.o.more = false
+vim.opt.rtp:prepend(vim.fn.getcwd())
+local fixture = assert(vim.env.EDA_BENCH_DIR, "Set EDA_BENCH_DIR to a 100 x 100 file fixture")
+local output = assert(vim.env.EDA_BENCH_OUTPUT, "Set EDA_BENCH_OUTPUT to the output JSON path")
+local api = vim.api
+local counts, active = {}, false
+local preserve = require("eda.buffer.edit_preserve")
+local capture = preserve.capture
+preserve.capture = function(...)
+  local start = vim.uv.hrtime()
+  local result = capture(...)
+  if active then
+    counts.capture_calls = counts.capture_calls + 1
+    counts.capture_ms = counts.capture_ms + (vim.uv.hrtime() - start) / 1e6
+  end
+  return result
+end
+local Parser = require("eda.buffer.parser")
+local parse = Parser.parse_lines
+Parser.parse_lines = function(...)
+  local start = vim.uv.hrtime()
+  local result = parse(...)
+  if active then
+    counts.parse_ms = counts.parse_ms + (vim.uv.hrtime() - start) / 1e6
+  end
+  return result
+end
+local function run()
+  if #api.nvim_list_uis() == 0 then
+    vim.o.lines = 40
+    vim.o.columns = 140
+  end
+  local eda = require("eda")
+  eda.setup({
+    git = { enabled = false },
+    header = false,
+    confirm = false,
+    window = { kind = "replace" },
+    icon = { provider = "none" },
+  })
+  eda.open({ dir = fixture })
+  assert(
+    vim.wait(10000, function()
+      return eda.get_current() and eda.get_current()._initial_scan_complete
+    end, 1),
+    "initial scan timeout"
+  )
+  local ex = eda.get_current()
+  local ctx = {
+    explorer = ex,
+    store = ex.store,
+    scanner = ex.scanner,
+    buffer = ex.buffer,
+    window = ex.window,
+    config = require("eda.config").get(),
+  }
+  local action = require("eda.action")
+  action.dispatch("expand_all", ctx)
+  assert(
+    vim.wait(10000, function()
+      return #ex.buffer.flat_lines == 10100
+    end, 1),
+    "expand timeout"
+  )
+  local target = ex.buffer.flat_lines[1].node
+  assert(target.type == "directory" and #target.children_ids == 100, "Expected 100 files in the first directory")
+  local buf, painter = ex.buffer.bufnr, ex.buffer.painter
+  local row = 103
+  local rename_id = api.nvim_buf_get_extmarks(buf, painter.ns_ids, { row, 0 }, { row, -1 }, {})[1][1]
+  local text = api.nvim_buf_get_lines(buf, row, row + 1, false)[1]
+  api.nvim_buf_set_text(buf, row, 2, row, #text, { "renamed-benchmark.txt" })
+  assert(
+    api.nvim_buf_get_extmark_by_id(buf, painter.ns_ids, rename_id, { details = true })[3].invalid ~= true,
+    "Rename invalidated the ID"
+  )
+  api.nvim_buf_set_lines(buf, row + 1, row + 2, false, {})
+  api.nvim_buf_set_lines(buf, row + 1, row + 1, false, { "  inserted-benchmark.txt" })
+  local expected_lines = api.nvim_buf_get_lines(buf, 0, -1, false)
+  local expected_capture = capture(buf, painter, ex.store, ex.root_path, 2)
+  assert(
+    vim.tbl_count(expected_capture.moves) == 1
+      and vim.tbl_count(expected_capture.deletes) == 1
+      and #expected_capture.creates == 1,
+    "Expected one rename, delete, and insert"
+  )
+  local function verify()
+    assert(vim.bo[buf].modified, "Lost modified state")
+    assert(
+      vim.deep_equal(api.nvim_buf_get_lines(buf, 0, -1, false), expected_lines),
+      "Dirty text changed after toggle pair"
+    )
+    local current = capture(buf, painter, ex.store, ex.root_path, 2)
+    assert(vim.deep_equal(current.moves, expected_capture.moves), "Renamed ID changed")
+    assert(vim.deep_equal(current.deletes, expected_capture.deletes), "Deleted ID changed")
+    assert(vim.deep_equal(current.creates, expected_capture.creates), "Inserted entry changed")
+  end
+  local function toggle(open, from_child)
+    counts = { capture_calls = 0, capture_ms = 0, parse_ms = 0 }
+    api.nvim_win_set_cursor(ex.window.winid, { not open and from_child and 2 or 1, 0 })
+    local start = vim.uv.hrtime()
+    action.dispatch(open and "select" or "collapse_node", ctx)
+    assert(
+      vim.wait(10000, function()
+        return target.open == open
+          and api.nvim_buf_line_count(buf) == (open and #expected_lines or #expected_lines - 100)
+      end, 1),
+      "toggle timeout"
+    )
+    vim.cmd("redraw")
+    counts.total_ms = (vim.uv.hrtime() - start) / 1e6
+    counts.direction = open and "expand" or "collapse"
+    counts.cursor = from_child and "child" or "directory"
+    return vim.deepcopy(counts)
+  end
+  local result = { ui = api.nvim_list_uis(), version = vim.version(), fixture = fixture, samples = {} }
+  for _, from_child in ipairs({ false, true }) do
+    for repetition = 1, 5 do
+      active = false
+      for _ = 1, 5 do
+        toggle(false, from_child)
+        toggle(true, from_child)
+      end
+      verify()
+      for _ = 1, 20 do
+        active = true
+        local collapse, expand = toggle(false, from_child), toggle(true, from_child)
+        active = false
+        collapse.repetition, expand.repetition = repetition, repetition
+        result.samples[#result.samples + 1] = collapse
+        result.samples[#result.samples + 1] = expand
+        verify()
+      end
+    end
+  end
+  vim.fn.writefile({ vim.json.encode(result) }, output)
+  eda.close()
+end
+vim.schedule(function()
+  local ok, err = xpcall(run, debug.traceback)
+  if not ok then
+    vim.fn.writefile({ tostring(err) }, output .. ".error")
+    vim.cmd("cquit 1")
+  end
+  vim.cmd("qa!")
+end)

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -283,12 +283,13 @@ action.register("collapse_node", function(ctx)
   if not node then
     return
   end
+  local capture
   if Node.is_dir(node) and node.open then
     -- Check if collapsing would lose edits
     if vim.bo[ctx.buffer.bufnr].modified then
       local edit_preserve = require("eda.buffer.edit_preserve")
       local cfg = ctx.config
-      local capture =
+      capture =
         edit_preserve.capture(ctx.buffer.bufnr, ctx.buffer.painter, ctx.store, ctx.explorer.root_path, cfg.indent.width)
       if has_edits_under(capture, node.path) then
         vim.notify("eda: save or discard changes in " .. node.name .. "/ before collapsing", vim.log.levels.WARN)
@@ -297,7 +298,7 @@ action.register("collapse_node", function(ctx)
     end
     node.open = false
     ctx.explorer._incremental_hint = { toggled_node_id = node.id }
-    refresh_preserving(ctx)
+    refresh_preserving(ctx, capture)
   elseif node.parent_id then
     local parent = ctx.store:get(node.parent_id)
     if parent and parent.id ~= ctx.store.root_id then
@@ -305,7 +306,7 @@ action.register("collapse_node", function(ctx)
       if vim.bo[ctx.buffer.bufnr].modified then
         local edit_preserve = require("eda.buffer.edit_preserve")
         local cfg = ctx.config
-        local capture = edit_preserve.capture(
+        capture = edit_preserve.capture(
           ctx.buffer.bufnr,
           ctx.buffer.painter,
           ctx.store,
@@ -320,7 +321,7 @@ action.register("collapse_node", function(ctx)
       parent.open = false
       ctx.buffer.target_node_id = parent.id
       ctx.explorer._incremental_hint = { toggled_node_id = parent.id }
-      refresh_preserving(ctx)
+      refresh_preserving(ctx, capture)
     elseif parent then
       navigate_to_parent_root(ctx)
     end

--- a/tests/e2e/test_edit_preserve.lua
+++ b/tests/e2e/test_edit_preserve.lua
@@ -258,4 +258,89 @@ T["edit preserving repaint"]["clean buffer operations work as before"] = functio
   )
 end
 
+for _, from_child in ipairs({ false, true }) do
+  local target = from_child and "child" or "directory"
+  T["edit preserving repaint"]["collapse from " .. target .. " captures once and preserves successive edits"] = function()
+    e2e.create_file(tmp .. "/delete.txt", "delete")
+    e2e.create_file(tmp .. "/replace.txt", "replace")
+    e2e.open_eda(child, tmp)
+    move_to_line(child, "dir_b/")
+    e2e.feed(child, "<CR>")
+    e2e.wait_for_node_loaded(child, tmp .. "/dir_b")
+    move_to_line(child, "file_b.txt")
+    e2e.exec(
+      child,
+      [[
+      local ex = require("eda").get_current()
+      local buf = ex.buffer.bufnr
+      local function row(name)
+        for i, text in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
+          if text == name then return i - 1 end
+        end
+        error("Missing " .. name)
+      end
+      local rename = row("root.txt")
+      vim.api.nvim_buf_set_text(buf, rename, 0, rename, #"root.txt", { "renamed.txt" })
+      local deleted = row("delete.txt")
+      vim.api.nvim_buf_set_lines(buf, deleted, deleted + 1, false, {})
+      local replaced = row("replace.txt")
+      vim.api.nvim_buf_set_lines(buf, replaced, replaced + 1, false, { "replacement.txt" })
+      vim.api.nvim_buf_set_lines(buf, -1, -1, false, { "first.txt", "second.txt" })
+      _G.expected_dirty = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      local preserve = require("eda.buffer.edit_preserve")
+      local capture = preserve.capture
+      _G.capture_calls = 0
+      preserve.capture = function(...)
+        _G.capture_calls = _G.capture_calls + 1
+        return capture(...)
+      end
+    ]]
+    )
+    for iteration = 1, 3 do
+      move_to_line(child, from_child and "file_b.txt" or "dir_b/")
+      local calls = e2e.exec(
+        child,
+        [[
+        _G.capture_calls = 0
+        local ex = require("eda").get_current()
+        require("eda.action").dispatch("collapse_node", {
+          explorer = ex, buffer = ex.buffer, store = ex.store, scanner = ex.scanner,
+          window = ex.window, config = require("eda.config").get(),
+        })
+        return _G.capture_calls
+      ]]
+      )
+      MiniTest.expect.equality(calls, 1)
+      MiniTest.expect.equality(buf_has_line(child, "file_b.txt"), false)
+      move_to_line(child, "dir_b/")
+      e2e.expand_and_wait_for_render(child)
+      MiniTest.expect.equality(
+        e2e.exec(
+          child,
+          [[
+        return vim.bo.modified and vim.deep_equal(vim.api.nvim_buf_get_lines(0, 0, -1, false), _G.expected_dirty)
+      ]]
+        ),
+        true
+      )
+      if iteration == 1 then
+        move_to_line(child, "second.txt")
+        e2e.feed(child, "o")
+        e2e.feed_insert(child, "third.txt")
+        e2e.feed(child, "u")
+        e2e.wait_until(
+          child,
+          [[not table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n"):find("third.txt", 1, true)]]
+        )
+        e2e.feed(child, "<C-r>")
+        e2e.wait_until(
+          child,
+          [[table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n"):find("third.txt", 1, true) ~= nil]]
+        )
+        e2e.exec(child, "_G.expected_dirty = vim.api.nvim_buf_get_lines(0, 0, -1, false)")
+      end
+    end
+  end
+end
+
 return T


### PR DESCRIPTION
## Summary

Collapsing a directory with unrelated unsaved edits parsed the buffer once to check the subtree and immediately parsed it again to preserve edits during repaint. Pass the first capture directly to the existing edit-preserving render in both directory-cursor and child-cursor paths. Reuse is local to the synchronous action; later edits and navigation still produce a fresh capture.

Add regressions for repeated toggles with insertion, rename, deletion, invalidated line replacement, and intervening undo/redo. Add a reproducible 10,100-line dirty-buffer workload that checks exact text and captured identities after every pair, with repeated measurements and Scenario 8 controls documented alongside it.

The measured collapse paths decreased from two captures to one and about 46 ms to 38–39 ms total. Expansion control timings also varied; no individual-parser or general navigation speedup is claimed.

Validation: formatting, lint, type checks, 843 unit tests, 232 E2E tests, targeted edit-preservation tests on nightly, five repeated standard benchmark runs per revision, and 100 actual-operation samples per direction/cursor mode. Self-reviewed call-local reuse, dirty/clean/blocked/root-boundary branches, and benchmark accounting.

Closes #67.
