### PR TITLE
fix: honor the large directory warning threshold

### DIFF
--- a/doc/eda.md
+++ b/doc/eda.md
@@ -346,8 +346,15 @@ Broken symlinks show `EdaBrokenSymlink` highlight but no target suffix.
 
 `integer` (default: `5000`)
 
-When a directory contains more entries than this threshold, eda.nvim shows
-a warning before scanning.
+Warn when a directory contains strictly more entries than this threshold.
+Set to `0` to disable warnings; other values must be positive integers.
+
+The count includes all immediate filesystem entries, including hidden and ignored
+entries, before visibility filtering. Each symlink counts once; descendants are
+not included. The warning appears after asynchronous directory enumeration
+completes, before filtering and symlink resolution. Scanning continues normally.
+Each directory path warns at most once per Neovim session, including across
+refreshes, multiple explorers, and closing/reopening the explorer.
 
 ### expand_depth
 

--- a/doc/eda.nvim.txt
+++ b/doc/eda.nvim.txt
@@ -372,8 +372,16 @@ LARGE_DIR_THRESHOLD ~
 
 `integer` (default: `5000`)
 
-When a directory contains more entries than this threshold, eda.nvim shows a
-warning before scanning.
+Warn when a directory contains strictly more entries than this threshold. Set
+to `0` to disable warnings; other values must be positive integers.
+
+The count includes all immediate filesystem entries, including hidden and
+ignored entries, before visibility filtering. Each symlink counts once;
+descendants are not included. The warning appears after asynchronous directory
+enumeration completes, before filtering and symlink resolution. Scanning
+continues normally. Each directory path warns at most once per Neovim session,
+including across refreshes, multiple explorers, and closing/reopening the
+explorer.
 
 
 EXPAND_DEPTH ~

--- a/lua/eda/config.lua
+++ b/lua/eda/config.lua
@@ -368,6 +368,10 @@ end
 ---Setup configuration with user options.
 ---@param opts? table
 function M.setup(opts)
+  local threshold = opts and opts.large_dir_threshold
+  if threshold ~= nil and (type(threshold) ~= "number" or threshold < 0 or threshold % 1 ~= 0) then
+    error("eda: large_dir_threshold must be a non-negative integer", 2)
+  end
   if opts then
     if opts.default_mappings == false then
       local base = vim.deepcopy(defaults)

--- a/lua/eda/tree/scanner.lua
+++ b/lua/eda/tree/scanner.lua
@@ -1,6 +1,10 @@
 local Node = require("eda.tree.node")
 local Metadata = require("eda.tree.metadata")
 
+-- Refreshes create new scanners, so instance-local warning state would repeat on every rescan.
+---@type table<string, true>
+local warned_directories = {}
+
 ---@class eda.ScanIdentity
 ---@field node eda.TreeNode
 ---@field root eda.TreeNode?
@@ -201,6 +205,14 @@ function Scanner:_do_scan_io(node_id, callback, gen, identity)
           elseif read_err then
             finish(read_err)
           else
+            local threshold = self.config.large_dir_threshold or 5000
+            if threshold > 0 and #entries > threshold and not warned_directories[path] then
+              warned_directories[path] = true
+              vim.notify(
+                string.format("eda: %s contains %d entries (large_dir_threshold = %d)", path, #entries, threshold),
+                vim.log.levels.WARN
+              )
+            end
             self:_apply_entries(node_id, entries, finish, valid)
           end
         end)

--- a/tests/e2e/test_large_directory.lua
+++ b/tests/e2e/test_large_directory.lua
@@ -1,0 +1,72 @@
+local e2e = require("e2e.helpers")
+local child, tmp
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child = e2e.spawn()
+      tmp = vim.uv.fs_realpath(e2e.create_temp_dir())
+      for i = 1, 3 do
+        e2e.create_file(tmp .. "/file" .. i, "file")
+      end
+      e2e.setup_eda(child)
+      e2e.exec(
+        child,
+        [[
+      require("eda.config").get().large_dir_threshold = 2
+      _G.large_warnings, _G.scans = {}, 0
+      vim.notify = function(message)
+        if message:find("large_dir_threshold", 1, true) then
+          table.insert(_G.large_warnings, message)
+        end
+      end
+      local Scanner = require("eda.tree.scanner")
+      local scan = Scanner.scan
+      Scanner.scan = function(self, id, callback)
+        return scan(self, id, function(...)
+          _G.scans = _G.scans + 1
+          callback(...)
+        end)
+      end
+    ]]
+      )
+    end,
+    post_case = function()
+      e2e.stop(child)
+      e2e.remove_temp_dir(tmp)
+    end,
+  },
+})
+T["watcher refreshes, manual refresh, and reopening warn once for the session"] = function()
+  e2e.open_eda(child, tmp)
+  e2e.wait_until(child, "#_G.large_warnings == 1")
+  for i = 1, 2 do
+    local path = tmp .. "/added" .. i
+    e2e.create_file(path, "added")
+    e2e.wait_for_path_in_snapshot(child, path)
+    e2e.wait_until(
+      child,
+      [[
+      local refresh = require("eda").get_current().refresh
+      return not refresh.pending and not refresh.running
+    ]]
+    )
+    MiniTest.expect.equality(e2e.exec(child, "return #_G.large_warnings"), 1)
+  end
+  local before = e2e.exec(child, "return _G.scans")
+  e2e.exec(child, [[require("eda").refresh_all()]])
+  e2e.wait_until(
+    child,
+    string.format(
+      [[
+    local refresh = require("eda").get_current().refresh
+    return _G.scans > %d and not refresh.pending and not refresh.running
+  ]],
+      before
+    )
+  )
+  e2e.exec(child, [[require("eda").close()]])
+  e2e.open_eda(child, tmp)
+  e2e.wait_for_path_in_snapshot(child, tmp .. "/added2")
+  MiniTest.expect.equality(e2e.exec(child, "return #_G.large_warnings"), 1)
+end
+return T

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -7,6 +7,9 @@ T["setup"] = MiniTest.new_set({
     pre_case = function()
       config.setup()
     end,
+    post_case = function()
+      config.setup()
+    end,
   },
 })
 
@@ -273,4 +276,24 @@ T["get"]["returns config table"] = function()
   MiniTest.expect.equality(type(c.root_markers), "table")
 end
 
+T["setup"]["large directory threshold accepts zero and positive integers"] = function()
+  MiniTest.expect.equality(config.get().large_dir_threshold, 5000)
+  for _, value in ipairs({ 0, 1, 5000 }) do
+    config.setup({ large_dir_threshold = value })
+    MiniTest.expect.equality(config.get().large_dir_threshold, value)
+  end
+end
+T["setup"]["invalid large directory thresholds leave the previous config intact"] = function()
+  config.setup({ large_dir_threshold = 7 })
+  local previous = config.get()
+  for _, value in ipairs({ -1, 0.5, "10", false, {}, math.huge, 0 / 0 }) do
+    local ok, err = pcall(config.setup, { large_dir_threshold = value })
+    MiniTest.expect.equality(ok, false)
+    MiniTest.expect.equality(
+      tostring(err):find("large_dir_threshold must be a non-negative integer", 1, true) ~= nil,
+      true
+    )
+    MiniTest.expect.equality(config.get() == previous, true)
+  end
+end
 return T

--- a/tests/tree/test_large_directory.lua
+++ b/tests/tree/test_large_directory.lua
@@ -1,0 +1,133 @@
+local Store = require("eda.tree.store")
+local Scanner = require("eda.tree.scanner")
+local helpers = require("helpers")
+local tmp, notify, warnings, scanners
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmp = vim.uv.fs_realpath(helpers.create_temp_dir())
+      warnings, scanners = {}, {}
+      notify = vim.notify
+      vim.notify = function(message, level)
+        warnings[#warnings + 1] = { message = message, level = level }
+      end
+    end,
+    post_case = function()
+      for _, scanner in ipairs(scanners) do
+        scanner:dispose()
+      end
+      vim.notify = notify
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+local function new_scanner(opts)
+  local store = Store.new()
+  store:set_root(tmp)
+  local scanner = Scanner.new(store, opts)
+  scanners[#scanners + 1] = scanner
+  return scanner, store
+end
+local function scan(scanner, id)
+  local done, failure = false, nil
+  scanner:scan(id, function(err)
+    done, failure = true, err
+  end)
+  MiniTest.expect.equality(
+    helpers.wait_for(3000, function()
+      return done
+    end),
+    true
+  )
+  MiniTest.expect.equality(failure, nil)
+end
+for _, nested in ipairs({ false, true }) do
+  for count = 2, 4 do
+    T[(nested and "nested" or "root") .. " directory with " .. count .. " entries at threshold 3"] = function()
+      local path = nested and tmp .. "/nested" or tmp
+      helpers.create_dir(path)
+      for i = 1, count do
+        helpers.create_file(path .. "/file" .. i, "file")
+      end
+      local scanner, store = new_scanner({ large_dir_threshold = 3 })
+      scan(scanner, store.root_id)
+      local node = store:get_by_path(path)
+      if nested then
+        scan(scanner, node.id)
+      end
+      MiniTest.expect.equality(#store:children(node.id), count)
+      MiniTest.expect.equality(#warnings, count > 3 and 1 or 0)
+      if count > 3 then
+        MiniTest.expect.equality(warnings[1], {
+          message = "eda: " .. path .. " contains 4 entries (large_dir_threshold = 3)",
+          level = vim.log.levels.WARN,
+        })
+      end
+    end
+  end
+end
+T["counts raw immediate entries before filtering and resolves no descendants"] = function()
+  helpers.create_file(tmp .. "/.hidden", "hidden")
+  helpers.create_file(tmp .. "/ignored", "ignored")
+  helpers.create_file(tmp .. "/directory/child", "child")
+  assert(vim.uv.fs_symlink(tmp .. "/directory", tmp .. "/link"))
+  local scanner, store =
+    new_scanner({ large_dir_threshold = 3, show_hidden = false, ignore_patterns = { "^ignored$" } })
+  local done = false
+  scanner:scan(store.root_id, function(err)
+    MiniTest.expect.equality(err, nil)
+    done = true
+  end)
+  MiniTest.expect.equality(#warnings, 0)
+  MiniTest.expect.equality(done, false)
+  MiniTest.expect.equality(
+    helpers.wait_for(3000, function()
+      return done
+    end),
+    true
+  )
+  MiniTest.expect.equality(#warnings, 1)
+  MiniTest.expect.equality(warnings[1].message, "eda: " .. tmp .. " contains 4 entries (large_dir_threshold = 3)")
+  MiniTest.expect.equality(#store:children(store.root_id), 2)
+  MiniTest.expect.equality(store:get_by_path(tmp .. "/directory/child"), nil)
+end
+T["deduplicates warnings across rescans and replacement scanners"] = function()
+  helpers.create_file(tmp .. "/one", "one")
+  helpers.create_file(tmp .. "/two", "two")
+  local scanner, store = new_scanner({ large_dir_threshold = 1 })
+  scan(scanner, store.root_id)
+  scan(scanner, store.root_id)
+  scanner:dispose()
+  local replacement, replacement_store = new_scanner({ large_dir_threshold = 1 })
+  scan(replacement, replacement_store.root_id)
+  MiniTest.expect.equality(#warnings, 1)
+end
+T["zero disables warnings without suppressing scanning"] = function()
+  helpers.create_file(tmp .. "/one", "one")
+  local scanner, store = new_scanner({ large_dir_threshold = 0 })
+  scan(scanner, store.root_id)
+  MiniTest.expect.equality(#warnings, 0)
+  MiniTest.expect.equality(#store:children(store.root_id), 1)
+end
+T["cancelled enumeration neither warns nor consumes the later warning"] = function()
+  helpers.create_file(tmp .. "/one", "one")
+  helpers.create_file(tmp .. "/two", "two")
+  local scanner, store = new_scanner({ large_dir_threshold = 1 })
+  local done, failure = false, nil
+  scanner:scan(store.root_id, function(err)
+    done, failure = true, err
+  end)
+  scanner:dispose()
+  MiniTest.expect.equality(
+    helpers.wait_for(3000, function()
+      return done
+    end),
+    true
+  )
+  MiniTest.expect.equality(failure, "scan cancelled")
+  MiniTest.expect.equality(#warnings, 0)
+  local replacement, replacement_store = new_scanner({ large_dir_threshold = 1 })
+  scan(replacement, replacement_store.root_id)
+  MiniTest.expect.equality(#warnings, 1)
+end
+return T


### PR DESCRIPTION
## Summary

`large_dir_threshold` was configurable but had no effect. Warn when asynchronous enumeration finds strictly more immediate entries than the threshold, before filtering or symlink resolution. Count hidden/ignored entries and each symlink once; scanning continues normally. Suppress repeated warnings for the same path throughout the Neovim session, including candidate refresh scanners and reopened explorers.

Support zero to disable warnings and positive integers to enable them. Reject invalid values before replacing the current configuration. Document count, timing, and session-wide suppression; regenerate vimdoc.

Validation: formatting, lint, type checks, 873 unit tests and 239 E2E tests. Ten scanner cases cover root/nested boundaries, raw filtered counts, asynchronous completion, replacement scanners, disabling, and cancellation. A real filesystem-watcher E2E case covers repeated refreshes and reopening. All 45 focused scanner/config cases and the new E2E case also pass on nightly. Self-reviewed owner validation, warning timing, candidate-scanner lifecycle, and configuration/test isolation.

Closes #70.
