### PR TITLE
fix: verify filesystem outcomes and preserve symlink targets

### DIFF
--- a/lua/eda/fs.lua
+++ b/lua/eda/fs.lua
@@ -42,7 +42,18 @@ end
 ---@param cb fun(err?: string)
 function M.delete(path, cb)
   vim.schedule(function()
-    local ok, err = pcall(vim.fs.rm, path, { recursive = true, force = true })
+    local ok, err = pcall(function()
+      -- Neovim 0.11's vim.fs.rm follows a top-level symlink and can delete its target's contents.
+      local stat = vim.uv.fs_lstat(path)
+      if stat and stat.type == "link" then
+        local removed, unlink_err, code = vim.uv.fs_unlink(path)
+        if not removed and code ~= "ENOENT" then
+          error(unlink_err)
+        end
+      else
+        vim.fs.rm(path, { recursive = true, force = true })
+      end
+    end)
     if not ok then
       cb("Failed to delete: " .. (err or path))
     else

--- a/tests/test_fs.lua
+++ b/tests/test_fs.lua
@@ -1,38 +1,74 @@
 local Fs = require("eda.fs")
 local helpers = require("helpers")
 
-local T = MiniTest.new_set()
+local tmpdir
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      tmpdir = helpers.create_temp_dir()
+    end,
+    post_case = function()
+      helpers.remove_temp_dir(tmpdir)
+    end,
+  },
+})
 
-local function create_and_wait(path, is_dir)
-  local done, result = false, nil
-  Fs.create(path, is_dir, function(err)
-    result = err
-    done = true
+local function await_callback(start)
+  local calls, result, fast = 0, nil, false
+  start(function(value)
+    calls, result = calls + 1, value
+    fast = fast or vim.in_fast_event()
   end)
-  helpers.wait_for(3000, function()
-    return done
+  MiniTest.expect.equality(
+    helpers.wait_for(5000, function()
+      return calls > 0
+    end),
+    true
+  )
+  local drained = false
+  vim.schedule(function()
+    drained = true
   end)
+  MiniTest.expect.equality(
+    helpers.wait_for(5000, function()
+      return drained
+    end),
+    true
+  )
+  MiniTest.expect.equality(calls, 1)
+  MiniTest.expect.equality(fast, false)
   return result
 end
 
+local function create_and_wait(path, is_dir)
+  return await_callback(function(cb)
+    Fs.create(path, is_dir, cb)
+  end)
+end
+
+local function read_bytes(path)
+  local file = assert(io.open(path, "rb"))
+  local contents = file:read("*a")
+  file:close()
+  return contents
+end
+
 T["create rejects an existing file without changing its contents"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   local path = dir .. "/keep.txt"
   helpers.create_file(path, "keep this content")
   MiniTest.expect.equality(type(create_and_wait(path, false)), "string")
   MiniTest.expect.equality(vim.fn.readfile(path), { "keep this content" })
-  helpers.remove_temp_dir(dir)
 end
 
 T["create rejects an existing directory"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   MiniTest.expect.equality(type(create_and_wait(dir, true)), "string")
   MiniTest.expect.equality(vim.fn.isdirectory(dir), 1)
-  helpers.remove_temp_dir(dir)
 end
 
 T["create rejects valid and broken symlink destinations"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   local target = dir .. "/target.txt"
   helpers.create_file(target, "keep target")
   for _, source in ipairs({ target, dir .. "/missing.txt" }) do
@@ -43,197 +79,226 @@ T["create rejects valid and broken symlink destinations"] = function()
   end
   MiniTest.expect.equality(vim.fn.readfile(target), { "keep target" })
   MiniTest.expect.equality(vim.uv.fs_stat(dir .. "/missing.txt"), nil)
-  helpers.remove_temp_dir(dir)
 end
 
 T["create protects a file appearing after preflight"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   local path = dir .. "/race.txt"
   local operations = { { type = "create", path = path, entry_type = "file" } }
   local store = require("eda.tree.store").new()
   store:set_root(dir)
   MiniTest.expect.equality(require("eda.tree.diff").validate(operations, store).valid, true)
   helpers.create_file(path, "external writer")
-  local result
-  Fs.execute_operations(operations, { delete_to_trash = false }, function(value)
-    result = value
-  end)
-  helpers.wait_for(3000, function()
-    return result ~= nil
+  local result = await_callback(function(cb)
+    Fs.execute_operations(operations, { delete_to_trash = false }, cb)
   end)
   MiniTest.expect.equality(#result.completed, 0)
   MiniTest.expect.equality(type(result.error), "string")
   MiniTest.expect.equality(vim.fn.readfile(path), { "external writer" })
-  helpers.remove_temp_dir(dir)
 end
 
 T["create makes missing parents for exclusive files and directories"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   MiniTest.expect.equality(create_and_wait(dir .. "/a/b/file.txt", false), nil)
   MiniTest.expect.equality(create_and_wait(dir .. "/c/d/nested", true), nil)
   MiniTest.expect.equality(vim.fn.filereadable(dir .. "/a/b/file.txt"), 1)
   MiniTest.expect.equality(vim.fn.isdirectory(dir .. "/c/d/nested"), 1)
-  helpers.remove_temp_dir(dir)
 end
 
 T["create preserves filesystem resolution through symlink parents"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   helpers.create_dir(dir .. "/real/nested")
   assert(vim.uv.fs_symlink(dir .. "/real/nested", dir .. "/link"))
   MiniTest.expect.equality(create_and_wait(dir .. "/link/../file.txt", false), nil)
   MiniTest.expect.equality(vim.fn.filereadable(dir .. "/real/file.txt"), 1)
   MiniTest.expect.equality(vim.fn.filereadable(dir .. "/file.txt"), 0)
-  helpers.remove_temp_dir(dir)
 end
 
 T["create reports parent errors through its callback"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   helpers.create_file(dir .. "/parent", "not a directory")
   MiniTest.expect.equality(type(create_and_wait(dir .. "/parent/file.txt", false)), "string")
   MiniTest.expect.equality(vim.fn.readfile(dir .. "/parent"), { "not a directory" })
-  helpers.remove_temp_dir(dir)
-end
-
-T["execute_operations module loads"] = function()
-  MiniTest.expect.equality(type(Fs.create), "function")
-  MiniTest.expect.equality(type(Fs.delete), "function")
-  MiniTest.expect.equality(type(Fs.move), "function")
-  MiniTest.expect.equality(type(Fs.copy), "function")
-  MiniTest.expect.equality(type(Fs.trash), "function")
-  MiniTest.expect.equality(type(Fs.execute_operations), "function")
 end
 
 T["create file"] = function()
-  local tmpdir = helpers.create_temp_dir()
   local path = tmpdir .. "/test.lua"
-
-  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
-  local f = io.open(path, "w")
-  if f then
-    f:write("")
-    f:close()
-  end
-
-  MiniTest.expect.equality(vim.fn.filereadable(path), 1)
-  helpers.remove_temp_dir(tmpdir)
+  MiniTest.expect.equality(create_and_wait(path, false), nil)
+  MiniTest.expect.equality(read_bytes(path), "")
 end
 
 T["create nested file with auto-mkdir"] = function()
-  local tmpdir = helpers.create_temp_dir()
   local path = tmpdir .. "/a/b/c/nested.lua"
-
-  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
-  local f = io.open(path, "w")
-  if f then
-    f:write("")
-    f:close()
-  end
-
-  MiniTest.expect.equality(vim.fn.filereadable(path), 1)
+  MiniTest.expect.equality(create_and_wait(path, false), nil)
+  MiniTest.expect.equality(read_bytes(path), "")
   MiniTest.expect.equality(vim.fn.isdirectory(tmpdir .. "/a/b/c"), 1)
-  helpers.remove_temp_dir(tmpdir)
 end
 
-T["create directory"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local path = tmpdir .. "/new_dir"
-
-  vim.fn.mkdir(path, "p")
-  MiniTest.expect.equality(vim.fn.isdirectory(path), 1)
-  helpers.remove_temp_dir(tmpdir)
-end
-
-T["create nested directory"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local path = tmpdir .. "/x/y/z"
-
-  vim.fn.mkdir(path, "p")
-  MiniTest.expect.equality(vim.fn.isdirectory(path), 1)
-  helpers.remove_temp_dir(tmpdir)
+for _, name in ipairs({ "new_dir", "x/y/z" }) do
+  T["create directory " .. name] = function()
+    local path = tmpdir .. "/" .. name
+    MiniTest.expect.equality(create_and_wait(path, true), nil)
+    MiniTest.expect.equality(vim.fn.isdirectory(path), 1)
+    MiniTest.expect.equality(vim.fn.readdir(path), {})
+  end
 end
 
 T["delete file"] = function()
-  local tmpdir = helpers.create_temp_dir()
   local path = tmpdir .. "/to_delete.lua"
   helpers.create_file(path, "delete me")
-
-  vim.fn.delete(path)
-  MiniTest.expect.equality(vim.fn.filereadable(path), 0)
-  helpers.remove_temp_dir(tmpdir)
+  helpers.create_file(tmpdir .. "/keep", "KEEP")
+  MiniTest.expect.equality(
+    await_callback(function(cb)
+      Fs.delete(path, cb)
+    end),
+    nil
+  )
+  MiniTest.expect.equality(vim.uv.fs_lstat(path), nil)
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/keep"), "KEEP")
 end
 
 T["delete directory recursively"] = function()
-  local tmpdir = helpers.create_temp_dir()
   local dir = tmpdir .. "/dir_to_delete"
-  helpers.create_dir(dir)
   helpers.create_file(dir .. "/child.txt", "content")
-
-  vim.fn.delete(dir, "rf")
-  MiniTest.expect.equality(vim.fn.isdirectory(dir), 0)
-  helpers.remove_temp_dir(tmpdir)
+  helpers.create_file(dir .. "/nested/.hidden", "hidden")
+  helpers.create_file(tmpdir .. "/keep", "KEEP")
+  MiniTest.expect.equality(
+    await_callback(function(cb)
+      Fs.delete(dir, cb)
+    end),
+    nil
+  )
+  MiniTest.expect.equality(vim.uv.fs_lstat(dir), nil)
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/keep"), "KEEP")
 end
 
-T["move/rename file"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local src = tmpdir .. "/old.lua"
-  local dst = tmpdir .. "/new.lua"
-  helpers.create_file(src, "content")
-
-  vim.fn.rename(src, dst)
-  MiniTest.expect.equality(vim.fn.filereadable(src), 0)
-  MiniTest.expect.equality(vim.fn.filereadable(dst), 1)
-  helpers.remove_temp_dir(tmpdir)
+for _, target in ipairs({ "target", "target/keep", "missing" }) do
+  T["delete symlink to " .. target .. " preserves target contents"] = function()
+    helpers.create_file(tmpdir .. "/target/keep", "KEEP")
+    assert(vim.uv.fs_symlink(tmpdir .. "/" .. target, tmpdir .. "/link"))
+    local err = await_callback(function(cb)
+      Fs.delete(tmpdir .. "/link", cb)
+    end)
+    MiniTest.expect.equality(read_bytes(tmpdir .. "/target/keep"), "KEEP")
+    MiniTest.expect.equality(vim.uv.fs_lstat(tmpdir .. "/missing"), nil)
+    MiniTest.expect.equality(vim.uv.fs_lstat(tmpdir .. "/link"), nil)
+    MiniTest.expect.equality(err, nil)
+  end
 end
 
-T["move creates parent directory if needed"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local src = tmpdir .. "/src.txt"
-  local dst = tmpdir .. "/sub/dir/dst.txt"
-  helpers.create_file(src, "content")
-
-  vim.fn.mkdir(vim.fn.fnamemodify(dst, ":h"), "p")
-  vim.fn.rename(src, dst)
-  MiniTest.expect.equality(vim.fn.filereadable(dst), 1)
-  helpers.remove_temp_dir(tmpdir)
-end
-
-T["copy file via uv"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local src = tmpdir .. "/original.lua"
-  local dst = tmpdir .. "/copy.lua"
-  helpers.create_file(src, "original content")
-
-  local done = false
-  vim.uv.fs_copyfile(src, dst, function()
-    done = true
+T["delete directory leaves nested symlink targets intact"] = function()
+  helpers.create_file(tmpdir .. "/target/keep", "KEEP")
+  helpers.create_file(tmpdir .. "/remove/nested/file", "DELETE")
+  assert(vim.uv.fs_symlink(tmpdir .. "/target", tmpdir .. "/remove/nested/link"))
+  local err = await_callback(function(cb)
+    Fs.delete(tmpdir .. "/remove", cb)
   end)
-  helpers.wait_for(3000, function()
-    return done
-  end)
-
-  MiniTest.expect.equality(vim.fn.filereadable(src), 1)
-  MiniTest.expect.equality(vim.fn.filereadable(dst), 1)
-  helpers.remove_temp_dir(tmpdir)
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/target/keep"), "KEEP")
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmpdir .. "/remove"), nil)
+  MiniTest.expect.equality(err, nil)
 end
 
-T["copy directory recursively"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local src = tmpdir .. "/dir_src"
-  local dst = tmpdir .. "/dir_dst"
-  helpers.create_dir(src)
-  helpers.create_file(src .. "/a.txt", "a")
-  helpers.create_dir(src .. "/sub")
-  helpers.create_file(src .. "/sub/b.txt", "b")
+T["delete reports unlink failure and retains the link and target"] = function()
+  helpers.create_file(tmpdir .. "/target", "KEEP")
+  assert(vim.uv.fs_symlink("target", tmpdir .. "/link"))
+  local unlink = vim.uv.fs_unlink
+  vim.uv.fs_unlink = function()
+    return nil, "EACCES: injected unlink failure"
+  end
+  local ok, err = pcall(await_callback, function(cb)
+    Fs.delete(tmpdir .. "/link", cb)
+  end)
+  vim.uv.fs_unlink = unlink
+  assert(ok, err)
+  MiniTest.expect.equality(type(err), "string")
+  MiniTest.expect.equality(err:find("EACCES", 1, true) ~= nil, true)
+  MiniTest.expect.equality(vim.uv.fs_readlink(tmpdir .. "/link"), "target")
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/target"), "KEEP")
+end
 
-  vim.fn.system({ "cp", "-R", src, dst })
-  MiniTest.expect.equality(vim.fn.isdirectory(dst), 1)
-  MiniTest.expect.equality(vim.fn.filereadable(dst .. "/a.txt"), 1)
-  MiniTest.expect.equality(vim.fn.filereadable(dst .. "/sub/b.txt"), 1)
-  helpers.remove_temp_dir(tmpdir)
+T["delete missing path succeeds without changing its neighbors"] = function()
+  helpers.create_file(tmpdir .. "/keep", "KEEP")
+  MiniTest.expect.equality(
+    await_callback(function(cb)
+      Fs.delete(tmpdir .. "/missing", cb)
+    end),
+    nil
+  )
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmpdir .. "/missing"), nil)
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/keep"), "KEEP")
+end
+
+for _, operation in ipairs({ "move", "copy" }) do
+  for _, destination in ipairs({ "new file's.bin", "sub/dir/new file's.bin" }) do
+    T[operation .. " preserves file bytes at " .. destination] = function()
+      local src, dst = tmpdir .. "/source file's.bin", tmpdir .. "/" .. destination
+      local contents = "first\0second\nlast\255"
+      helpers.create_file(src, contents)
+      MiniTest.expect.equality(
+        await_callback(function(cb)
+          Fs[operation](src, dst, cb)
+        end),
+        nil
+      )
+      MiniTest.expect.equality(read_bytes(dst), contents)
+      if operation == "copy" then
+        MiniTest.expect.equality(read_bytes(src), contents)
+      else
+        MiniTest.expect.equality(vim.uv.fs_lstat(src), nil)
+      end
+    end
+  end
+
+  T[operation .. " reports a missing source without changing the destination"] = function()
+    local dst = tmpdir .. "/keep"
+    helpers.create_file(dst, "KEEP")
+    MiniTest.expect.equality(
+      type(await_callback(function(cb)
+        Fs[operation](tmpdir .. "/missing", dst, cb)
+      end)),
+      "string"
+    )
+    MiniTest.expect.equality(read_bytes(dst), "KEEP")
+    MiniTest.expect.equality(vim.uv.fs_lstat(tmpdir .. "/missing"), nil)
+  end
+
+  T[operation .. " reports a missing source without creating a destination"] = function()
+    local dst = tmpdir .. "/nested/absent"
+    MiniTest.expect.equality(
+      type(await_callback(function(cb)
+        Fs[operation](tmpdir .. "/missing", dst, cb)
+      end)),
+      "string"
+    )
+    MiniTest.expect.equality(vim.uv.fs_lstat(dst), nil)
+  end
+
+  T[operation .. " preserves recursive contents and empty directories"] = function()
+    local src, dst = tmpdir .. "/src", tmpdir .. "/parent/dst"
+    helpers.create_file(src .. "/child.txt", "child\0content")
+    helpers.create_file(src .. "/nested/.hidden", "hidden\ncontent")
+    helpers.create_dir(src .. "/empty")
+    MiniTest.expect.equality(
+      await_callback(function(cb)
+        Fs[operation](src, dst, cb)
+      end),
+      nil
+    )
+    MiniTest.expect.equality(read_bytes(dst .. "/child.txt"), "child\0content")
+    MiniTest.expect.equality(read_bytes(dst .. "/nested/.hidden"), "hidden\ncontent")
+    MiniTest.expect.equality(vim.fn.isdirectory(dst .. "/empty"), 1)
+    MiniTest.expect.equality(vim.fn.readdir(dst .. "/empty"), {})
+    if operation == "copy" then
+      MiniTest.expect.equality(read_bytes(src .. "/child.txt"), "child\0content")
+      MiniTest.expect.equality(read_bytes(src .. "/nested/.hidden"), "hidden\ncontent")
+      MiniTest.expect.equality(vim.fn.isdirectory(src .. "/empty"), 1)
+    else
+      MiniTest.expect.equality(vim.uv.fs_lstat(src), nil)
+    end
+  end
 end
 
 T["Fs.execute_operations empty list succeeds synchronously"] = function()
-  -- execute_operations with empty list calls cb synchronously (no vim.schedule)
   local exec_result
   Fs.execute_operations({}, { delete_to_trash = false }, function(result)
     exec_result = result
@@ -244,7 +309,6 @@ T["Fs.execute_operations empty list succeeds synchronously"] = function()
 end
 
 T["Fs.execute_operations runs all ops and reports success"] = function()
-  local tmpdir = helpers.create_temp_dir()
   helpers.create_file(tmpdir .. "/file1.txt", "content1")
 
   local ops = {
@@ -252,48 +316,37 @@ T["Fs.execute_operations runs all ops and reports success"] = function()
     { type = "move", src = tmpdir .. "/file1.txt", dst = tmpdir .. "/moved.txt", path = tmpdir .. "/moved.txt" },
   }
 
-  local exec_result
-  Fs.execute_operations(ops, { delete_to_trash = false }, function(result)
-    exec_result = result
-  end)
-
-  helpers.wait_for(5000, function()
-    return exec_result ~= nil
+  local exec_result = await_callback(function(cb)
+    Fs.execute_operations(ops, { delete_to_trash = false }, cb)
   end)
 
   MiniTest.expect.equality(exec_result.error, nil)
-  MiniTest.expect.equality(#exec_result.completed, 2)
-  MiniTest.expect.equality(vim.fn.filereadable(tmpdir .. "/new_file.txt"), 1)
-  MiniTest.expect.equality(vim.fn.filereadable(tmpdir .. "/moved.txt"), 1)
+  MiniTest.expect.equality(exec_result.completed, ops)
+  MiniTest.expect.equality(exec_result.failed, nil)
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/new_file.txt"), "")
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/moved.txt"), "content1")
   MiniTest.expect.equality(vim.fn.filereadable(tmpdir .. "/file1.txt"), 0)
-  helpers.remove_temp_dir(tmpdir)
 end
 
 T["Fs.execute_operations halts on first error"] = function()
-  local tmpdir = helpers.create_temp_dir()
   helpers.create_file(tmpdir .. "/file1.txt", "content1")
 
   local ops = {
     { type = "create", path = tmpdir .. "/ok.txt", entry_type = "file" },
     { type = "move", src = tmpdir .. "/nonexistent.txt", dst = tmpdir .. "/moved.txt", path = tmpdir .. "/moved.txt" },
-    { type = "create", path = tmpdir .. "/should_not_run.txt", entry_type = "file" },
+    { type = "delete", path = tmpdir .. "/file1.txt" },
   }
 
-  local exec_result
-  Fs.execute_operations(ops, { delete_to_trash = false }, function(result)
-    exec_result = result
+  local exec_result = await_callback(function(cb)
+    Fs.execute_operations(ops, { delete_to_trash = false }, cb)
   end)
 
-  helpers.wait_for(5000, function()
-    return exec_result ~= nil
-  end)
-
-  MiniTest.expect.equality(exec_result.error ~= nil, true)
-  MiniTest.expect.equality(#exec_result.completed, 1)
-  MiniTest.expect.equality(exec_result.failed.type, "move")
-  -- Third op should not have run
-  MiniTest.expect.equality(vim.fn.filereadable(tmpdir .. "/should_not_run.txt"), 0)
-  helpers.remove_temp_dir(tmpdir)
+  MiniTest.expect.equality(type(exec_result.error), "string")
+  MiniTest.expect.equality(exec_result.completed, { ops[1] })
+  MiniTest.expect.equality(exec_result.failed, ops[2])
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/ok.txt"), "")
+  MiniTest.expect.equality(vim.uv.fs_lstat(tmpdir .. "/moved.txt"), nil)
+  MiniTest.expect.equality(read_bytes(tmpdir .. "/file1.txt"), "content1")
 end
 
 T["Fs.trash rejects path with newline"] = function()
@@ -316,48 +369,16 @@ T["Fs.trash rejects path with carriage return"] = function()
   MiniTest.expect.equality(err_msg:find("control characters") ~= nil, true)
 end
 
-T["Fs.copy copies directory recursively"] = function()
-  local tmpdir = helpers.create_temp_dir()
-  local src = tmpdir .. "/src_dir"
-  local dst = tmpdir .. "/dst_dir"
-  helpers.create_dir(src)
-  helpers.create_file(src .. "/child.txt", "child_content")
-  helpers.create_dir(src .. "/nested")
-  helpers.create_file(src .. "/nested/deep.txt", "deep_content")
-
-  local done = false
-  local copy_err
-  Fs.copy(src, dst, function(err)
-    copy_err = err
-    done = true
-  end)
-
-  helpers.wait_for(5000, function()
-    return done
-  end)
-
-  MiniTest.expect.equality(copy_err, nil)
-  MiniTest.expect.equality(vim.fn.isdirectory(dst), 1)
-  MiniTest.expect.equality(vim.fn.filereadable(dst .. "/child.txt"), 1)
-  MiniTest.expect.equality(vim.fn.filereadable(dst .. "/nested/deep.txt"), 1)
-  helpers.remove_temp_dir(tmpdir)
-end
-
 T["Fs.move reports parent creation failure without removing the source"] = function()
-  local dir = helpers.create_temp_dir()
+  local dir = tmpdir
   helpers.create_file(dir .. "/source", "source")
   helpers.create_file(dir .. "/blocked", "blocker")
-  local result
-  Fs.move(dir .. "/source", dir .. "/blocked/target", function(err)
-    result = err or false
-  end)
-  helpers.wait_for(5000, function()
-    return result ~= nil
+  local result = await_callback(function(cb)
+    Fs.move(dir .. "/source", dir .. "/blocked/target", cb)
   end)
   MiniTest.expect.equality(type(result), "string")
   MiniTest.expect.equality(vim.fn.readfile(dir .. "/source"), { "source" })
   MiniTest.expect.equality(vim.fn.readfile(dir .. "/blocked"), { "blocker" })
-  helpers.remove_temp_dir(dir)
 end
 
 return T


### PR DESCRIPTION
Filesystem tests now call the exported `Fs` API and verify exact contents, directory structure, callback completion, and source preservation. Previously, representative create/delete/move/copy tests still passed when all four wrappers were replaced with no-ops; their replacements all fail under that negative control.

The new symlink tests also exposed a data-loss bug on Neovim 0.11.0: `vim.fs.rm` follows a top-level directory symlink, deletes its target contents, then fails to remove the link. `Fs.delete` now detects links with `lstat` and unlinks them directly, including broken links. Ordinary recursive deletion retains its existing backend. This does not provide isolation against concurrent filesystem changes.

Coverage includes binary and quoted-path transfers, missing sources, automatic parent creation, hidden/empty recursive entries, link target preservation, unlink failure, and exact partial-batch outcomes. Existing no-replace collision, mutation, trash-backend, and E2E regressions remain active; trash processes are stubbed.

Validation: format-check, lint, typecheck, 883 unit cases, and 239 E2E cases passed on Neovim 0.12.5. All 63 filesystem cases passed on exact 0.11.0 and nightly after reproducing the minimum-version failures. Full diff, failure paths, callback waits, and fixture cleanup self-reviewed.

Closes #76
