### PR TITLE
ci: verify minimum Neovim macOS and Lua types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           just lint
 
   test:
-    name: test (${{ matrix.os }}, ${{ matrix.neovim }})
+    name: test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,12 +27,16 @@ jobs:
         include:
           - os: ubuntu-latest
             neovim: v0.11.0
+            label: v0.11.0
           - os: ubuntu-latest
             neovim: stable
+            label: stable
           - os: ubuntu-latest
             neovim: nightly
+            label: nightly
           - os: macos-15
             neovim: stable
+            label: macos-15, stable
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,21 +19,47 @@ jobs:
           just lint
 
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }}, ${{ matrix.neovim }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        neovim: [stable, nightly]
+        include:
+          - os: ubuntu-latest
+            neovim: v0.11.0
+          - os: ubuntu-latest
+            neovim: stable
+          - os: ubuntu-latest
+            neovim: nightly
+          - os: macos-15
+            neovim: stable
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1
         with:
           neovim: true
           version: ${{ matrix.neovim }}
+      - name: Prepare isolated test directories
+        run: |
+          for kind in CONFIG DATA STATE CACHE; do
+            printf 'XDG_%s_HOME=%s/eda-test-%s\n' "$kind" "$RUNNER_TEMP" "$kind"
+          done >> "$GITHUB_ENV"
+      - name: Record Neovim version
+        run: |
+          command -v nvim
+          nvim --version
       - name: Run tests
         run: nvim --headless -l tests/minit.lua
       - name: Run E2E tests
         run: nvim --headless -l tests/e2e_minit.lua
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/setup-nix
+      - name: Typecheck
+        run: nix develop .#typecheck --command just typecheck
 
   docs:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,16 @@ E2E tests inside the shell. Both use mini.test; the test bootstrap downloads
 mini.nvim into Neovim's data directory when needed. Async unit cases execute
 serially so a wait inside one case cannot run other cases nested inside it.
 
-The [CI workflow](.github/workflows/ci.yaml) defines the automated jobs and test
-matrix. Use the full local sequence above even when a check is not in CI.
+The [CI workflow](.github/workflows/ci.yaml) runs formatting, lint, type checking,
+and generated-vimdoc freshness checks. Full unit and E2E suites run on Ubuntu
+with Neovim 0.11.0, stable, and nightly, and on macOS with stable Neovim. Test
+jobs use temporary dependency/data directories and report the Neovim binary and
+version used by the parent and E2E child processes.
+
+To test another installed Neovim locally, use
+`just nvim=/absolute/path/to/nvim test-all` inside the development shell. The
+same override selects the runtime definitions used by `just typecheck`. CI's
+separate typecheck job uses the Neovim and Lua Language Server pinned by Nix.
 
 ## Documentation Changes
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,14 +21,16 @@
             pkgs.stylua
             selene-luajit
           ];
+          typecheckPackages = [
+            pkgs.just
+            pkgs.jq
+            pkgs.neovim
+            pkgs.lua-language-server
+          ];
         in
         {
           default = pkgs.mkShell {
-            packages = lintPackages ++ [
-              pkgs.just
-              pkgs.jq
-              pkgs.neovim
-              pkgs.lua-language-server
+            packages = lintPackages ++ typecheckPackages ++ [
               pkgs.git
               pkgs.panvimdoc
               pkgs.vhs
@@ -40,6 +42,10 @@
               pkgs.just
               pkgs.panvimdoc
             ];
+          };
+
+          typecheck = pkgs.mkShell {
+            packages = typecheckPackages;
           };
         }
       );

--- a/justfile
+++ b/justfile
@@ -17,7 +17,8 @@ lint:
 typecheck:
     #!/usr/bin/env bash
     set -euo pipefail
-    export VIMRUNTIME=$(nvim --headless +"echo \$VIMRUNTIME" +q 2>&1 | tail -1)
+    VIMRUNTIME=$({{ nvim }} --headless +"echo \$VIMRUNTIME" +q 2>&1 | tail -1)
+    export VIMRUNTIME
     lua-language-server --check lua/ --configpath <(jq --arg vr "$VIMRUNTIME/lua" '.workspace.library += [$vr]' .luarc.json)
 
 # Run unit tests with mini.test

--- a/tests/e2e/helpers.lua
+++ b/tests/e2e/helpers.lua
@@ -3,12 +3,22 @@ local helpers = require("helpers")
 local M = {}
 
 local plugin_root = vim.fn.getcwd()
+local reported_child = false
 
 ---Spawn a child Neovim instance for E2E testing via MiniTest.new_child_neovim().
 ---@return table child object from MiniTest.new_child_neovim()
 function M.spawn()
   local child = MiniTest.new_child_neovim()
   child.start()
+  if not reported_child then
+    local runtime = child.lua("return { path = vim.v.progpath, version = tostring(vim.version()) }")
+    io.write(string.format("E2E child Neovim: %s (%s)\n", runtime.path, runtime.version))
+    if runtime.path ~= vim.v.progpath or runtime.version ~= tostring(vim.version()) then
+      child.stop()
+      error("E2E child Neovim does not match its parent")
+    end
+    reported_child = true
+  end
   -- Add eda.nvim to runtimepath
   child.lua("vim.opt.rtp:prepend(...)", { plugin_root })
   return child

--- a/tests/e2e/test_refresh.lua
+++ b/tests/e2e/test_refresh.lua
@@ -183,24 +183,28 @@ for _, event in ipairs({ "create", "rename", "delete" }) do
   end
 end
 
-local function hold_background_scan()
+local function hold_background_scan(filename)
+  child.lua("_G.refresh_filename = ...", { filename })
   e2e.exec(
     child,
     [[
     local ex = require("eda").get_current()
     ex.watcher:unwatch_all()
     local Scanner = require("eda.tree.scanner")
-    local rescan = Scanner.rescan_preserving_state
-    Scanner.rescan_preserving_state = function(self, id, callback, state_store)
-      return rescan(self, id, function()
-        callback()
-        _G.finished_scans = (_G.finished_scans or 0) + 1
-      end, state_store)
+    local scan = Scanner.scan
+    Scanner.scan = function(self, id, callback)
+      return scan(self, id, function(err)
+        callback(err)
+        if self == _G.held_scanner then
+          _G.finished_scans = (_G.finished_scans or 0) + 1
+        end
+      end)
     end
     local readdir = vim.uv.fs_readdir
     vim.uv.fs_readdir = function(dir, callback)
       return readdir(dir, function(err, entries)
         if not entries and not _G.release_scan then
+          _G.held_scanner = ex.refresh._scanner
           _G.release_scan = function()
             vim.uv.fs_readdir = readdir
             callback(err, entries)
@@ -210,7 +214,7 @@ local function hold_background_scan()
         end
       end)
     end
-    _G.watcher_callbacks[ex.root_path]()
+    _G.watcher_callbacks[ex.root_path](_G.refresh_filename)
   ]]
   )
   e2e.wait_until(child, "_G.release_scan ~= nil")
@@ -370,29 +374,31 @@ T["refresh"]["coalesces watcher events raised during a save"] = function()
   )
 end
 
-T["refresh"]["ignores a background scan completed after close"] = function()
-  intercept_watcher()
-  e2e.open_eda(child, tmp)
-  hold_background_scan()
-  e2e.exec(
-    child,
-    [[
+for _, mode in ipairs({ "full", "scoped" }) do
+  T["refresh"]["ignores a " .. mode .. " background scan completed after close"] = function()
+    intercept_watcher()
+    e2e.open_eda(child, tmp)
+    hold_background_scan(mode == "scoped" and "existing.txt" or nil)
+    e2e.exec(
+      child,
+      [[
     _G.closed_explorer = require("eda").get_current()
     _G.closed_nodes = _G.closed_explorer.store.nodes
     require("eda").close()
     _G.release_scan()
   ]]
-  )
-  e2e.wait_until(child, "(_G.finished_scans or 0) > 0")
-  MiniTest.expect.equality(
-    e2e.exec(
-      child,
-      [[
+    )
+    e2e.wait_until(child, "(_G.finished_scans or 0) > 0")
+    MiniTest.expect.equality(
+      e2e.exec(
+        child,
+        [[
     return require("eda").get_current() == nil and _G.closed_explorer.store.nodes == _G.closed_nodes
   ]]
-    ),
-    true
-  )
+      ),
+      true
+    )
+  end
 end
 
 T["refresh"]["ignores old root callbacks and installs a guarded new root watcher"] = function()

--- a/tests/e2e_minit.lua
+++ b/tests/e2e_minit.lua
@@ -1,4 +1,5 @@
 vim.o.shadafile = "NONE"
+io.write(string.format("E2E parent Neovim: %s (%s)\n", vim.v.progpath, tostring(vim.version())))
 
 -- Bootstrap mini.nvim for E2E testing
 local deps_path = vim.fn.stdpath("data") .. "/eda-test-deps"

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -1,4 +1,5 @@
 vim.o.shadafile = "NONE"
+io.write(string.format("Unit parent Neovim: %s (%s)\n", vim.v.progpath, tostring(vim.version())))
 
 -- Bootstrap mini.nvim for testing
 local deps_path = vim.fn.stdpath("data") .. "/eda-test-deps"


### PR DESCRIPTION
CI now tests the declared minimum Neovim 0.11.0 release and macOS alongside Ubuntu stable/nightly. Each matrix entry runs the complete unit and E2E suites with isolated XDG directories, records its selected Neovim, and logs/checks the actual E2E child against its parent.

A separate Nix shell supplies the existing Lua Language Server typecheck gate without pulling in screenshot tools. The `just nvim=...` override now also selects typecheck runtime definitions, and failed runtime discovery stops the recipe. Formatting, lint, and generated-vimdoc freshness checks remain active. Contributor instructions match the resulting seven gates. Existing `test (stable)` and `test (nightly)` check names are preserved for the repository's required checks.

Minimum-version verification exposed a test synchronization gap: the held-background-scan helper counted only full rescans, although scoped refreshes can also be held. It now tracks the specific held scanner's completion, with close-after-scan coverage for both routes. A scoped watcher event reproduced the old timeout deterministically; runtime behavior is unchanged.

Validation: 883 unit and 240 E2E cases passed locally on both exact Neovim 0.11.0 and 0.12.5. Parent/child binary and version reports match. Format-check, lint, typecheck, and actionlint passed. A deliberate type error exits 1; a missing selected Neovim exits 127. Reviewed the full diff, pinned setup action's Linux/macOS support, matrix isolation, and failure propagation. Local ravelact could not start because an installed dynamic library is missing; actionlint and direct workflow dependency review passed.

Closes #77
