### PR TITLE
test: pin and validate shared mini.nvim bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Framework: mini.test (from mini.nvim)
 - Test files: `tests/` directory, mirroring `lua/eda/` structure with `test_` prefix
-- Test bootstrap: `tests/minit.lua` auto-clones mini.nvim to `~/.local/share/nvim/eda-test-deps/`
+- Test bootstrap: both runners use the mini.nvim commit pinned in `tests/bootstrap.lua`, cached under `stdpath("data")/eda-test-deps/mini.nvim-<revision>`. See CONTRIBUTING.md for cache recovery and pin updates.
 - Helper utilities in `tests/helpers.lua` (temp dirs, file creation, wait_for)
 - Async tests: use `helpers.wait_for(timeout_ms, predicate_fn)` for `vim.uv` callback completion
 - `tests/minit.lua` executes cases one at a time. `MiniTest.run()` schedules every case up front, so a `vim.wait` inside a case would run the remaining cases nested inside it and a timed-out wait would be reported as passing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,9 @@ nix develop --command just format
 
 For focused development, use `just test` for unit tests or `just test-e2e` for
 E2E tests inside the shell. Both use mini.test; the test bootstrap downloads
-mini.nvim into Neovim's data directory when needed. Async unit cases execute
-serially so a wait inside one case cannot run other cases nested inside it.
+the pinned mini.nvim revision into Neovim's data directory when needed. Async
+unit cases execute serially so a wait inside one case cannot run other cases
+nested inside it.
 
 The [CI workflow](.github/workflows/ci.yaml) runs formatting, lint, type checking,
 and generated-vimdoc freshness checks. Full unit and E2E suites run on Ubuntu
@@ -42,6 +43,37 @@ To test another installed Neovim locally, use
 `just nvim=/absolute/path/to/nvim test-all` inside the development shell. The
 same override selects the runtime definitions used by `just typecheck`. CI's
 separate typecheck job uses the Neovim and Lua Language Server pinned by Nix.
+
+## Test Dependency Updates and Recovery
+
+Both test runners use the commit recorded in [tests/bootstrap.lua](tests/bootstrap.lua).
+The cache is `stdpath("data")/eda-test-deps/mini.nvim-<revision>`. A fresh run
+requires Git and network access to fetch that commit; subsequent runs work
+offline when the checkout matches the pin and its working tree is clean.
+
+The bootstrap rejects incomplete checkouts, a different HEAD, local changes,
+and untracked files. It reports the affected path and stops before collecting
+tests. Inspect and move that specific cache directory aside to preserve any
+local work, then rerun the tests. Other revisions and the old unversioned
+`mini.nvim` directory are left untouched.
+
+Concurrent fresh runs build separate staging directories and publish only
+validated checkouts. A failed fetch or checkout removes its own staging
+directory. Forcefully terminating a process can leave an unused
+`.mini.nvim-<revision>-<random>` directory; it is never used as a dependency.
+
+To update mini.test:
+
+1. Choose and review an upstream mini.nvim commit, then replace the full
+   40-character `revision` in `tests/bootstrap.lua`.
+2. Run `nix develop --command just test-all`. The new revision gets its own
+   cache, so this exercises a fresh fetch and checkout.
+3. Rerun `just test-all` to exercise the matching cache, and verify the minimum
+   supported Neovim as well as the development version. CI also checks stable,
+   nightly, and macOS.
+4. Commit the pin change with any required test adjustments. The unit suite's
+   bootstrap tests use local Git fixtures to cover cached, failed, and
+   concurrent setup without an external network dependency.
 
 ## Documentation Changes
 

--- a/tests/bootstrap.lua
+++ b/tests/bootstrap.lua
@@ -1,0 +1,104 @@
+local M = { revision = "59f09943573c5348ca6c88393fa09ce3b66a7818" }
+
+local function git(path, operation, ...)
+  local command = { "git", "-C", path, operation, ... }
+  local ok, result = pcall(function()
+    return vim.system(command, { text = true }):wait(60000)
+  end)
+  local failure = "mini.nvim bootstrap git " .. operation .. " failed at " .. path
+  if not ok then
+    error(failure .. ": " .. tostring(result), 0)
+  end
+  if result.code ~= 0 then
+    local detail = result.stderr ~= "" and result.stderr or result.stdout
+    error(failure .. " (exit " .. result.code .. "): " .. (detail or ""), 0)
+  end
+  return vim.trim(result.stdout or "")
+end
+
+local function validate(path, revision)
+  local function invalid(reason)
+    error(
+      "Invalid mini.nvim cache at "
+        .. path
+        .. ": "
+        .. reason
+        .. ". Inspect and move this directory aside, then rerun the tests.",
+      0
+    )
+  end
+  local directory = vim.uv.fs_lstat(path)
+  local metadata = vim.uv.fs_lstat(path .. "/.git")
+  if not directory or directory.type ~= "directory" or not metadata or metadata.type ~= "directory" then
+    invalid("expected a complete Git checkout")
+  end
+  local entrypoint = vim.uv.fs_lstat(path .. "/lua/mini/test.lua")
+  if not entrypoint or entrypoint.type ~= "file" then
+    invalid("missing lua/mini/test.lua")
+  end
+  local head = git(path, "rev-parse", "HEAD")
+  if head ~= revision then
+    invalid("expected " .. revision .. ", found " .. head)
+  end
+  if git(path, "status", "--porcelain=v1", "--untracked-files=all") ~= "" then
+    invalid("working tree contains local changes")
+  end
+end
+
+---@param opts? { root?: string, repository?: string, revision?: string }
+---@return string
+function M.ensure(opts)
+  opts = opts or {}
+  local revision = opts.revision or M.revision
+  assert(#revision == 40 and revision:match("^%x+$"), "mini.nvim revision must be a full 40-character commit hash")
+  local root = opts.root or (vim.fn.stdpath("data") .. "/eda-test-deps")
+  local path = root .. "/mini.nvim-" .. revision
+  if vim.uv.fs_lstat(path) then
+    validate(path, revision)
+    return path
+  end
+
+  -- mkdir(..., "p") can still raise EEXIST when another process creates the directory concurrently.
+  local created, create_err = pcall(vim.fn.mkdir, root, "p")
+  local root_stat = vim.uv.fs_stat(root)
+  if not created and (not root_stat or root_stat.type ~= "directory") then
+    error("mini.nvim bootstrap cannot create cache root: " .. tostring(create_err), 0)
+  end
+  local staging, staging_err = vim.uv.fs_mkdtemp(root .. "/.mini.nvim-" .. revision .. "-XXXXXX")
+  assert(staging, "mini.nvim bootstrap cannot create staging directory: " .. tostring(staging_err))
+  local ok, result = pcall(function()
+    git(staging, "init", "--quiet")
+    git(
+      staging,
+      "fetch",
+      "--quiet",
+      "--depth=1",
+      opts.repository or "https://github.com/echasnovski/mini.nvim",
+      revision
+    )
+    git(staging, "checkout", "--quiet", "--detach", "FETCH_HEAD")
+    validate(staging, revision)
+    if vim.uv.fs_lstat(path) then
+      validate(path, revision)
+      return path
+    end
+    -- Publishing before checkout finishes lets another runner accept a partial dependency.
+    local published, publish_err = vim.uv.fs_rename(staging, path)
+    if not published then
+      if not vim.uv.fs_lstat(path) then
+        error("mini.nvim bootstrap cannot publish checkout: " .. tostring(publish_err), 0)
+      end
+      validate(path, revision)
+    end
+    return path
+  end)
+  if vim.uv.fs_lstat(staging) then
+    vim.fn.delete(staging, "rf")
+  end
+  if not ok then
+    error(result, 0)
+  end
+  return result
+end
+
+return M

--- a/tests/e2e_minit.lua
+++ b/tests/e2e_minit.lua
@@ -1,13 +1,7 @@
 vim.o.shadafile = "NONE"
 io.write(string.format("E2E parent Neovim: %s (%s)\n", vim.v.progpath, tostring(vim.version())))
 
--- Bootstrap mini.nvim for E2E testing
-local deps_path = vim.fn.stdpath("data") .. "/eda-test-deps"
-local mini_path = deps_path .. "/mini.nvim"
-
-if not vim.uv.fs_stat(mini_path) then
-  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/echasnovski/mini.nvim", mini_path })
-end
+local mini_path = dofile("tests/bootstrap.lua").ensure()
 
 vim.opt.runtimepath:prepend(mini_path)
 vim.opt.runtimepath:prepend(vim.fn.getcwd())

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -1,13 +1,7 @@
 vim.o.shadafile = "NONE"
 io.write(string.format("Unit parent Neovim: %s (%s)\n", vim.v.progpath, tostring(vim.version())))
 
--- Bootstrap mini.nvim for testing
-local deps_path = vim.fn.stdpath("data") .. "/eda-test-deps"
-local mini_path = deps_path .. "/mini.nvim"
-
-if not vim.uv.fs_stat(mini_path) then
-  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/echasnovski/mini.nvim", mini_path })
-end
+local mini_path = dofile("tests/bootstrap.lua").ensure()
 
 vim.opt.runtimepath:prepend(mini_path)
 vim.opt.runtimepath:prepend(vim.fn.getcwd())

--- a/tests/test_bootstrap.lua
+++ b/tests/test_bootstrap.lua
@@ -1,0 +1,227 @@
+local bootstrap = dofile("tests/bootstrap.lua")
+local helpers = require("helpers")
+local tmp, source, revision, newer, options, original_system, original_rename
+
+local function git(path, ...)
+  local result = vim.system({ "git", "-C", path, ... }, { text = true }):wait(10000)
+  assert(result.code == 0, result.stderr)
+  return vim.trim(result.stdout)
+end
+
+local function cache_path()
+  return options.root .. "/mini.nvim-" .. revision
+end
+
+local function expect_error(fn, pattern)
+  local ok, err = pcall(fn)
+  MiniTest.expect.equality(ok, false)
+  MiniTest.expect.equality(tostring(err):find(pattern, 1, true) ~= nil, true)
+end
+
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      original_system, original_rename = vim.system, vim.uv.fs_rename
+      tmp = helpers.create_temp_dir()
+      source = tmp .. "/source"
+      helpers.create_file(source .. "/lua/mini/test.lua", "return { fixture = true }\n")
+      git(source, "init", "--quiet")
+      git(source, "config", "user.name", "Test")
+      git(source, "config", "user.email", "test@example.com")
+      git(source, "config", "commit.gpgsign", "false")
+      git(source, "add", ".")
+      git(source, "commit", "--quiet", "-m", "fixture")
+      revision = git(source, "rev-parse", "HEAD")
+      helpers.create_file(source .. "/newer", "new commit")
+      git(source, "add", ".")
+      git(source, "commit", "--quiet", "-m", "newer fixture")
+      newer = git(source, "rev-parse", "HEAD")
+      options = { root = tmp .. "/cache", repository = source, revision = revision }
+    end,
+    post_case = function()
+      vim.system, vim.uv.fs_rename = original_system, original_rename
+      helpers.remove_temp_dir(tmp)
+    end,
+  },
+})
+
+T["fresh bootstrap checks out the requested commit rather than remote HEAD"] = function()
+  local path = bootstrap.ensure(options)
+  MiniTest.expect.equality(path, cache_path())
+  MiniTest.expect.equality(git(path, "rev-parse", "HEAD"), revision)
+  MiniTest.expect.equality(vim.fn.readfile(path .. "/lua/mini/test.lua"), { "return { fixture = true }" })
+  MiniTest.expect.equality(vim.uv.fs_stat(path .. "/newer"), nil)
+  MiniTest.expect.equality(vim.fn.readdir(options.root), { "mini.nvim-" .. revision })
+end
+
+T["matching cache works without contacting the repository"] = function()
+  local path = bootstrap.ensure(options)
+  options.repository = tmp .. "/offline"
+  MiniTest.expect.equality(bootstrap.ensure(options), path)
+  MiniTest.expect.equality(git(path, "rev-parse", "HEAD"), revision)
+end
+
+T["mismatched cache is rejected without resetting its checkout"] = function()
+  local path = bootstrap.ensure(options)
+  git(path, "fetch", "--quiet", source, newer)
+  git(path, "checkout", "--quiet", "--detach", newer)
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "expected " .. revision)
+  MiniTest.expect.equality(git(path, "rev-parse", "HEAD"), newer)
+  MiniTest.expect.equality(vim.fn.readfile(path .. "/newer"), { "new commit" })
+end
+
+for _, filename in ipairs({ "lua/mini/test.lua", "untracked.lua" }) do
+  T["dirty cache preserves local changes to " .. filename] = function()
+    local path = bootstrap.ensure(options)
+    helpers.create_file(path .. "/" .. filename, "KEEP LOCAL CHANGES")
+    expect_error(function()
+      bootstrap.ensure(options)
+    end, "working tree")
+    MiniTest.expect.equality(vim.fn.readfile(path .. "/" .. filename), { "KEEP LOCAL CHANGES" })
+  end
+end
+
+T["incomplete cache is rejected without deleting unrelated data"] = function()
+  helpers.create_file(cache_path() .. "/keep", "KEEP")
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "cache")
+  MiniTest.expect.equality(vim.fn.readfile(cache_path() .. "/keep"), { "KEEP" })
+end
+
+T["missing entrypoint is rejected even when HEAD matches"] = function()
+  local path = bootstrap.ensure(options)
+  assert(vim.uv.fs_unlink(path .. "/lua/mini/test.lua"))
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "lua/mini/test.lua")
+  MiniTest.expect.equality(git(path, "rev-parse", "HEAD"), revision)
+end
+
+T["fetch failure names the operation and cleans its staging directory"] = function()
+  options.repository = tmp .. "/missing-repository"
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "fetch")
+  MiniTest.expect.equality(vim.fn.readdir(options.root), {})
+end
+
+T["checkout failure cannot publish an initialized but incomplete repository"] = function()
+  vim.system = function(command, opts)
+    if command[4] == "checkout" then
+      return {
+        wait = function()
+          return { code = 1, stderr = "injected checkout failure" }
+        end,
+      }
+    end
+    return original_system(command, opts)
+  end
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "checkout")
+  MiniTest.expect.equality(vim.fn.readdir(options.root), {})
+end
+
+T["spawn failure names the attempted Git operation"] = function()
+  vim.system = function()
+    error("injected executable unavailable")
+  end
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "init")
+  MiniTest.expect.equality(vim.fn.readdir(options.root), {})
+end
+
+T["a blocked cache root is reported without changing the blocking file"] = function()
+  helpers.create_file(options.root, "KEEP")
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "cache root")
+  MiniTest.expect.equality(vim.fn.readfile(options.root), { "KEEP" })
+end
+
+T["publication failure leaves no final or staging checkout"] = function()
+  vim.uv.fs_rename = function()
+    return nil, "injected publication failure"
+  end
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "cannot publish checkout")
+  MiniTest.expect.equality(vim.fn.readdir(options.root), {})
+end
+
+T["an invalid destination appearing during checkout is preserved"] = function()
+  vim.system = function(command, opts)
+    if command[4] == "checkout" then
+      helpers.create_file(cache_path() .. "/keep", "KEEP")
+    end
+    return original_system(command, opts)
+  end
+  expect_error(function()
+    bootstrap.ensure(options)
+  end, "cache")
+  MiniTest.expect.equality(vim.fn.readfile(cache_path() .. "/keep"), { "KEEP" })
+  MiniTest.expect.equality(vim.fn.readdir(options.root), { "mini.nvim-" .. revision })
+end
+
+T["concurrent fresh processes publish one complete checkout"] = function()
+  local processes = {}
+  for index = 1, 2 do
+    local script = tmp .. "/bootstrap-" .. index .. ".lua"
+    helpers.create_file(
+      script,
+      string.format(
+        [[
+local system, rename = vim.system, vim.uv.fs_rename
+local function barrier(stage)
+  vim.fn.writefile({}, %q .. stage)
+  assert(vim.wait(10000, function() return vim.uv.fs_stat(%q .. stage) ~= nil end, 10))
+end
+vim.system = function(command, opts)
+  if command[4] == "fetch" then barrier("fetch") end
+  return system(command, opts)
+end
+vim.uv.fs_rename = function(src, dst)
+  barrier("publish")
+  return rename(src, dst)
+end
+local path = dofile("tests/bootstrap.lua").ensure(%s)
+print(path)
+vim.cmd("qa!")
+]],
+        tmp .. "/ready-" .. index,
+        tmp .. "/ready-" .. (3 - index),
+        vim.inspect(options)
+      )
+    )
+    processes[index] = original_system({ vim.v.progpath, "--clean", "--headless", "-l", script }, { text = true })
+  end
+  local results = { processes[1]:wait(20000), processes[2]:wait(20000) }
+  for _, result in ipairs(results) do
+    assert(result.code == 0, results[1].stderr .. "\n" .. results[2].stderr)
+  end
+  MiniTest.expect.equality(git(cache_path(), "rev-parse", "HEAD"), revision)
+  MiniTest.expect.equality(vim.fn.readdir(options.root), { "mini.nvim-" .. revision })
+  MiniTest.expect.equality(bootstrap.ensure(options), cache_path())
+end
+
+for _, runner in ipairs({ "tests/minit.lua", "tests/e2e_minit.lua" }) do
+  T[runner .. " exits before collection when its cache is invalid"] = function()
+    local data = tmp .. "/data"
+    local cache = data .. "/nvim/eda-test-deps/mini.nvim-" .. bootstrap.revision
+    helpers.create_file(cache .. "/keep", "KEEP")
+    local result = original_system(
+      { vim.v.progpath, "--clean", "--headless", "-l", runner },
+      { text = true, env = { XDG_DATA_HOME = data } }
+    ):wait(20000)
+    MiniTest.expect.equality(result.code ~= 0, true)
+    MiniTest.expect.equality(result.stderr:find("cache", 1, true) ~= nil, true)
+    MiniTest.expect.equality(result.stdout:find("Total number of cases", 1, true), nil)
+    MiniTest.expect.equality(vim.fn.readfile(cache .. "/keep"), { "KEEP" })
+  end
+end
+
+return T


### PR DESCRIPTION
Unit and E2E tests now share the mini.nvim commit pinned in `tests/bootstrap.lua`. Fresh runs fetch that exact commit into a revision-specific cache; existing caches must contain the expected entrypoint, matching HEAD, and a clean working tree. Invalid caches fail before test collection with recovery guidance, without resetting or deleting local work. Matching caches require no network access.

Each fresh process builds and validates its own staging checkout before publication. Concurrent contenders validate the completed winner, and failures remove only their own staging directories. Git errors identify the operation, path, and exit status. A terminated process may leave an unused staging directory, which is never accepted as a dependency. Contributor and agent instructions document pin updates, cache recovery, and offline reruns.

The 16 new integration cases use local Git fixtures and actual child Neovim processes. They cover a pinned commit behind remote HEAD, offline cache use, stale/dirty/incomplete caches, fetch/checkout/spawn/publication failures, a blocked cache root, a destination appearing during checkout, simultaneous fetch/publication, and both runners exiting before collection. Repeated concurrent setup exposed and verified a fix for `mkdir(..., "p")` raising EEXIST when another process creates the cache root.

Validation: format-check, lint, typecheck, 899 unit cases, and 240 E2E cases passed with the real pinned cache. All 16 bootstrap cases passed on exact Neovim 0.11.0 and nightly. Concurrent publication passed 12 repeated two-process runs. Self-reviewed the full diff, cache validation, error handling, publication races, staging ownership, cleanup, and unchanged serial unit execution.

Closes #78
