### PR TITLE
perf: resolve symlink metadata with bounded async work

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -185,3 +185,84 @@ The standard scenario uses its existing insert/whole-line replacement fixture;
 the actual-action workload above additionally exercises a surviving rename ID
 and deletion. Neither result demonstrates that an individual parse became
 faster.
+
+## Symlink scan workload
+
+Create three 1,000-entry directories containing 0, 100, and 1,000 symlinks.
+Link targets alternate between a file, a directory, and a missing path:
+
+```sh
+export EDA_BENCH_DIR="$(mktemp -d)"
+python3 - <<'PYTHON'
+import os
+from pathlib import Path
+root = Path(os.environ["EDA_BENCH_DIR"])
+(root / "targets").mkdir()
+(root / "targets" / "file").write_text("target\n")
+(root / "targets" / "directory").mkdir()
+for links in (0, 100, 1000):
+    directory = root / f"links-{links}"
+    directory.mkdir()
+    for index in range(1000):
+        entry = directory / f"entry-{index:04d}"
+        if index < links:
+            target = ("file", "directory", "missing")[index % 3]
+            entry.symlink_to(root / "targets" / target)
+        else:
+            entry.write_text("ordinary\n")
+PYTHON
+EDA_BENCH_OUTPUT=/tmp/eda-symlinks.json \
+  nvim --headless -l benchmarks/symlinks.lua
+```
+
+The harness runs one warmup and five measured scans for every link count,
+`follow_symlinks` setting, and delay setting. The zero-delay mode uses the real
+local filesystem. The synthetic mode adds a 1 ms delay to each metadata call:
+a blocking sleep for synchronous calls or a deferred callback for asynchronous
+calls. This is a controlled latency model, not a measurement of a network
+filesystem. Runs should be sequential, without competing benchmark/test work.
+
+JSON records directory enumeration time (through `fs_closedir` completion),
+metadata call counts and accumulated request times, synchronous metadata
+blocking time, `_apply_entries` call duration, store reconciliation, sorting,
+plain painting, total scan latency, and the maximum gap in a 1 ms heartbeat.
+Metadata request times overlap when asynchronous and must not be added to total
+latency. `_apply_entries` returns after queuing asynchronous metadata; subsequent
+reconciliation is timed separately. For ordinary files it still reconciles
+before returning. Sorting and plain painting are measured after scan completion
+and are not included in `scan_ms`; no terminal display latency is measured.
+
+Recorded on macOS arm64 / Neovim 0.12.5, comparing base `fad6cc9` with bounded
+asynchronous symlink metadata. Each row summarizes five measured scans after
+one warmup. Scan times show mean ± sample standard deviation in milliseconds;
+heartbeat columns show the mean of each scan's maximum gap.
+
+| Added delay (ms/call) | Links | Follow | Scan before (ms) | Scan after (ms) | Heartbeat gap before → after (ms) |
+| ---: | ---: | --- | ---: | ---: | ---: |
+| 0 | 0 | true | 7.828 ± 0.710 | 7.240 ± 0.324 | 7.112 → 6.728 |
+| 0 | 0 | false | 7.236 ± 0.175 | 7.039 ± 0.346 | 6.750 → 6.613 |
+| 0 | 100 | true | 11.101 ± 1.234 | 9.501 ± 0.686 | 10.557 → 6.798 |
+| 0 | 100 | false | 10.513 ± 0.446 | 9.523 ± 0.729 | 10.088 → 6.985 |
+| 0 | 1,000 | true | 42.718 ± 2.668 | 25.393 ± 0.397 | 42.133 → 7.340 |
+| 0 | 1,000 | false | 42.359 ± 1.405 | 24.265 ± 0.630 | 41.825 → 6.724 |
+| 1 | 0 | true | 8.743 ± 2.270 | 7.417 ± 0.250 | 7.956 → 6.860 |
+| 1 | 0 | false | 7.225 ± 0.196 | 8.926 ± 2.498 | 6.854 → 7.839 |
+| 1 | 100 | true | 221.808 ± 0.614 | 15.573 ± 0.759 | 221.466 → 6.189 |
+| 1 | 100 | false | 138.803 ± 1.592 | 13.036 ± 1.387 | 137.936 → 6.231 |
+| 1 | 1,000 | true | 2158.818 ± 10.444 | 78.799 ± 1.448 | 2158.359 → 6.635 |
+| 1 | 1,000 | false | 1324.969 ± 19.909 | 59.457 ± 6.259 | 1324.182 → 6.553 |
+
+For 1,000 real links with following enabled, enumeration averaged 1.223 ms
+before / 0.916 ms after, and synchronous metadata blocking fell from 34.282 ms
+to zero. All 1,667 metadata requests after the change were asynchronous
+(1,000 realpaths and 667 target stats). `_apply_entries` call duration fell
+from 41.491 ms to 0.227 ms because it now queues that work. Reconciliation
+still runs later on the main loop: 6.584 ms before / 6.708 ms after. Sorting
+was 1.204/1.118 ms and plain painting 0.877/1.332 ms. Those small sort/paint
+variations are not an optimization claim.
+
+The remaining roughly 7 ms heartbeat gap is consistent with synchronous
+materialization; this change does not make every scan stage asynchronous.
+Normal-file scans remain in the same range. The synthetic case demonstrates
+that metadata latency no longer becomes an equally long main-loop stall;
+its speedup is specific to the injected delay and bounded overlapping work.

--- a/benchmarks/symlinks.lua
+++ b/benchmarks/symlinks.lua
@@ -1,0 +1,144 @@
+vim.o.shadafile = "NONE"
+vim.opt.rtp:prepend(vim.fn.getcwd())
+local fixture = assert(vim.env.EDA_BENCH_DIR, "Set EDA_BENCH_DIR")
+local output = assert(vim.env.EDA_BENCH_OUTPUT, "Set EDA_BENCH_OUTPUT")
+local uv, api = vim.uv, vim.api
+local Store, Scanner = require("eda.tree.store"), require("eda.tree.scanner")
+local Painter, Flatten = require("eda.render.painter"), require("eda.render.flatten")
+local active, sample, delay = false, {}, 0
+local function ms()
+  return uv.hrtime() / 1e6
+end
+for _, name in ipairs({ "fs_realpath", "fs_stat" }) do
+  local original = uv[name]
+  uv[name] = function(path, callback)
+    if not active then
+      return original(path, callback)
+    end
+    local start = ms()
+    sample.metadata_calls = sample.metadata_calls + 1
+    if callback then
+      sample.async_calls = sample.async_calls + 1
+      return original(path, function(err, value)
+        local function finish()
+          sample.metadata_sum_ms = sample.metadata_sum_ms + ms() - start
+          callback(err, value)
+        end
+        if delay > 0 then
+          local timer = assert(uv.new_timer(), "Could not allocate benchmark timer")
+          timer:start(delay, 0, function()
+            timer:close()
+            finish()
+          end)
+        else
+          finish()
+        end
+      end)
+    end
+    if delay > 0 then
+      uv.sleep(delay)
+    end
+    local result, err = original(path)
+    sample.metadata_sum_ms = sample.metadata_sum_ms + ms() - start
+    sample.metadata_blocking_ms = sample.metadata_blocking_ms + ms() - start
+    return result, err
+  end
+end
+local close = uv.fs_closedir
+uv.fs_closedir = function(dir, callback)
+  return close(dir, function(...)
+    if active then
+      sample.enumeration_ms = ms() - sample.start
+    end
+    callback(...)
+  end)
+end
+local apply = Scanner._apply_entries
+Scanner._apply_entries = function(self, ...)
+  local start = ms()
+  local result = apply(self, ...)
+  sample.apply_ms = sample.apply_ms + ms() - start
+  return result
+end
+local reconcile = Store.reconcile_children
+Store.reconcile_children = function(self, ...)
+  local start = ms()
+  local result = reconcile(self, ...)
+  sample.materialize_ms = sample.materialize_ms + ms() - start
+  return result
+end
+local function run()
+  local samples = {}
+  for _, delay_ms in ipairs({ 0, 1 }) do
+    delay = delay_ms
+    for _, links in ipairs({ 0, 100, 1000 }) do
+      for _, follow in ipairs({ true, false }) do
+        for repetition = 0, 5 do
+          local store = Store.new()
+          local root_id = store:set_root(fixture .. "/links-" .. links)
+          local scanner = Scanner.new(store, { follow_symlinks = follow })
+          sample = {
+            start = ms(),
+            links = links,
+            follow = follow,
+            delay_ms = delay,
+            repetition = repetition,
+            metadata_calls = 0,
+            async_calls = 0,
+            metadata_sum_ms = 0,
+            metadata_blocking_ms = 0,
+            apply_ms = 0,
+            materialize_ms = 0,
+            max_heartbeat_gap_ms = 0,
+          }
+          local tick = sample.start
+          local timer = assert(uv.new_timer(), "Could not allocate benchmark timer")
+          local function beat()
+            local now = ms()
+            sample.max_heartbeat_gap_ms = math.max(sample.max_heartbeat_gap_ms, now - tick)
+            tick = now
+          end
+          timer:start(1, 1, beat)
+          active = true
+          local done = false
+          scanner:scan(root_id, function()
+            sample.scan_ms = ms() - sample.start
+            beat()
+            done = true
+          end)
+          assert(
+            vim.wait(30000, function()
+              return done
+            end, 1),
+            "scan timeout"
+          )
+          active = false
+          timer:stop()
+          timer:close()
+          local start = ms()
+          local children = store:children(root_id)
+          sample.sort_ms = ms() - start
+          assert(#children == 1000, "Expected 1000 entries")
+          local buf = api.nvim_create_buf(false, true)
+          local painter = Painter.new(buf)
+          local rows = Flatten.flatten(store, root_id)
+          start = ms()
+          painter:paint(rows)
+          sample.paint_ms = ms() - start
+          api.nvim_buf_delete(buf, { force = true })
+          sample.start = nil
+          if repetition > 0 then
+            samples[#samples + 1] = sample
+          end
+        end
+      end
+    end
+  end
+  vim.fn.writefile({ vim.json.encode({ version = vim.version(), fixture = fixture, samples = samples }) }, output)
+end
+local ok, err = xpcall(run, debug.traceback)
+if not ok then
+  vim.fn.writefile({ tostring(err) }, output .. ".error")
+  vim.cmd("cquit 1")
+end
+vim.cmd("qa!")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,11 @@ Collapsed (hidden) nodes are excluded from the diff on `:w`, preventing accident
 
 ### Progressive Async Rendering
 
-All filesystem scanning is fully asynchronous via `vim.uv`. The target file's ancestor chain is scanned first, so the relevant portion of the tree appears immediately. Remaining directories load progressively in the background.
+Directory enumeration uses asynchronous `vim.uv` calls in 64-entry batches. Retained symlinks are resolved asynchronously with at most 32 metadata chains active per scanner across all directories; each chain resolves the real path and, when `follow_symlinks` is enabled, stats the target. Ordinary files require no per-entry metadata request. The existing 32-scan limit remains held through metadata completion, so callers and refresh guards observe a complete scan.
+
+Filtering and preparing entries, reconciling store nodes, sorting, and render preparation/painting still run synchronously on Neovim's main loop. Symlink metadata completes before the directory's children are committed; completion order does not determine display order. Root changes and buffer disposal stop queued work and settle scan callbacks, while already submitted metadata requests drain without committing their results. Node identity, path, root identity, and scan generation are checked before committing.
+
+The target file's ancestor chain is scanned before the initial render. Cached open directories and explicitly requested descendants may require further asynchronous scans.
 
 Directory expand/collapse — the hot path for re-render — is applied incrementally: only the affected line range is replaced via `nvim_buf_set_lines`. Other changes fall back to a full repaint.
 

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -904,7 +904,7 @@ function M.open(opts)
   -- Scan, fetch git status, and render
   local function on_initial_scan_complete()
     vim.schedule(function()
-      if not util.is_valid_buf(buffer.bufnr) then
+      if explorer.scanner ~= scanner or not util.is_valid_buf(buffer.bufnr) then
         return
       end
 
@@ -919,7 +919,7 @@ function M.open(opts)
           if resolved then
             scanner:scan_ancestors(resolved, function()
               vim.schedule(function()
-                if not util.is_valid_buf(buffer.bufnr) then
+                if explorer.scanner ~= scanner or not util.is_valid_buf(buffer.bufnr) then
                   return
                 end
                 local resolved_node = store:get_by_path(resolved)
@@ -952,7 +952,7 @@ function M.open(opts)
         -- Phase 2: Iteratively scan open+unloaded directories
         scanner:scan_open_unloaded(cached.open_dirs, function()
           vim.schedule(function()
-            if not util.is_valid_buf(buffer.bufnr) then
+            if explorer.scanner ~= scanner or not util.is_valid_buf(buffer.bufnr) then
               return
             end
             -- Restore cursor position from cache if no target_path
@@ -972,7 +972,7 @@ function M.open(opts)
       if expand_path then
         scanner:scan_ancestors(expand_path, function()
           vim.schedule(function()
-            if not util.is_valid_buf(buffer.bufnr) then
+            if explorer.scanner ~= scanner or not util.is_valid_buf(buffer.bufnr) then
               return
             end
             local ep_node = store:get_by_path(expand_path)
@@ -1001,7 +1001,7 @@ function M.open(opts)
       -- Fetch git status after initial render
       if cfg.git.enabled then
         git.status(root_path, function(_status)
-          if not util.is_valid_buf(buffer.bufnr) then
+          if explorer.scanner ~= scanner or not util.is_valid_buf(buffer.bufnr) then
             return
           end
           -- Always re-render after git.status resolves (ready/no_repo/error) so
@@ -1206,6 +1206,7 @@ function M._change_root(explorer, new_path, opts)
   -- Increment generation to invalidate stale callbacks
   explorer.generation = explorer.generation + 1
   explorer.refresh:reset()
+  explorer.scanner:dispose()
 
   -- Reset the pre-render dispatch gate: after a root change, the new scan is
   -- in flight and `flat_lines` is empty until `on_scan_complete` below. Treat

--- a/lua/eda/refresh.lua
+++ b/lua/eda/refresh.lua
@@ -12,6 +12,7 @@ local git = require("eda.git")
 ---@field paths table<string, boolean>
 ---@field full boolean
 ---@field _scheduled boolean
+---@field _scanner eda.Scanner?
 local Refresh = {}
 Refresh.__index = Refresh
 
@@ -42,6 +43,7 @@ function Refresh.new(explorer)
     buffer = explorer.buffer.bufnr,
     callback = function()
       self:reset()
+      explorer.scanner:dispose()
       explorer.watcher:unwatch_all()
       vim.api.nvim_del_autocmd(option_event)
     end,
@@ -56,6 +58,11 @@ function Refresh:reset()
   self.paths = {}
   self.full = false
   self._scheduled = false
+  local scanner = self._scanner
+  self._scanner = nil
+  if scanner then
+    scanner:dispose()
+  end
 end
 
 ---@param path string
@@ -183,6 +190,7 @@ function Refresh:flush()
   candidate:set_root(ex.root_path)
   local cfg = config.get()
   local scanner = Scanner.new(candidate, cfg)
+  self._scanner = scanner
   local roots = {}
 
   local function commit()
@@ -190,6 +198,7 @@ function Refresh:flush()
       return
     end
     self.running = false
+    self._scanner = nil
     if ex.generation ~= generation or not util.is_valid_buf(bufnr) then
       return
     end

--- a/lua/eda/tree/metadata.lua
+++ b/lua/eda/tree/metadata.lua
@@ -1,0 +1,166 @@
+---@class eda.MetadataGroup
+---@field remaining integer
+---@field valid fun(): boolean
+---@field callback fun(err?: string)
+---@field settled boolean
+
+---@class eda.MetadataJob
+---@field group eda.MetadataGroup
+---@field fields table
+---@field follow boolean
+
+---@class eda.MetadataResolver
+---@field _queue eda.MetadataJob[]
+---@field _head integer
+---@field _active integer
+---@field _limit integer
+---@field _disposed boolean
+---@field _draining boolean
+---@field _groups table<eda.MetadataGroup, true>
+local Metadata = {}
+Metadata.__index = Metadata
+
+---@return eda.MetadataResolver
+function Metadata.new()
+  return setmetatable({
+    _queue = {},
+    _head = 1,
+    _active = 0,
+    _limit = 32,
+    _disposed = false,
+    _draining = false,
+    _groups = {},
+  }, Metadata)
+end
+
+---@param group eda.MetadataGroup
+---@param err? string
+function Metadata:_settle(group, err)
+  if group.settled then
+    return
+  end
+  group.settled = true
+  self._groups[group] = nil
+  group.callback(err)
+end
+
+---@param method string
+---@param path string
+---@param callback fun(err?: string, value?: any)
+local function request(method, path, callback)
+  local settled = false
+  local function complete(err, value)
+    if settled then
+      return
+    end
+    settled = true
+    callback(err, value)
+  end
+  local ok, req, err = pcall(vim.uv[method], path, vim.schedule_wrap(complete))
+  if not ok or not req then
+    complete(tostring(ok and err or req))
+  end
+end
+
+---@param job eda.MetadataJob
+function Metadata:_start(job)
+  self._active = self._active + 1
+  local group, fields = job.group, job.fields
+  local function valid()
+    return not self._disposed and not group.settled and group.valid()
+  end
+  local function finish()
+    self._active = self._active - 1
+    group.remaining = group.remaining - 1
+    if not valid() then
+      self:_settle(group, "scan cancelled")
+    elseif group.remaining == 0 then
+      self:_settle(group)
+    end
+    self:_drain()
+  end
+  request("fs_realpath", fields.path, function(err, target)
+    if not valid() then
+      finish()
+      return
+    end
+    fields.link_broken = err ~= nil or target == nil
+    fields.link_target = target
+    if fields.link_broken or not job.follow then
+      finish()
+      return
+    end
+    request("fs_stat", target, function(stat_err, stat)
+      if valid() then
+        if stat_err or not stat then
+          fields.link_target = nil
+          fields.link_broken = true
+        elseif stat.type == "directory" then
+          fields.type = "directory"
+        end
+      end
+      finish()
+    end)
+  end)
+end
+
+function Metadata:_drain()
+  if self._draining then
+    return
+  end
+  self._draining = true
+  while not self._disposed and self._active < self._limit and self._head <= #self._queue do
+    local job = self._queue[self._head]
+    self._head = self._head + 1
+    if job.group.settled or not job.group.valid() then
+      self:_settle(job.group, "scan cancelled")
+    else
+      self:_start(job)
+    end
+  end
+  if self._head > #self._queue then
+    self._queue = {}
+    self._head = 1
+  end
+  self._draining = false
+end
+
+---@param children table[]
+---@param follow boolean
+---@param valid fun(): boolean
+---@param callback fun(err?: string)
+function Metadata:resolve(children, follow, valid, callback)
+  if self._disposed or not valid() then
+    callback("scan cancelled")
+    return
+  end
+  local group = { remaining = 0, valid = valid, callback = callback, settled = false }
+  for _, fields in ipairs(children) do
+    if fields.type == "link" then
+      group.remaining = group.remaining + 1
+      self._queue[#self._queue + 1] = { group = group, fields = fields, follow = follow }
+    end
+  end
+  if group.remaining == 0 then
+    callback()
+    return
+  end
+  self._groups[group] = true
+  self:_drain()
+end
+
+function Metadata:dispose()
+  if self._disposed then
+    return
+  end
+  self._disposed = true
+  self._queue = {}
+  self._head = 1
+  local groups = self._groups
+  self._groups = {}
+  for group in pairs(groups) do
+    self:_settle(group, "scan cancelled")
+  end
+end
+
+return Metadata

--- a/lua/eda/tree/scanner.lua
+++ b/lua/eda/tree/scanner.lua
@@ -1,13 +1,22 @@
 local Node = require("eda.tree.node")
+local Metadata = require("eda.tree.metadata")
+
+---@class eda.ScanIdentity
+---@field node eda.TreeNode
+---@field root eda.TreeNode?
+---@field path string
 
 ---@class eda.Scanner
 ---@field store eda.Store
 ---@field config table
 ---@field _scanning table<integer, boolean>
+---@field _metadata eda.MetadataResolver
+---@field _disposed boolean
+---@field _draining boolean
 ---@field _active_fds integer
 ---@field _max_concurrent_fds integer
 ---@field _node_gen table<integer, integer>
----@field _pending_scans { node_id: integer, callback: fun(err?: string), gen: integer }[]
+---@field _pending_scans { node_id: integer, callback: fun(err?: string), gen: integer, identity: eda.ScanIdentity }[]
 ---@field _waiters table<integer, fun(err?: string)[]>
 local Scanner = {}
 Scanner.__index = Scanner
@@ -21,6 +30,9 @@ function Scanner.new(store, config)
     store = store,
     config = config or {},
     _scanning = {},
+    _metadata = Metadata.new(),
+    _disposed = false,
+    _draining = false,
     _node_gen = {},
     _active_fds = 0,
     _max_concurrent_fds = 32,
@@ -45,11 +57,16 @@ end
 ---Drain pending scans while under the fd limit.
 ---@private
 function Scanner:_drain_pending()
+  if self._draining then
+    return
+  end
+  self._draining = true
   while #self._pending_scans > 0 and self._active_fds < self._max_concurrent_fds do
     local entry = table.remove(self._pending_scans, 1)
     self._active_fds = self._active_fds + 1
-    self:_do_scan_io(entry.node_id, entry.callback, entry.gen)
+    self:_do_scan_io(entry.node_id, entry.callback, entry.gen, entry.identity)
   end
+  self._draining = false
 end
 
 ---Release one fd slot and drain pending scans.
@@ -63,6 +80,10 @@ end
 ---@param node_id integer
 ---@param callback fun(err?: string)
 function Scanner:scan(node_id, callback)
+  if self._disposed then
+    callback("scan cancelled")
+    return
+  end
   local node = self.store:get(node_id)
   if not node or not Node.is_dir(node) then
     if callback then
@@ -85,12 +106,13 @@ function Scanner:scan(node_id, callback)
   local gen = (self._node_gen[node_id] or 0) + 1
   self._node_gen[node_id] = gen
   node.children_state = "loading"
+  local identity = { node = node, root = self.store:get(self.store.root_id), path = node.path }
 
   if self._active_fds < self._max_concurrent_fds then
     self._active_fds = self._active_fds + 1
-    self:_do_scan_io(node_id, callback, gen)
+    self:_do_scan_io(node_id, callback, gen, identity)
   else
-    table.insert(self._pending_scans, { node_id = node_id, callback = callback, gen = gen })
+    table.insert(self._pending_scans, { node_id = node_id, callback = callback, gen = gen, identity = identity })
   end
 end
 
@@ -99,17 +121,26 @@ end
 ---@private
 ---@param node_id integer
 ---@param callback fun(err?: string)?
-function Scanner:_settle(node_id, callback)
-  if callback then
-    callback()
-  end
+---@param err? string
+function Scanner:_settle(node_id, callback, err)
+  self._scanning[node_id] = nil
   local waiters = self._waiters[node_id]
-  if waiters then
-    self._waiters[node_id] = nil
-    for _, w in ipairs(waiters) do
-      w()
-    end
+  self._waiters[node_id] = nil
+  if callback then
+    callback(err)
   end
+  for _, waiter in ipairs(waiters or {}) do
+    waiter(err)
+  end
+end
+
+function Scanner:dispose()
+  if self._disposed then
+    return
+  end
+  self._disposed = true
+  self._metadata:dispose()
+  self:_drain_pending()
 end
 
 ---Perform the actual I/O for a directory scan.
@@ -117,25 +148,38 @@ end
 ---@param node_id integer
 ---@param callback fun(err?: string)
 ---@param gen integer
-function Scanner:_do_scan_io(node_id, callback, gen)
-  local node = self.store:get(node_id)
-  if not node then
-    callback("node not found")
+---@param identity eda.ScanIdentity
+function Scanner:_do_scan_io(node_id, callback, gen, identity)
+  local node, root, path = identity.node, identity.root, identity.path
+  local function valid()
+    return not self._disposed
+      and node ~= nil
+      and self.store:get(node_id) == node
+      and self.store:get(self.store.root_id) == root
+      and node.path == path
+      and self._node_gen[node_id] == gen
+  end
+  local function finish(err)
+    if err and self.store:get(node_id) == node and node then
+      node.children_state = "unloaded"
+    end
+    self:_release_fd()
+    self:_settle(node_id, callback, err)
+  end
+  if not valid() or not node then
+    finish("scan cancelled")
     return
   end
 
   vim.uv.fs_opendir(node.path, function(err, dir)
     if err then
       vim.schedule(function()
-        self:_release_fd()
-        self._scanning[node_id] = nil
-        if self._node_gen[node_id] ~= gen then
-          self:_settle(node_id, callback)
+        if not valid() then
+          finish("scan cancelled")
           return
         end
         node.children_state = "loaded"
         self.store:remove_children(node_id)
-        -- Create error child node
         self.store:add({
           name = err,
           path = node.path .. "/__error__",
@@ -143,38 +187,41 @@ function Scanner:_do_scan_io(node_id, callback, gen)
           parent_id = node_id,
           error = "permission_denied",
         })
-        self:_settle(node_id, callback)
+        finish()
       end)
       return
     end
 
     local entries = {}
-
+    local function close(read_err)
+      vim.uv.fs_closedir(dir, function()
+        vim.schedule(function()
+          if not valid() then
+            finish("scan cancelled")
+          elseif read_err then
+            finish(read_err)
+          else
+            self:_apply_entries(node_id, entries, finish, valid)
+          end
+        end)
+      end)
+    end
     local function read_next()
+      if not valid() then
+        close("scan cancelled")
+        return
+      end
       vim.uv.fs_readdir(dir, function(read_err, ents)
         if read_err or not ents then
-          vim.uv.fs_closedir(dir, function()
-            vim.schedule(function()
-              self:_release_fd()
-              self._scanning[node_id] = nil
-              if self._node_gen[node_id] ~= gen then
-                self:_settle(node_id, callback)
-                return
-              end
-              self:_apply_entries(node_id, entries)
-              self:_settle(node_id, callback)
-            end)
-          end)
+          close(read_err)
           return
         end
-
         for _, ent in ipairs(ents) do
-          table.insert(entries, ent)
+          entries[#entries + 1] = ent
         end
         read_next()
       end)
     end
-
     read_next()
   end, 64)
 end
@@ -182,10 +229,18 @@ end
 ---Apply scanned entries to the store.
 ---@param node_id integer
 ---@param entries table[]
-function Scanner:_apply_entries(node_id, entries)
+---@param callback? fun(err?: string)
+---@param valid? fun(): boolean
+function Scanner:_apply_entries(node_id, entries, callback, valid)
   local node = self.store:get(node_id)
   if not node then
+    if callback then
+      callback("node not found")
+    end
     return
+  end
+  valid = valid or function()
+    return not self._disposed and self.store:get(node_id) == node
   end
 
   local children = {}
@@ -222,28 +277,18 @@ function Scanner:_apply_entries(node_id, entries)
       parent_id = node_id,
     }
 
-    if child_type == "link" then
-      local target = vim.uv.fs_realpath(child_path)
-      if target then
-        fields.link_target = target
-        fields.link_broken = false
-        if follow_symlinks then
-          local target_stat = vim.uv.fs_stat(target)
-          if target_stat and target_stat.type == "directory" then
-            fields.type = "directory"
-          end
-        end
-      else
-        fields.link_target = nil
-        fields.link_broken = true
-      end
-    end
-
     table.insert(children, fields)
     ::continue_entry::
   end
 
-  self.store:reconcile_children(node_id, children)
+  self._metadata:resolve(children, follow_symlinks, valid, function(err)
+    if not err and valid() then
+      self.store:reconcile_children(node_id, children)
+    end
+    if callback then
+      callback(err)
+    end
+  end)
 end
 
 ---Scan ancestor directories from root to target path.
@@ -281,7 +326,13 @@ function Scanner:scan_ancestors(target_path, callback)
   local idx = 0
 
   local function scan_next()
-    self:scan(current_id, function()
+    self:scan(current_id, function(err)
+      if err then
+        if callback then
+          callback()
+        end
+        return
+      end
       idx = idx + 1
       if idx > #segments then
         if callback then
@@ -318,7 +369,11 @@ end
 ---@param node_id integer
 ---@param callback fun()
 function Scanner:scan_expanded(node_id, callback)
-  self:scan(node_id, function()
+  self:scan(node_id, function(err)
+    if err then
+      callback()
+      return
+    end
     local open_dirs = {}
     local function collect(id)
       local node = self.store:get(id)
@@ -340,14 +395,20 @@ end
 ---@param max_depth integer
 ---@param callback fun()
 function Scanner:scan_recursive(node_id, max_depth, callback)
-  if max_depth <= 0 then
+  if self._disposed or max_depth <= 0 then
     if callback then
       callback()
     end
     return
   end
 
-  self:scan(node_id, function()
+  self:scan(node_id, function(err)
+    if err then
+      if callback then
+        callback()
+      end
+      return
+    end
     local node = self.store:get(node_id)
     if not node or not node.children_ids then
       if callback then
@@ -380,7 +441,11 @@ function Scanner:scan_recursive(node_id, max_depth, callback)
         self:scan_recursive(dirs[i], max_depth - 1, function()
           batch_completed = batch_completed + 1
           if batch_completed == (end_idx - start_idx + 1) then
-            if end_idx < #dirs then
+            if self._disposed then
+              if callback then
+                callback()
+              end
+            elseif end_idx < #dirs then
               scan_batch(end_idx + 1)
             elseif callback then
               callback()
@@ -399,6 +464,10 @@ end
 ---@param open_dirs table<string, boolean> path→true map of dirs that should be open
 ---@param callback fun()
 function Scanner:scan_open_unloaded(open_dirs, callback)
+  if self._disposed then
+    callback()
+    return
+  end
   -- Apply open states using path index (O(|open_dirs|) instead of O(|all_nodes|))
   for path in pairs(open_dirs) do
     local node = self.store:get_by_path(path)
@@ -431,12 +500,18 @@ function Scanner:scan_open_unloaded(open_dirs, callback)
   end
 
   local remaining = #dirs_to_scan
+  local failed = false
   for _, nid in ipairs(dirs_to_scan) do
-    self:scan(nid, function()
+    self:scan(nid, function(err)
+      failed = failed or err ~= nil
       remaining = remaining - 1
       if remaining == 0 then
         vim.schedule(function()
-          self:scan_open_unloaded(open_dirs, callback)
+          if failed then
+            callback()
+          else
+            self:scan_open_unloaded(open_dirs, callback)
+          end
         end)
       end
     end)

--- a/tests/e2e/test_scanner_cancellation.lua
+++ b/tests/e2e/test_scanner_cancellation.lua
@@ -1,0 +1,105 @@
+local e2e = require("e2e.helpers")
+local child, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      e2e.setup_eda(child)
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      e2e.create_file(tmp .. "/target", "target")
+      e2e.create_dir(tmp .. "/new-root")
+      e2e.create_file(tmp .. "/new-root/keep.txt", "keep")
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+for _, transition in ipairs({ "initial root change", "initial close", "refresh root change" }) do
+  T[transition .. " cancels pending symlink metadata"] = function()
+    if transition == "refresh root change" then
+      e2e.open_eda(child, tmp)
+    end
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      _G.metadata_root = %q
+      _G.metadata_callbacks = {}
+      local realpath = vim.uv.fs_realpath
+      vim.uv.fs_realpath = function(path, callback)
+        if callback and path:sub(1, #_G.metadata_root + 5) == _G.metadata_root .. "/link" then
+          _G.metadata_callbacks[#_G.metadata_callbacks + 1] = callback
+          return {}
+        end
+        return realpath(path, callback)
+      end
+    ]],
+        tmp
+      )
+    )
+    for i = 1, 50 do
+      assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/link" .. i))
+    end
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      local eda = require("eda")
+      if %q == "refresh root change" then
+        eda.get_current().refresh:request(_G.metadata_root)
+      else
+        eda.open({ dir = _G.metadata_root })
+      end
+    ]],
+        transition
+      )
+    )
+    e2e.wait_until(child, "#_G.metadata_callbacks > 0")
+    e2e.exec(
+      child,
+      string.format(
+        [[
+      local eda = require("eda")
+      local ex = eda.get_current()
+      _G.cancelled_scanner = %q == "refresh root change" and ex.refresh._scanner or ex.scanner
+      assert(_G.cancelled_scanner)
+      if %q == "initial close" then
+        eda.close()
+      else
+        eda._change_root(ex, _G.metadata_root .. "/new-root")
+      end
+    ]],
+        transition,
+        transition
+      )
+    )
+    MiniTest.expect.equality(e2e.exec(child, "return _G.cancelled_scanner._disposed"), true)
+    if transition ~= "initial close" then
+      e2e.wait_until(
+        child,
+        [[
+        local ex = require("eda").get_current()
+        return ex and ex.root_path == _G.metadata_root .. "/new-root" and ex._initial_scan_complete
+      ]]
+      )
+      MiniTest.expect.equality(e2e.get_buf_lines(child), { "keep.txt" })
+    end
+    e2e.exec(
+      child,
+      [[
+      for _, callback in ipairs(_G.metadata_callbacks) do callback(nil, _G.metadata_root .. "/target") end
+    ]]
+    )
+    e2e.wait_until(child, "_G.cancelled_scanner._metadata._active == 0")
+    MiniTest.expect.equality(e2e.exec(child, "return _G.cancelled_scanner._active_fds"), 0)
+    MiniTest.expect.equality(e2e.exec(child, "return next(_G.cancelled_scanner._scanning) == nil"), true)
+    if transition == "initial close" then
+      MiniTest.expect.equality(e2e.exec(child, "return require('eda').get_current() == nil"), true)
+    else
+      MiniTest.expect.equality(e2e.get_buf_lines(child), { "keep.txt" })
+    end
+  end
+end
+return T

--- a/tests/tree/test_scanner.lua
+++ b/tests/tree/test_scanner.lua
@@ -498,6 +498,7 @@ T["scan fd semaphore recovers from opendir errors"] = function()
   -- Pending queue should be empty
   MiniTest.expect.equality(#scanner._pending_scans, 0)
 
+  vim.fn.setfperm(tmp .. "/no_access", "rwx------")
   helpers.remove_temp_dir(tmp)
 end
 

--- a/tests/tree/test_scanner_metadata.lua
+++ b/tests/tree/test_scanner_metadata.lua
@@ -1,0 +1,316 @@
+local Store = require("eda.tree.store")
+local Scanner = require("eda.tree.scanner")
+local helpers = require("helpers")
+local tmp, original_realpath, original_stat, scanners
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+      original_realpath, original_stat = vim.uv.fs_realpath, vim.uv.fs_stat
+      scanners = {}
+    end,
+    post_case = function()
+      vim.uv.fs_realpath, vim.uv.fs_stat = original_realpath, original_stat
+      for _, scanner in ipairs(scanners) do
+        if scanner.dispose then
+          scanner:dispose()
+        end
+      end
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+local function scanner_for(path, follow)
+  local store = Store.new()
+  store:set_root(path)
+  local scanner = Scanner.new(store, { follow_symlinks = follow })
+  scanners[#scanners + 1] = scanner
+  return scanner, store
+end
+local function scan(scanner, id)
+  local done = false
+  scanner:scan(id or scanner.store.root_id, function()
+    done = true
+  end)
+  helpers.wait_for(3000, function()
+    return done
+  end)
+  MiniTest.expect.equality(done, true)
+end
+for _, follow in ipairs({ false, true }) do
+  T["resolves file, directory, and broken links asynchronously with follow=" .. tostring(follow)] = function()
+    helpers.create_file(tmp .. "/file", "file")
+    helpers.create_dir(tmp .. "/dir")
+    for _, name in ipairs({ "file", "dir", "missing" }) do
+      assert(vim.uv.fs_symlink(tmp .. "/" .. name, tmp .. "/link-" .. name))
+    end
+    local calls, sync_calls = 0, 0
+    vim.uv.fs_realpath = function(path, callback)
+      calls = calls + 1
+      if not callback then
+        sync_calls = sync_calls + 1
+      end
+      return original_realpath(path, callback)
+    end
+    vim.uv.fs_stat = function(path, callback)
+      if not callback then
+        sync_calls = sync_calls + 1
+      end
+      return original_stat(path, callback)
+    end
+    local scanner, store = scanner_for(tmp, follow)
+    scan(scanner)
+    MiniTest.expect.equality(sync_calls, 0)
+    MiniTest.expect.equality(calls, 3)
+    MiniTest.expect.equality(store:get_by_path(tmp .. "/link-file").type, "link")
+    MiniTest.expect.equality(store:get_by_path(tmp .. "/link-dir").type, follow and "directory" or "link")
+    MiniTest.expect.equality(store:get_by_path(tmp .. "/link-dir").link_target, tmp .. "/dir")
+    MiniTest.expect.equality(store:get_by_path(tmp .. "/link-missing").link_broken, true)
+    MiniTest.expect.equality(scanner._active_fds, 0)
+  end
+end
+T["bounds pending metadata across directories and settles coalesced callers"] = function()
+  helpers.create_file(tmp .. "/target", "target")
+  for _, name in ipairs({ "a", "b" }) do
+    helpers.create_dir(tmp .. "/" .. name)
+    for i = 1, 50 do
+      assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/" .. name .. "/link" .. i))
+    end
+  end
+  local scanner, store = scanner_for(tmp, true)
+  scan(scanner)
+  local pending, active, peak, sync_calls = {}, 0, 0, 0
+  vim.uv.fs_realpath = function(path, callback)
+    if not callback then
+      sync_calls = sync_calls + 1
+      return original_realpath(path)
+    end
+    active = active + 1
+    peak = math.max(peak, active)
+    pending[#pending + 1] = function()
+      active = active - 1
+      callback(nil, tmp .. "/target")
+    end
+    return {}
+  end
+  local settled = 0
+  for _, name in ipairs({ "a", "b", "a" }) do
+    scanner:scan(store:get_by_path(tmp .. "/" .. name).id, function()
+      settled = settled + 1
+    end)
+  end
+  helpers.wait_for(3000, function()
+    return #pending >= 32 or settled == 3
+  end)
+  MiniTest.expect.equality(sync_calls, 0)
+  MiniTest.expect.equality(settled, 0)
+  MiniTest.expect.equality(peak <= 32, true)
+  for _ = 1, 10 do
+    local batch = pending
+    pending = {}
+    for _, complete in ipairs(batch) do
+      complete()
+    end
+    helpers.wait_for(3000, function()
+      return #pending > 0 or settled == 3
+    end)
+    if settled == 3 then
+      break
+    end
+  end
+  MiniTest.expect.equality(settled, 3)
+  MiniTest.expect.equality(peak <= 32, true)
+  MiniTest.expect.equality(scanner._active_fds, 0)
+  MiniTest.expect.equality(#store:children(store:get_by_path(tmp .. "/a").id), 50)
+  MiniTest.expect.equality(#store:children(store:get_by_path(tmp .. "/b").id), 50)
+end
+T["disposal skips queued links and settles both scan callbacks exactly once"] = function()
+  helpers.create_file(tmp .. "/target", "target")
+  for i = 1, 80 do
+    assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/link" .. i))
+  end
+  local pending, starts = {}, 0
+  vim.uv.fs_realpath = function(path, callback)
+    if not callback then
+      return original_realpath(path)
+    end
+    starts = starts + 1
+    pending[#pending + 1] = callback
+    return {}
+  end
+  local scanner, store = scanner_for(tmp, true)
+  local settled = 0
+  scanner:scan(store.root_id, function()
+    settled = settled + 1
+  end)
+  scanner:scan(store.root_id, function()
+    settled = settled + 1
+  end)
+  helpers.wait_for(3000, function()
+    return #pending > 0 or settled > 0
+  end)
+  MiniTest.expect.equality(settled, 0)
+  scanner:dispose()
+  helpers.wait_for(3000, function()
+    return settled == 2
+  end)
+  local before = starts
+  for _, complete in ipairs(pending) do
+    complete(nil, tmp .. "/target")
+  end
+  helpers.wait_for(3000, function()
+    return scanner._metadata._active == 0
+  end)
+  MiniTest.expect.equality(settled, 2)
+  MiniTest.expect.equality(starts, before)
+  MiniTest.expect.equality(#store:children(store.root_id), 0)
+  MiniTest.expect.equality(scanner._active_fds, 0)
+end
+T["root replacement abandons pending results without populating the new root"] = function()
+  helpers.create_file(tmp .. "/target", "target")
+  assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/link"))
+  helpers.create_dir(tmp .. "/new-root")
+  local pending
+  vim.uv.fs_realpath = function(path, callback)
+    if not callback then
+      return original_realpath(path)
+    end
+    pending = callback
+    return {}
+  end
+  local scanner, store = scanner_for(tmp, true)
+  local done = false
+  scanner:scan(store.root_id, function()
+    done = true
+  end)
+  helpers.wait_for(3000, function()
+    return pending ~= nil or done
+  end)
+  MiniTest.expect.equality(done, false)
+  store:set_root(tmp .. "/new-root")
+  pending(nil, tmp .. "/target")
+  helpers.wait_for(3000, function()
+    return done
+  end)
+  MiniTest.expect.equality(#store:children(store.root_id), 0)
+  MiniTest.expect.equality(store:get_by_path(tmp .. "/link"), nil)
+  MiniTest.expect.equality(scanner._active_fds, 0)
+end
+T["deleted targets and metadata submission failure settle without hanging"] = function()
+  helpers.create_file(tmp .. "/target", "target")
+  assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/link"))
+  vim.uv.fs_stat = function(path, callback)
+    if callback then
+      return nil, "ENOENT"
+    end
+    return original_stat(path)
+  end
+  local scanner, store = scanner_for(tmp, true)
+  scan(scanner)
+  MiniTest.expect.equality(store:get_by_path(tmp .. "/link").link_broken, true)
+  MiniTest.expect.equality(scanner._active_fds, 0)
+end
+T["detects a target deleted after realpath completes"] = function()
+  helpers.create_file(tmp .. "/target", "target")
+  assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/link"))
+  local pending
+  vim.uv.fs_realpath = function(path, callback)
+    if not callback then
+      return original_realpath(path)
+    end
+    return original_realpath(path, function(err, target)
+      pending = function()
+        callback(err, target)
+      end
+    end)
+  end
+  local scanner, store = scanner_for(tmp, true)
+  local done = false
+  scanner:scan(store.root_id, function()
+    done = true
+  end)
+  helpers.wait_for(3000, function()
+    return pending ~= nil
+  end)
+  assert(vim.uv.fs_unlink(tmp .. "/target"))
+  pending()
+  helpers.wait_for(3000, function()
+    return done
+  end)
+  local link = store:get_by_path(tmp .. "/link")
+  MiniTest.expect.equality(link.link_broken, true)
+  MiniTest.expect.equality(link.link_target, nil)
+end
+T["a queued directory removed from the store releases its scan slot"] = function()
+  helpers.create_dir(tmp .. "/a")
+  helpers.create_dir(tmp .. "/b")
+  helpers.create_file(tmp .. "/target", "target")
+  assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/a/link"))
+  local scanner, store = scanner_for(tmp, true)
+  scan(scanner)
+  scanner._max_concurrent_fds = 1
+  local pending
+  vim.uv.fs_realpath = function(path, callback)
+    if not callback then
+      return original_realpath(path)
+    end
+    pending = callback
+    return {}
+  end
+  local settled = 0
+  local a, b = store:get_by_path(tmp .. "/a"), store:get_by_path(tmp .. "/b")
+  scanner:scan(a.id, function()
+    settled = settled + 1
+  end)
+  scanner:scan(b.id, function()
+    settled = settled + 1
+  end)
+  helpers.wait_for(3000, function()
+    return pending ~= nil
+  end)
+  store:remove(b.id)
+  pending(nil, tmp .. "/target")
+  helpers.wait_for(3000, function()
+    return settled == 2
+  end)
+  MiniTest.expect.equality(scanner._active_fds, 0)
+  MiniTest.expect.equality(#scanner._pending_scans, 0)
+  MiniTest.expect.equality(next(scanner._scanning), nil)
+end
+T["queued scans keep the root identity from the original request"] = function()
+  helpers.create_dir(tmp .. "/a")
+  helpers.create_dir(tmp .. "/b")
+  helpers.create_dir(tmp .. "/new-root")
+  helpers.create_file(tmp .. "/target", "target")
+  helpers.create_file(tmp .. "/b/unexpected", "unexpected")
+  assert(vim.uv.fs_symlink(tmp .. "/target", tmp .. "/a/link"))
+  local scanner, store = scanner_for(tmp, true)
+  scan(scanner)
+  scanner._max_concurrent_fds = 1
+  local pending
+  vim.uv.fs_realpath = function(path, callback)
+    if not callback then
+      return original_realpath(path)
+    end
+    pending = callback
+    return {}
+  end
+  local settled = 0
+  scanner:scan(store:get_by_path(tmp .. "/a").id, function()
+    settled = settled + 1
+  end)
+  scanner:scan(store:get_by_path(tmp .. "/b").id, function()
+    settled = settled + 1
+  end)
+  helpers.wait_for(3000, function()
+    return pending ~= nil
+  end)
+  store:set_root(tmp .. "/new-root")
+  pending(nil, tmp .. "/target")
+  helpers.wait_for(3000, function()
+    return settled == 2
+  end)
+  MiniTest.expect.equality(store:get_by_path(tmp .. "/b/unexpected"), nil)
+  MiniTest.expect.equality(scanner._active_fds, 0)
+end
+return T


### PR DESCRIPTION
## Summary

Directory enumeration was asynchronous, but resolving every symlink blocked Neovim's main loop after enumeration. Resolve retained links with a scanner-wide limit of 32 asynchronous metadata chains, and commit children only after they finish. Ordinary files retain the existing direct materialization path.

Keep scan slots and coalesced callbacks active through metadata completion. Cancel queued work on root changes/buffer disposal/refresh reset; reject stale node, path, root, and generation identities captured when the scan was requested. Submitted requests drain without committing after cancellation. Preserve file/directory/broken-link behavior and handle targets disappearing between metadata stages.

Add a reproducible real/synthetic benchmark and scanner/E2E regressions. On the fixed 1,000-link fixture, real scan time decreased from 42.7 ms to 25.4 ms and the mean maximum heartbeat gap from 42.1 ms to 7.3 ms. With an injected 1 ms metadata delay, the gap decreased from 2,158 ms to 6.6 ms. Ordinary-file timing was similar. Reconciliation, sorting, and painting remain synchronous; benchmark documentation includes stage timings, repeated variability, and limitations.

Validation: formatting, lint, type checks, 852 unit tests and 235 E2E tests; targeted scanner, symlink, cancellation, and refresh cases on nightly. Self-review found and fixed a queued-scan root identity gap, verified by a failing regression before the correction. Reviewed cancellation, queue reentrancy, callback settlement, fd accounting, and owner cleanup.

Closes #68.
