### PR TITLE
fix: keep preview toggle state per explorer

### DIFF
--- a/lua/eda/action/builtin.lua
+++ b/lua/eda/action/builtin.lua
@@ -844,9 +844,8 @@ end, { desc = "Open with system application" })
 
 action.register("toggle_preview", function(ctx)
   local preview = ctx.explorer.preview
-  local cfg = ctx.config.preview
-  cfg.enabled = not cfg.enabled
-  if cfg.enabled then
+  preview:set_enabled(not preview:is_enabled())
+  if preview:is_enabled() then
     local node = ctx.buffer:get_cursor_node(ctx.window.winid)
     preview:update(node)
   else

--- a/lua/eda/preview.lua
+++ b/lua/eda/preview.lua
@@ -6,6 +6,7 @@ local util = require("eda.util")
 ---@field winid integer?
 ---@field bufnr integer?
 ---@field config eda.PreviewConfig
+---@field enabled boolean  Runtime toggle state; seeded from config but never written back
 ---@field window eda.Window?
 ---@field store eda.Store?
 ---@field scanner eda.Scanner?
@@ -34,6 +35,7 @@ function Preview.new(config)
     winid = nil,
     bufnr = nil,
     config = config,
+    enabled = config.enabled and true or false,
     window = nil,
     store = nil,
     scanner = nil,
@@ -44,6 +46,20 @@ function Preview.new(config)
     _pending_target = nil,
     _current_target = nil,
   }, Preview)
+end
+
+---Whether this explorer's preview is turned on.
+---@return boolean
+function Preview:is_enabled()
+  return self.enabled
+end
+
+---Turn this explorer's preview on or off. Runtime toggles are per-instance:
+---writing back to `self.config` would leak the choice into every other explorer,
+---because `config.get()` hands out one shared table.
+---@param value boolean
+function Preview:set_enabled(value)
+  self.enabled = value and true or false
 end
 
 ---Attach the filer window and (optionally) tree dependencies for directory preview.
@@ -73,7 +89,7 @@ end
 ---@param request_id integer
 ---@return boolean
 function Preview:_is_current(target, request_id)
-  return self.config.enabled and self._pending_target == target and self._request_id == request_id
+  return self:is_enabled() and self._pending_target == target and self._request_id == request_id
 end
 
 ---Check if a file is binary (contains NUL byte in first 512 bytes).
@@ -125,7 +141,7 @@ end
 ---Show preview for a file.
 ---@param path string
 function Preview:show(path)
-  if not self.config.enabled then
+  if not self:is_enabled() then
     self:close()
     return
   end
@@ -269,7 +285,7 @@ end
 ---Show a directory preview using eda's tree-render style.
 ---@param node eda.TreeNode
 function Preview:show_directory(node)
-  if not self.config.enabled then
+  if not self:is_enabled() then
     self:close()
     return
   end
@@ -440,7 +456,7 @@ end
 ---tree-render path and files to the byte-content path.
 ---@param node eda.TreeNode?
 function Preview:update(node)
-  if not self.config.enabled then
+  if not self:is_enabled() then
     self:close()
     return
   end

--- a/tests/e2e/test_multi_instance.lua
+++ b/tests/e2e/test_multi_instance.lua
@@ -64,6 +64,105 @@ T["multi instance"]["split action creates two independent explorers"] = function
   MiniTest.expect.equality(both_eda, true)
 end
 
+T["multi instance"]["toggle_preview only changes the acting explorer"] = function()
+  e2e.open_eda(child, tmp)
+
+  e2e.exec(
+    child,
+    [[
+    local action = require("eda.action")
+    local eda = require("eda")
+    local explorer = eda.get_current()
+    local ctx = {
+      store = explorer.store,
+      buffer = explorer.buffer,
+      window = explorer.window,
+      scanner = explorer.scanner,
+      config = require("eda.config").get(),
+      explorer = explorer,
+    }
+    action.dispatch("split", ctx)
+  ]]
+  )
+  e2e.wait_until(child, "#require('eda').get_all() == 2", 10000)
+
+  -- Every instance starts from the configured default (preview is off by default).
+  local before = e2e.exec(
+    child,
+    [[
+    local states = {}
+    for _, inst in ipairs(require("eda").get_all()) do
+      table.insert(states, inst.preview:is_enabled())
+    end
+    return { states = states, shared = require("eda.config").get().preview.enabled }
+  ]]
+  )
+  MiniTest.expect.equality(before.states, { false, false })
+  MiniTest.expect.equality(before.shared, false)
+
+  -- Toggle in the first explorer only.
+  local after = e2e.exec(
+    child,
+    [[
+    local action = require("eda.action")
+    local eda = require("eda")
+    local explorer = eda.get_all()[1]
+    local ctx = {
+      store = explorer.store,
+      buffer = explorer.buffer,
+      window = explorer.window,
+      scanner = explorer.scanner,
+      config = require("eda.config").get(),
+      explorer = explorer,
+    }
+    action.dispatch("toggle_preview", ctx)
+    local states = {}
+    for _, inst in ipairs(eda.get_all()) do
+      table.insert(states, inst.preview:is_enabled())
+    end
+    return { states = states, shared = require("eda.config").get().preview.enabled }
+  ]]
+  )
+  MiniTest.expect.equality(after.states, { true, false })
+  MiniTest.expect.equality(after.shared, false)
+end
+
+T["multi instance"]["a newly opened explorer uses the configured default, not the last toggle"] = function()
+  e2e.open_eda(child, tmp)
+
+  e2e.exec(
+    child,
+    [[
+    local action = require("eda.action")
+    local eda = require("eda")
+    local explorer = eda.get_current()
+    local ctx = {
+      store = explorer.store,
+      buffer = explorer.buffer,
+      window = explorer.window,
+      scanner = explorer.scanner,
+      config = require("eda.config").get(),
+      explorer = explorer,
+    }
+    action.dispatch("toggle_preview", ctx)
+    action.dispatch("split", ctx)
+  ]]
+  )
+  e2e.wait_until(child, "#require('eda').get_all() == 2", 10000)
+
+  local states = e2e.exec(
+    child,
+    [[
+    local states = {}
+    for _, inst in ipairs(require("eda").get_all()) do
+      table.insert(states, inst.preview:is_enabled())
+    end
+    return states
+  ]]
+  )
+  MiniTest.expect.equality(states, { true, false })
+end
+
 local child_a, child_b, shared_tmp
 
 T["cross-process swap conflict"] = MiniTest.new_set({

--- a/tests/e2e/test_preview.lua
+++ b/tests/e2e/test_preview.lua
@@ -473,8 +473,8 @@ end
 T["preview"]["root changes rebind preview dependencies and show the new tree"] = function()
   e2e.setup_eda(child)
   e2e.create_file(tmp .. "/next/visible.txt", "NEW ROOT")
-  e2e.exec(child, [[require("eda.config").get().preview.enabled = true]])
   e2e.open_eda(child, tmp)
+  e2e.exec(child, [[require("eda").get_current().preview:set_enabled(true)]])
   e2e.exec(
     child,
     string.format(

--- a/tests/preview/test_lifecycle.lua
+++ b/tests/preview/test_lifecycle.lua
@@ -75,7 +75,7 @@ for _, action in ipairs({ "close", "disable", "disable_and_close" }) do
   T[action .. " prevents a pending text read from opening a preview"] = function()
     show_read(tmp .. "/file.txt", 1)
     if action ~= "close" then
-      preview.config.enabled = false
+      preview:set_enabled(false)
     end
     if action ~= "disable" then
       preview:close()
@@ -183,7 +183,7 @@ T["disabled updates do not reconfigure a filer that has no preview"] = function(
     changes = changes + 1
   end
   preview.window.kind = "float"
-  preview.config.enabled = false
+  preview:set_enabled(false)
   local ok, err = pcall(function()
     preview:update(nil)
   end)

--- a/tests/preview/test_preview.lua
+++ b/tests/preview/test_preview.lua
@@ -92,6 +92,32 @@ T["Preview.new initial state"] = function()
   MiniTest.expect.equality(p.bufnr, nil)
 end
 
+-- PR-11: enabled state is per-instance, not shared through the config table
+T["Preview enabled state is instance-local"] = function()
+  config.setup({ preview = { enabled = false } })
+  local cfg = config.get()
+  local a = Preview.new(cfg.preview)
+  local b = Preview.new(cfg.preview)
+  MiniTest.expect.equality(a:is_enabled(), false)
+  MiniTest.expect.equality(b:is_enabled(), false)
+
+  a:set_enabled(true)
+  MiniTest.expect.equality(a:is_enabled(), true)
+  MiniTest.expect.equality(b:is_enabled(), false)
+  MiniTest.expect.equality(cfg.preview.enabled, false)
+end
+
+-- PR-12: a new instance starts from the configured default, not another instance's toggle
+T["Preview initial enabled follows config"] = function()
+  config.setup({ preview = { enabled = true } })
+  local cfg = config.get()
+  local a = Preview.new(cfg.preview)
+  a:set_enabled(false)
+  local b = Preview.new(cfg.preview)
+  MiniTest.expect.equality(b:is_enabled(), true)
+  MiniTest.expect.equality(cfg.preview.enabled, true)
+end
+
 -- PR-2: attach sets window reference
 T["Preview:attach sets window"] = function()
   config.setup()


### PR DESCRIPTION
## Summary

`toggle_preview` flipped `config.preview.enabled`, and `config.get()` hands every caller the same table. Toggling the preview in one explorer therefore changed the enabled state of all of them, and a newly opened explorer inherited the last toggle instead of the configured default.

`Preview` now snapshots the configured value into an instance field at construction and exposes `is_enabled()` / `set_enabled()`. The action operates on the explorer's own `Preview` and no longer writes to the shared config.

This is the first half of #90 — it stands on its own for the `float` and `split_*` layouts, and #90's replace overlay builds on it.

## Verification

- `just format-check`, `just lint`, `just typecheck` — clean
- `just test`, `just test-e2e` — 0 failures
- Observed on a real driven Neovim (`--embed` + `nvim_ui_attach`, `<Tab>` mapped to `toggle_preview`, real keystrokes): with two explorers open, pressing `<Tab>` in the first toggles only that one, leaves `config.get().preview.enabled` untouched, and a third explorer opens with the configured default.

## Test changes

- `tests/preview/test_preview.lua` — two cases pinning instance-local state and that the shared config is not written.
- `tests/e2e/test_multi_instance.lua` — toggling in one explorer leaves the other and the shared config alone; a newly opened explorer uses the configured default.
- `tests/preview/test_lifecycle.lua`, `tests/e2e/test_preview.lua` — existing tests that assigned into the shared config now use the new API.

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)