### PR TITLE
perf: coordinate Git status requests per repository

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -266,3 +266,62 @@ materialization; this change does not make every scan stage asynchronous.
 Normal-file scans remain in the same range. The synthetic case demonstrates
 that metadata latency no longer becomes an equally long main-loop stall;
 its speedup is specific to the injected delay and bounded overlapping work.
+
+## Git status during a burst of saves
+
+`git-burst.lua` opens three real explorer splits over a 1,000-file Git fixture.
+Each burst writes 25 loaded buffers through normal Neovim `:write` commands;
+filesystem watchers trigger refresh without explicit refresh calls. Git status
+uses real subprocesses. One warmup burst precedes five measured bursts.
+
+Create a disposable fixture once (the workload rewrites files 1 through 25):
+
+```sh
+export EDA_BENCH_DIR="$(mktemp -d)"
+python3 - <<'PYTHON'
+import os
+import subprocess
+from pathlib import Path
+root = Path(os.environ["EDA_BENCH_DIR"])
+for index in range(1000):
+    (root / f"file-{index:04d}.txt").write_text("tracked\n")
+subprocess.run(["git", "init", str(root)], check=True)
+subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+subprocess.run(["git", "-C", str(root), "-c", "user.name=Benchmark",
+                "-c", "user.email=benchmark@example.invalid", "-c", "commit.gpgsign=false",
+                "commit", "-m", "fixture"], check=True)
+PYTHON
+EDA_BENCH_OUTPUT=/tmp/eda-git-burst.json \
+  nvim --headless -l benchmarks/git-burst.lua
+```
+
+The output records logical status requests, settled callbacks, process launches,
+peak concurrent processes, time spent saving, and time from the last save to the
+last status callback. It verifies that all 25 saved paths have modified status.
+A 100 ms quiet period checks settlement but is excluded from the recorded times.
+These are headless watcher/status measurements, not terminal display latency.
+
+### Recorded Git request coordination comparison
+
+Measured sequentially on macOS arm64 with Neovim 0.12.5, comparing `d48272a`
+with per-repository request coordination on the same fixture and workload.
+All five bursts issued three requests and settled all three callbacks.
+
+| Metric per burst | Before | After |
+| --- | ---: | ---: |
+| Status processes | 3 in every sample | 2, 2, 2, 2, 3 |
+| Peak concurrent status processes | 3 in every sample | 1 in every sample |
+| Save duration, ms | 121.225 ± 3.975 | 120.760 ± 1.597 |
+| Last save to last status callback, ms | 161.749 ± 4.498 | 178.652 ± 3.156 |
+| First save to last status callback, ms | 282.974 ± 6.281 | 299.412 ± 3.607 |
+
+Times are means ± sample standard deviations across five bursts. Process
+coordination reduced overlapping work, but this workload's completion latency
+increased by about 17 ms. Requests arriving after a process starts share a fresh
+follow-up round: later writes cannot safely rely on a command that may already
+have read the worktree. Watcher timing can place a third request after that
+follow-up starts, producing three sequential commands, as in the last sample.
+There is no fixed total-process bound for a continuing stream of writes; the
+bound is one active command and one queued round per repository. The fixture's
+local filesystem and small Git workload do not establish network-filesystem or
+large-repository latency improvements.

--- a/benchmarks/git-burst.lua
+++ b/benchmarks/git-burst.lua
@@ -1,0 +1,126 @@
+vim.o.shadafile = "NONE"
+vim.o.more = false
+vim.opt.rtp:prepend(vim.fn.getcwd())
+local fixture = assert(vim.env.EDA_BENCH_DIR, "Set EDA_BENCH_DIR to the Git fixture")
+local output = assert(vim.env.EDA_BENCH_OUTPUT, "Set EDA_BENCH_OUTPUT")
+local api = vim.api
+local function ms()
+  return vim.uv.hrtime() / 1e6
+end
+local sample, active, live = {}, false, 0
+local system = vim.system
+vim.system = function(command, opts, callback)
+  if not vim.tbl_contains(command, "status") then
+    return system(command, opts, callback)
+  end
+  local recorded = active and sample or nil
+  live = live + 1
+  if recorded then
+    recorded.processes = recorded.processes + 1
+    recorded.peak_processes = math.max(recorded.peak_processes, live)
+  end
+  return system(command, opts, function(result)
+    live = live - 1
+    callback(result)
+  end)
+end
+local git = require("eda.git")
+local status = git.status
+local last_callback = ms()
+git.status = function(root, callback)
+  local recorded = active and sample or nil
+  if recorded then
+    recorded.requests = recorded.requests + 1
+  end
+  return status(root, function(value)
+    callback(value)
+    last_callback = ms()
+    if recorded then
+      recorded.callbacks = recorded.callbacks + 1
+      recorded.last_callback = last_callback
+    end
+  end)
+end
+local function run()
+  local eda = require("eda")
+  eda.setup({
+    header = false,
+    icon = { provider = "none" },
+    window = { kind = "split_left" },
+    preview = { enabled = false },
+    update_focused_file = { enabled = false },
+  })
+  eda.open({ dir = fixture })
+  assert(
+    vim.wait(10000, function()
+      return eda.get_current()._initial_scan_complete and git.get_status_ready(fixture) == "ready"
+    end, 1),
+    "open timeout"
+  )
+  eda.open_split(fixture)
+  eda.open_split(fixture)
+  local function idle()
+    if live ~= 0 or ms() - last_callback < 100 then
+      return false
+    end
+    local all = eda.get_all()
+    if #all ~= 3 then
+      return false
+    end
+    for _, ex in ipairs(all) do
+      if not ex._initial_scan_complete or ex.refresh.pending or ex.refresh.running or ex.scanner._active_fds > 0 then
+        return false
+      end
+    end
+    return true
+  end
+  assert(vim.wait(10000, idle, 1), "initial idle timeout")
+  local buffers = {}
+  for i = 1, 25 do
+    local buf = vim.fn.bufadd(fixture .. string.format("/file-%04d.txt", i))
+    vim.fn.bufload(buf)
+    buffers[i] = buf
+  end
+  local result = { fixture = fixture, version = vim.version(), explorers = 3, saves_per_burst = 25, samples = {} }
+  for repetition = 0, 5 do
+    sample = { repetition = repetition, processes = 0, peak_processes = 0, requests = 0, callbacks = 0 }
+    active = true
+    local start = ms()
+    for i, buf in ipairs(buffers) do
+      api.nvim_buf_set_lines(buf, 0, -1, false, { "saved " .. repetition .. " / " .. i })
+      api.nvim_buf_call(buf, function()
+        vim.cmd("silent write")
+      end)
+    end
+    local saved = ms()
+    assert(
+      vim.wait(10000, function()
+        return sample.requests >= 3 and sample.callbacks == sample.requests and idle()
+      end, 1),
+      "save refresh timeout"
+    )
+    active = false
+    local cached = git.get_cached(fixture)
+    assert(cached, "Missing final Git status")
+    for i = 1, 25 do
+      assert(cached[fixture .. string.format("/file-%04d.txt", i)] == "M", "Missing saved file status")
+    end
+    sample.save_ms = saved - start
+    sample.refresh_after_save_ms = sample.last_callback - saved
+    sample.total_ms = sample.last_callback - start
+    sample.last_callback = nil
+    if repetition > 0 then
+      result.samples[#result.samples + 1] = sample
+    end
+  end
+  while eda.get_current() do
+    eda.close()
+  end
+  vim.fn.writefile({ vim.json.encode(result) }, output)
+end
+local ok, err = xpcall(run, debug.traceback)
+if not ok then
+  vim.fn.writefile({ tostring(err) }, output .. ".error")
+  vim.cmd("cquit 1")
+end
+vim.cmd("qa!")

--- a/doc/eda.md
+++ b/doc/eda.md
@@ -431,6 +431,14 @@ Maximum recursion depth for `expand_all` and `expand_recursive` actions.
   - `untracked`, `added`, `modified`, `deleted`, `renamed`, `staged`,
     `conflict`, `ignored`
 
+At most one status process runs for each repository. Requests made in the same
+event-loop turn are batched; requests arriving after a process starts share a
+subsequent refresh so later filesystem writes are included. Background status
+commands avoid optional index locks. During refresh, the last successful status
+remains visible, including after a temporary refresh failure. If the first
+status request fails, an active git-changes filter is disabled with a warning so
+the explorer remains usable. Refresh (`<C-l>`) retries status detection.
+
 ### indent
 
 `table`

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -452,6 +452,14 @@ GIT ~
     - `untracked`, `added`, `modified`, `deleted`, `renamed`, `staged`,
         `conflict`, `ignored`
 
+At most one status process runs for each repository. Requests made in the same
+event-loop turn are batched; requests arriving after a process starts share a
+subsequent refresh so later filesystem writes are included. Background status
+commands avoid optional index locks. During refresh, the last successful status
+remains visible, including after a temporary refresh failure. If the first
+status request fails, an active git-changes filter is disabled with a warning
+so the explorer remains usable. Refresh (`<C-l>`) retries status detection.
+
 
 INDENT ~
 

--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -57,9 +57,10 @@ end
 ---@param ctx eda.ActionContext
 local function refresh_git(ctx)
   if ctx.config.git.enabled then
+    local generation = ctx.explorer.generation
     git.status(ctx.explorer.root_path, function(_status)
       local util = require("eda.util")
-      if not util.is_valid_buf(ctx.buffer.bufnr) then
+      if ctx.explorer.generation ~= generation or not util.is_valid_buf(ctx.buffer.bufnr) then
         return
       end
       refresh(ctx)
@@ -383,7 +384,7 @@ local function navigate_git_change(ctx, dir)
 
   local root = ctx.explorer.root_path
   local ready = git.get_status_ready(root)
-  if ready == nil or ready == "loading" then
+  if ready == nil or ready == "loading" or ready == "error" then
     vim.notify("eda: git status not ready", vim.log.levels.WARN)
     return
   end
@@ -460,6 +461,11 @@ action.register("toggle_git_changes", function(ctx)
   local ready = git.get_status_ready(root)
   if ready == "no_repo" then
     vim.notify("eda: not a git repository", vim.log.levels.WARN)
+    return
+  end
+
+  if ready == "error" and not ctx.config.show_only_git_changes then
+    vim.notify("eda: git status unavailable", vim.log.levels.WARN)
     return
   end
 
@@ -1031,7 +1037,7 @@ action.register("open_in_browser", function(ctx)
 
   if ctx.config.git and ctx.config.git.enabled then
     local ready = git.get_status_ready(root)
-    if ready == "loading" then
+    if ready == "loading" or ready == "error" then
       vim.notify(git_url.MSG.loading, vim.log.levels.WARN)
       return
     end

--- a/lua/eda/git.lua
+++ b/lua/eda/git.lua
@@ -1,9 +1,9 @@
 local M = {}
 
 ---@class eda.GitCacheEntry
----@field statuses? table<string, string>  -- path → porcelain code (propagation 済み)
+---@field statuses? table<string, string>  -- path → porcelain code after propagation
 ---@field reported? table<string, true>    -- directly reported changed files only (before propagation)
----@field ready "loading"|"ready"|"no_repo"
+---@field ready "loading"|"ready"|"no_repo"|"error"
 
 ---@type table<string, eda.GitCacheEntry>
 local cache = {}
@@ -112,39 +112,120 @@ function M.find_git_root(root)
   return find_git_root(root)
 end
 
----Get git status for a directory asynchronously.
+---@class eda.GitRequest
+---@field epoch integer
+---@field callbacks fun(status: table<string, string>?)[]
+---@field finished? boolean
+
+---@class eda.GitRequestSlot
+---@field epoch integer
+---@field active? eda.GitRequest
+---@field pending? eda.GitRequest
+
+---@type table<string, eda.GitRequestSlot>
+local requests = {}
+
+---@param request eda.GitRequest
+---@param statuses? table<string, string>
+local function deliver(request, statuses)
+  local callbacks = request.callbacks
+  request.callbacks = {}
+  for _, callback in ipairs(callbacks) do
+    local ok, err = pcall(callback, statuses)
+    if not ok then
+      vim.schedule(function()
+        vim.notify("eda: Git status callback failed: " .. tostring(err), vim.log.levels.ERROR)
+      end)
+    end
+  end
+end
+
+---@type fun(root: string, slot: eda.GitRequestSlot)
+local start_pending
+
+---@param root string
+---@param slot eda.GitRequestSlot
+local function schedule_pending(root, slot)
+  local pending = slot.pending
+  if not pending or slot.active then
+    return
+  end
+  vim.schedule(function()
+    if slot.pending == pending and not slot.active then
+      start_pending(root, slot)
+    end
+  end)
+end
+
+start_pending = function(root, slot)
+  local request = slot.pending
+  if not request then
+    return
+  end
+  slot.pending = nil
+  slot.active = request
+  local function complete(result)
+    if request.finished then
+      return
+    end
+    request.finished = true
+    if slot.active ~= request then
+      deliver(request)
+      return
+    end
+    slot.active = nil
+    local statuses
+    if slot.epoch == request.epoch then
+      if result.code == 0 then
+        local reported = {}
+        statuses = parse_status(result.stdout or "", root, reported)
+        cache[root] = { statuses = statuses, reported = reported, ready = "ready" }
+      elseif not cache[root] or not cache[root].statuses then
+        cache[root] = { ready = slot.pending and "loading" or "error" }
+      end
+    end
+    schedule_pending(root, slot)
+    deliver(request, statuses)
+  end
+  local ok = pcall(
+    vim.system,
+    { "git", "--no-optional-locks", "-C", root, "status", "--porcelain=v1", "-z", "-uall", "--ignored=matching" },
+    {},
+    function(result)
+      vim.schedule(function()
+        complete(result)
+      end)
+    end
+  )
+  if not ok then
+    complete({ code = 1 })
+  end
+end
+
 ---@param root string Root directory path
 ---@param cb fun(status: table<string, string>?)
 function M.status(root, cb)
-  -- Find git root
   local git_root = find_git_root(root)
   if not git_root then
-    -- Non-git directory: record no_repo state under the input root path
     cache[root] = { ready = "no_repo" }
     cb(nil)
     return
   end
-
-  -- Mark as loading before the async call so UI can show a loading state
-  cache[git_root] = { ready = "loading" }
-
-  vim.system(
-    { "git", "-C", git_root, "status", "--porcelain=v1", "-z", "-uall", "--ignored=matching" },
-    {},
-    function(result)
-      vim.schedule(function()
-        if result.code ~= 0 then
-          cache[git_root] = nil
-          cb(nil)
-          return
-        end
-        local reported = {}
-        local statuses = parse_status(result.stdout or "", git_root, reported)
-        cache[git_root] = { statuses = statuses, reported = reported, ready = "ready" }
-        cb(statuses)
-      end)
-    end
-  )
+  if not cache[git_root] or not cache[git_root].statuses then
+    cache[git_root] = { ready = "loading" }
+  end
+  local slot = requests[git_root]
+  if not slot then
+    slot = { epoch = 0 }
+    requests[git_root] = slot
+  end
+  if slot.pending then
+    slot.pending.callbacks[#slot.pending.callbacks + 1] = cb
+    return
+  end
+  -- A request after process launch may follow a write that the running command has already missed.
+  slot.pending = { epoch = slot.epoch, callbacks = { cb } }
+  schedule_pending(git_root, slot)
 end
 
 ---Get cached git status (synchronous). Returns path→code map for backward compat.
@@ -175,7 +256,7 @@ end
 ---Get the readiness state of the git status cache for a root.
 ---Returns nil if status() has never been called for this root.
 ---@param root string
----@return "loading"|"ready"|"no_repo"|nil
+---@return "loading"|"ready"|"no_repo"|"error"|nil
 function M.get_status_ready(root)
   local git_root = find_git_root(root)
   if git_root then
@@ -193,6 +274,18 @@ function M.invalidate(root)
   local git_root = find_git_root(root)
   if git_root then
     cache[git_root] = nil
+    local slot = requests[git_root]
+    if slot then
+      slot.epoch = slot.epoch + 1
+      local pending = slot.pending
+      slot.pending = nil
+      if pending then
+        pending.finished = true
+        vim.schedule(function()
+          deliver(pending)
+        end)
+      end
+    end
   end
   -- Also clear the no_repo entry keyed under the input root path
   cache[root] = nil

--- a/lua/eda/init.lua
+++ b/lua/eda/init.lua
@@ -589,6 +589,11 @@ function M.open(opts)
       end
     end
 
+    if cfg_now.show_only_git_changes and git.get_status_ready(rp) == "error" then
+      cfg_now.show_only_git_changes = false
+      vim.notify("eda: git status unavailable, git changes filter disabled", vim.log.levels.WARN)
+    end
+
     -- Empty-state branch: "Git status loading..." when filter is on but status not yet ready
     -- (either still loading after git.status() was invoked, or not yet invoked = nil).
     -- Excludes "ready" and "no_repo" states.

--- a/tests/e2e/test_git.lua
+++ b/tests/e2e/test_git.lua
@@ -1175,4 +1175,185 @@ T["git"]["git status refreshes after renaming a file via buffer edit"] = functio
   )
 end
 
+T["git"]["initial status failure releases the changes filter and can recover"] = function()
+  e2e.exec(
+    child,
+    [[
+    _G.original_system = vim.system
+    _G.git_warnings = {}
+    vim.notify = function(message) _G.git_warnings[#_G.git_warnings + 1] = message end
+    vim.system = function(command, opts, callback)
+      if vim.tbl_contains(command, "status") then
+        vim.schedule(function() callback({ code = 128, stdout = "", stderr = "failed" }) end)
+        return { kill = function() end }
+      end
+      return _G.original_system(command, opts, callback)
+    end
+    require("eda").setup({ git = { enabled = true }, icon = { provider = "none" },
+      window = { kind = "split_left" }, header = false, show_only_git_changes = true })
+  ]]
+  )
+  e2e.open_eda(child, tmp)
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+    return require("eda.git").get_status_ready(%q) == "error"
+      and not require("eda.config").get().show_only_git_changes
+  ]],
+      tmp
+    )
+  )
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local text = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+    return text:find("tracked.txt", 1, true) ~= nil and text:find("loading", 1, true) == nil
+  ]]
+    ),
+    true
+  )
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local count = 0
+    for _, message in ipairs(_G.git_warnings) do
+      if message:find("git changes filter disabled", 1, true) then count = count + 1 end
+    end
+    return count
+  ]]
+    ),
+    1
+  )
+  e2e.exec(child, [[vim.system = _G.original_system; require("eda").refresh_all()]])
+  e2e.wait_until(child, string.format([[require("eda.git").get_status_ready(%q) == "ready"]], tmp))
+end
+
+T["git"]["refresh failure keeps the previous changes visible"] = function()
+  e2e.create_file(tmp .. "/untracked.txt", "untracked")
+  e2e.exec(
+    child,
+    [[
+    require("eda").setup({ git = { enabled = true }, icon = { provider = "none" },
+      window = { kind = "split_left" }, header = false, show_only_git_changes = true })
+  ]]
+  )
+  e2e.open_eda(child, tmp)
+  e2e.wait_until(child, string.format([[require("eda.git").get_status_ready(%q) == "ready"]], tmp))
+  e2e.wait_until(
+    child,
+    [[table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n"):find("untracked.txt", 1, true) ~= nil]]
+  )
+  e2e.exec(
+    child,
+    [[
+    local system = vim.system
+    vim.system = function(command, opts, callback)
+      if vim.tbl_contains(command, "status") then
+        _G.complete_status = callback
+        return { kill = function() end }
+      end
+      return system(command, opts, callback)
+    end
+    require("eda").refresh_all()
+  ]]
+  )
+  e2e.wait_until(child, "_G.complete_status ~= nil")
+  MiniTest.expect.equality(
+    e2e.exec(child, string.format([[return require("eda.git").get_status_ready(%q)]], tmp)),
+    "ready"
+  )
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    return table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n"):find("untracked.txt", 1, true) ~= nil
+  ]]
+    ),
+    true
+  )
+  e2e.exec(
+    child,
+    [[
+    _G.complete_status({ code = 128, stdout = "", stderr = "failed" })
+    vim.schedule(function() vim.schedule(function() _G.failed_refresh_done = true end) end)
+  ]]
+  )
+  e2e.wait_until(child, "_G.failed_refresh_done == true")
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      [[
+    local text = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+    return require("eda.config").get().show_only_git_changes
+      and text:find("untracked.txt", 1, true) ~= nil and text:find("loading", 1, true) == nil
+  ]]
+    ),
+    true
+  )
+end
+T["git"]["old-root status completion cannot disturb the new root"] = function()
+  local nested = tmp .. "/nested"
+  e2e.create_file(nested .. "/new.txt", "new")
+  e2e.create_git_repo(nested)
+  e2e.exec(
+    child,
+    [[
+    local system = vim.system
+    _G.git_jobs = {}
+    vim.system = function(command, opts, callback)
+      if vim.tbl_contains(command, "status") then
+        for i, arg in ipairs(command) do
+          if arg == "-C" then
+            local root = command[i + 1]
+            _G.git_jobs[root] = callback
+          end
+        end
+        return { kill = function() end }
+      end
+      return system(command, opts, callback)
+    end
+    require("eda").setup({ git = { enabled = true }, icon = { provider = "none" },
+      window = { kind = "split_left" }, header = false, show_only_git_changes = true })
+  ]]
+  )
+  e2e.open_eda(child, tmp)
+  e2e.wait_until(child, string.format("_G.git_jobs[%q] ~= nil", tmp))
+  e2e.exec(child, string.format([[require("eda")._change_root(require("eda").get_current(), %q)]], nested))
+  e2e.wait_until(child, string.format("_G.git_jobs[%q] ~= nil", nested))
+  e2e.exec(child, string.format([[_G.git_jobs[%q]({ code = 0, stdout = " M new.txt\0" })]], nested))
+  e2e.wait_until(child, string.format([[require("eda.git").get_status_ready(%q) == "ready"]], nested))
+  e2e.wait_for_path_in_snapshot(child, nested .. "/new.txt")
+  e2e.exec(
+    child,
+    string.format(
+      [[
+    _G.git_jobs[%q]({ code = 128, stdout = "" })
+    vim.schedule(function() vim.schedule(function() _G.old_root_done = true end) end)
+  ]],
+      tmp
+    )
+  )
+  e2e.wait_until(child, "_G.old_root_done == true")
+  MiniTest.expect.equality(
+    e2e.exec(
+      child,
+      string.format(
+        [[
+    local ex = require("eda").get_current()
+    local text = table.concat(vim.api.nvim_buf_get_lines(ex.buffer.bufnr, 0, -1, false), "\n")
+    return ex.root_path == %q and require("eda.config").get().show_only_git_changes
+      and require("eda.git").get_cached(%q)[%q] == "M"
+      and text:find("new.txt", 1, true) ~= nil and text:find("loading", 1, true) == nil
+  ]],
+        nested,
+        nested,
+        nested .. "/new.txt"
+      )
+    ),
+    true
+  )
+end
 return T

--- a/tests/git/test_requests.lua
+++ b/tests/git/test_requests.lua
@@ -1,0 +1,247 @@
+local git = require("eda.git")
+local helpers = require("helpers")
+local tmp, system, jobs, notified, notify
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+      helpers.create_dir(tmp .. "/.git")
+      helpers.create_dir(tmp .. "/nested")
+      git.invalidate(tmp)
+      jobs, notified = {}, {}
+      system, notify = vim.system, vim.notify
+      vim.notify = function(message)
+        notified[#notified + 1] = message
+      end
+      vim.system = function(command, opts, callback)
+        jobs[#jobs + 1] = { command = command, opts = opts, callback = callback }
+        return { kill = function() end }
+      end
+    end,
+    post_case = function()
+      git.invalidate(tmp)
+      vim.system, vim.notify = system, notify
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+local function wait_for(predicate)
+  MiniTest.expect.equality(helpers.wait_for(3000, predicate), true)
+end
+local function complete(index, output, code)
+  jobs[index].callback({ code = code or 0, stdout = output or "", stderr = "failed" })
+end
+T["batches same-tick equivalent requests and fans out one result"] = function()
+  local called = 0
+  for i = 1, 20 do
+    git.status(i % 2 == 0 and tmp .. "/nested" or tmp, function(value)
+      MiniTest.expect.equality(value[tmp .. "/new.txt"], "?")
+      called = called + 1
+    end)
+  end
+  wait_for(function()
+    return #jobs > 0
+  end)
+  MiniTest.expect.equality(#jobs, 1)
+  MiniTest.expect.equality(git.get_status_ready(tmp), "loading")
+  MiniTest.expect.equality(vim.tbl_contains(jobs[1].command, "--no-optional-locks"), true)
+  MiniTest.expect.equality(vim.tbl_contains(jobs[1].command, "-z"), true)
+  MiniTest.expect.equality(jobs[1].opts.text, nil)
+  complete(1, "?? new.txt\0")
+  wait_for(function()
+    return called == 20
+  end)
+  MiniTest.expect.equality(git.get_status_ready(tmp), "ready")
+end
+T["requests during an active command share one fresh follow-up"] = function()
+  local first, later = 0, 0
+  git.status(tmp, function(value)
+    MiniTest.expect.equality(value[tmp .. "/first"], "M")
+    first = first + 1
+  end)
+  wait_for(function()
+    return #jobs == 1
+  end)
+  for _ = 1, 10 do
+    git.status(tmp, function(value)
+      MiniTest.expect.equality(value[tmp .. "/later"], "?")
+      later = later + 1
+    end)
+  end
+  MiniTest.expect.equality(#jobs, 1)
+  complete(1, " M first\0")
+  wait_for(function()
+    return #jobs == 2
+  end)
+  MiniTest.expect.equality(first, 1)
+  MiniTest.expect.equality(later, 0)
+  MiniTest.expect.equality(git.get_cached(tmp)[tmp .. "/first"], "M")
+  MiniTest.expect.equality(git.get_status_ready(tmp), "ready")
+  complete(2, "?? later\0")
+  wait_for(function()
+    return later == 10
+  end)
+  MiniTest.expect.equality(#jobs, 2)
+end
+T["invalidation rejects an active result and serializes a newer request"] = function()
+  local old, fresh = 0, 0
+  git.status(tmp, function(value)
+    MiniTest.expect.equality(value, nil)
+    old = old + 1
+  end)
+  wait_for(function()
+    return #jobs == 1
+  end)
+  git.invalidate(tmp)
+  git.status(tmp, function(value)
+    MiniTest.expect.equality(value[tmp .. "/fresh"], "M")
+    fresh = fresh + 1
+  end)
+  MiniTest.expect.equality(#jobs, 1)
+  complete(1, "?? stale\0")
+  wait_for(function()
+    return #jobs == 2
+  end)
+  MiniTest.expect.equality(old, 1)
+  MiniTest.expect.equality(git.get_cached(tmp), nil)
+  complete(2, " M fresh\0")
+  wait_for(function()
+    return fresh == 1
+  end)
+  complete(1, "?? stale\0")
+  complete(2, "?? duplicate\0")
+  vim.schedule(function()
+    fresh = fresh + 10
+  end)
+  wait_for(function()
+    return fresh == 11
+  end)
+  MiniTest.expect.equality(old, 1)
+  MiniTest.expect.equality(git.get_cached(tmp), { [tmp .. "/fresh"] = "M" })
+end
+T["invalidation without another request settles subscribers without restoring cache"] = function()
+  local called = 0
+  git.status(tmp, function(value)
+    MiniTest.expect.equality(value, nil)
+    called = called + 1
+  end)
+  wait_for(function()
+    return #jobs == 1
+  end)
+  git.invalidate(tmp)
+  complete(1, "?? stale\0")
+  wait_for(function()
+    return called == 1
+  end)
+  MiniTest.expect.equality(git.get_cached(tmp), nil)
+  MiniTest.expect.equality(git.get_status_ready(tmp), nil)
+end
+T["invalidation cancels a scheduled request before subprocess creation"] = function()
+  local called = 0
+  git.status(tmp, function(value)
+    MiniTest.expect.equality(value, nil)
+    called = called + 1
+  end)
+  git.invalidate(tmp)
+  wait_for(function()
+    return called == 1
+  end)
+  MiniTest.expect.equality(#jobs, 0)
+end
+T["first-load failure is terminal and refresh failure retains usable data"] = function()
+  local called = 0
+  local function callback()
+    called = called + 1
+  end
+  git.status(tmp, callback)
+  wait_for(function()
+    return #jobs == 1
+  end)
+  complete(1, "", 128)
+  wait_for(function()
+    return called == 1
+  end)
+  MiniTest.expect.equality(git.get_status_ready(tmp), "error")
+  git.status(tmp, callback)
+  wait_for(function()
+    return #jobs == 2
+  end)
+  complete(2, " M known\0")
+  wait_for(function()
+    return called == 2
+  end)
+  git.status(tmp, callback)
+  wait_for(function()
+    return #jobs == 3
+  end)
+  MiniTest.expect.equality(git.get_status_ready(tmp), "ready")
+  MiniTest.expect.equality(git.get_cached(tmp)[tmp .. "/known"], "M")
+  complete(3, "", 128)
+  wait_for(function()
+    return called == 3
+  end)
+  MiniTest.expect.equality(git.get_status_ready(tmp), "ready")
+  MiniTest.expect.equality(git.get_cached(tmp)[tmp .. "/known"], "M")
+end
+T["submission failure settles all batched callbacks"] = function()
+  vim.system = function()
+    error("spawn failed")
+  end
+  local called = 0
+  for _ = 1, 4 do
+    git.status(tmp, function(value)
+      MiniTest.expect.equality(value, nil)
+      called = called + 1
+    end)
+  end
+  wait_for(function()
+    return called == 4
+  end)
+  MiniTest.expect.equality(git.get_status_ready(tmp), "error")
+end
+T["one failing subscriber does not strand other subscribers or reentrant requests"] = function()
+  local called = 0
+  git.status(tmp, function()
+    error("observer failed")
+  end)
+  git.status(tmp, function()
+    called = called + 1
+    git.status(tmp, function()
+      called = called + 1
+    end)
+  end)
+  wait_for(function()
+    return #jobs == 1
+  end)
+  complete(1, "?? one\0")
+  wait_for(function()
+    return #jobs == 2 and #notified == 1
+  end)
+  complete(2, "?? two\0")
+  wait_for(function()
+    return called == 2
+  end)
+end
+T["different repositories can finish in reverse order"] = function()
+  helpers.create_dir(tmp .. "/nested/.git")
+  git.invalidate(tmp .. "/nested")
+  local called = 0
+  git.status(tmp, function()
+    called = called + 1
+  end)
+  git.status(tmp .. "/nested", function()
+    called = called + 1
+  end)
+  wait_for(function()
+    return #jobs == 2
+  end)
+  complete(2, "?? nested-file\0")
+  complete(1, " M root-file\0")
+  wait_for(function()
+    return called == 2
+  end)
+  MiniTest.expect.equality(git.get_cached(tmp), { [tmp .. "/root-file"] = "M" })
+  MiniTest.expect.equality(git.get_cached(tmp .. "/nested"), { [tmp .. "/nested/nested-file"] = "?" })
+  git.invalidate(tmp .. "/nested")
+end
+return T


### PR DESCRIPTION
## Summary

Overlapping Git status requests could overwrite newer cached results and erase usable status while refreshing. Coordinate requests per repository with one active process and one coalesced follow-up round. Batch requests before launch, retain successful cached data, reject invalidated/duplicate completions, and settle every subscriber even when another callback throws. Requests arriving after launch receive a fresh round so later writes are included. Background status commands preserve raw NUL-delimited parsing and avoid optional index locks.

A failed first request now releases the Git-changes filter with a warning; refresh retries it. A failed later request keeps the last successful status visible. Guard mutation-triggered refresh callbacks against root changes.

The reproducible three-explorer / 25-save benchmark reduced peak concurrent Git processes from 3 to 1 and mean launches from 3 to 2.2. Completion after the last save increased from 162 ms to 179 ms: serialization lowers overlapping work but adds latency in this workload. The benchmark documentation records all five samples' counts, variability, and measurement limits.

Validation: formatting, lint, type checks, 861 unit tests, and 237 E2E tests, followed by all 23 Git E2E cases including the additional root-change regression (238 E2E cases in the final suite). Nightly passed nine request-coordinator unit cases and all 23 Git E2E cases. Regenerated vimdoc. Self-reviewed ownership, invalidation, callback fan-out/reentrancy, failure/readiness consumers, root-change callbacks, and benchmark accounting.

Closes #69.
