### PR TITLE
docs: fix the terminal action recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,9 +496,11 @@ See [`:help eda-api`](doc/eda.nvim.txt) for the full public API, including the `
 #### Example: open a terminal in the directory under the cursor
 
 ```lua
+local action = require("eda.action")
+
 action.register("open_terminal", function(ctx)
   local node = ctx.buffer:get_cursor_node(ctx.window.winid)
-  local dir = node and node.is_dir and node.path
+  local dir = node and node.type == "directory" and node.path
     or node and vim.fn.fnamemodify(node.path, ":h")
     or ctx.explorer.root_path
   vim.cmd("split | terminal")


### PR DESCRIPTION
The terminal action recipe checked a nonexistent `node.is_dir` field, so selecting a directory opened its parent. Use `node.type == "directory"` and define the action module inside the code block so it works independently.

Validation: extracted and executed the exact README block in headless Neovim; checked directory, file-parent, and missing-node fallbacks, shell escaping with spaces/apostrophes, and the working directory of a real terminal started by the action. The original block failed both standalone execution and directory selection. Self-reviewed precedence and duplicate recipes; there is no duplicate in help.

Closes #71.
